### PR TITLE
[tempo-vulture] fix annotation indentation in deployment template

### DIFF
--- a/charts/tempo-vulture/Chart.yaml
+++ b/charts/tempo-vulture/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-vulture
 description: Grafana Tempo Vulture - A tool to monitor Tempo performance.
 type: application
-version: 0.12.3
+version: 0.12.4
 # renovate: docker=docker.io/grafana/tempo-vulture
 appVersion: 2.10.0
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-vulture/README.md
+++ b/charts/tempo-vulture/README.md
@@ -1,6 +1,6 @@
 # tempo-vulture
 
-![Version: 0.12.3](https://img.shields.io/badge/Version-0.12.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.10.0](https://img.shields.io/badge/AppVersion-2.10.0-informational?style=flat-square)
+![Version: 0.12.4](https://img.shields.io/badge/Version-0.12.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.10.0](https://img.shields.io/badge/AppVersion-2.10.0-informational?style=flat-square)
 
 Grafana Tempo Vulture - A tool to monitor Tempo performance.
 

--- a/charts/tempo-vulture/templates/deployment.yaml
+++ b/charts/tempo-vulture/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "tempo-vulture.labels" . | nindent 4 }}
   {{- with .Values.annotations }}
   annotations:
-    {{- toYaml . | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   minReadySeconds: 10


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

The deployment template used `indent 4` instead of `nindent 4` for annotations, which produced invalid YAML when `.Values.annotations` was set. This switches to `nindent 4` to match the rest of the template.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

#### Special notes for your reviewer

The bug is on line 9 of `charts/tempo-vulture/templates/deployment.yaml`. The `indent 4` function does not emit a leading newline, so the annotation content gets appended to the `annotations:` key line instead of appearing on the next line. `nindent 4` fixes this.

#### Checklist

- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)