### PR TITLE
[grafana] Replace deprecated GF_INSTALL_PLUGINS with GF_PLUGINS_PREINSTALL_SYNC

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 11.1.0
+version: 11.1.1
 # renovate: docker=docker.io/grafana/grafana
 appVersion: 12.3.2
 kubeVersion: "^1.25.0-0"

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -1419,7 +1419,7 @@ containers:
             key: {{ .Values.admin.passwordKey | default "admin-password" }}
       {{- end }}
       {{- if .Values.plugins }}
-      - name: GF_INSTALL_PLUGINS
+      - name: GF_PLUGINS_PREINSTALL_SYNC
         valueFrom:
           configMapKeyRef:
             name: {{ include "grafana.fullname" . }}


### PR DESCRIPTION
## What this PR does

Replaces the deprecated `GF_INSTALL_PLUGINS` environment variable with `GF_PLUGINS_PREINSTALL_SYNC` in the Grafana chart's pod template.

Recent Grafana versions emit the following warning on startup when plugins are installed via `GF_INSTALL_PLUGINS`:

```
GF_INSTALL_PLUGINS is deprecated. Use GF_PLUGINS_PREINSTALL or GF_PLUGINS_PREINSTALL_SYNC instead
```

`GF_PLUGINS_PREINSTALL_SYNC` is used (rather than `GF_PLUGINS_PREINSTALL`) to maintain the current synchronous install behavior — plugins are fully installed before Grafana starts.

Fixes #71