### PR TITLE
[CI] fix issue triage labeler missing template input

### DIFF
--- a/.github/workflows/issue-triage.yaml
+++ b/.github/workflows/issue-triage.yaml
@@ -46,6 +46,11 @@ jobs:
         uses: redhat-plumbers-in-action/advanced-issue-labeler@b80ae64e3e156e9c111b075bfa04b295d54e8e2e # v3.2.4
         with:
           issue-form: ${{ steps.issue-parser.outputs.jsonString }}
+          template: >-
+            ${{
+              contains(github.event.issue.labels.*.name, 'bug')
+              && 'bug_report.yml' || 'feature_request.yml'
+            }}
           section: chart-name
           config-path: .github/advanced-issue-labeler.yml
           token: ${{ github.token }}


### PR DESCRIPTION
#### What this PR does / why we need it

The `advanced-issue-labeler` action in the issue triage workflow requires a `template` input to match the correct policy block in `.github/advanced-issue-labeler.yml`. Without it, the action prints "Nothing to do here" and never applies `chart/*` labels.

This adds the missing `template` input, using the same `bug`/`enhancement` label conditional already used by the `issue-parser` step to select the correct issue form template (`bug_report.yml` or `feature_request.yml`).

#### Which issue this PR fixes

*(Related to PR #75 which added the issue triage workflow)*

#### Special notes for your reviewer

This is a one-line addition to the workflow — the `template` input was the only missing piece preventing the labeler from working.

#### Checklist

- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped — N/A, no chart changes
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)