### PR TITLE
[grafana] Allow specifying IP block for network policy

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 11.1.5
+version: 11.1.6
 # renovate: docker=docker.io/grafana/grafana
 appVersion: 12.3.3
 kubeVersion: "^1.25.0-0"

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -243,14 +243,15 @@ The minimum required Kubernetes version is now 1.25. All references to deprecate
 | livenessProbe.initialDelaySeconds | int | `60` |  |
 | livenessProbe.timeoutSeconds | int | `30` |  |
 | namespaceOverride | string | `""` |  |
-| networkPolicy.allowExternal | bool | `true` |  |
-| networkPolicy.egress.blockDNSResolution | bool | `false` |  |
-| networkPolicy.egress.enabled | bool | `false` |  |
-| networkPolicy.egress.ports | list | `[]` |  |
-| networkPolicy.egress.to | list | `[]` |  |
-| networkPolicy.enabled | bool | `false` |  |
-| networkPolicy.explicitNamespacesSelector | object | `{}` |  |
-| networkPolicy.ingress | bool | `true` |  |
+| networkPolicy.allowExternal | bool | `true` | networkPolicy.ingress When true enables the creation an ingress network policy |
+| networkPolicy.egress.blockDNSResolution | bool | `false` | networkPolicy.egress.blockDNSResolution When enabled, DNS resolution will be blocked for all pods in the grafana namespace. |
+| networkPolicy.egress.enabled | bool | `false` | networkPolicy.egress.enabled When enabled, an egress network policy will be created allowing grafana to connect to external data sources from kubernetes cluster. |
+| networkPolicy.egress.ports | list | `[]` | networkPolicy.egress.ports Add individual ports to be allowed by the egress |
+| networkPolicy.egress.to | list | `[]` | networkPolicy.egress.to Allow egress traffic to specific destinations |
+| networkPolicy.enabled | bool | `false` | networkPolicy.enabled Enable creation of NetworkPolicy resources. Only Ingress traffic is filtered for now. |
+| networkPolicy.explicitIpBlocks | list | `[]` | networkPolicy.explicitIpBlocks List of CIDR blocks allowed as ingress sources. Each entry must be a valid CIDR notation string (e.g. 10.0.0.0/8). When defined, the specified CIDR ranges are added to the ingress `from` rules using `ipBlock` entries and complement the other configured ingress sources. </br>  Example:  ``` explicitIpBlocks:   - 35.191.0.0/16   - 130.211.0.0/22 ```  |
+| networkPolicy.explicitNamespacesSelector | object | `{}` | networkPolicy.explicitNamespacesSelector A Kubernetes LabelSelector to explicitly select namespaces from which traffic could be allowed If explicitNamespacesSelector is missing or set to {}, only client Pods that are in the networkPolicy's namespace and that match other criteria, the ones that have the good label, can reach the grafana. But sometimes, we want the grafana to be accessible to clients from other namespaces, in this case, we can use this LabelSelector to select these namespaces, note that the networkPolicy's namespace should also be explicitly added. </br>  Example:  ``` explicitNamespacesSelector:   matchLabels:     role: frontend   matchExpressions:    - {key: role, operator: In, values: [frontend]} ``` |
+| networkPolicy.ingress | bool | `true` | networkPolicy.allowExternal Don't require client label for connections The Policy model to apply. When set to false, only pods with the correct client label will have network access to  grafana port defined. When true, grafana will accept connections from any source (with the correct destination port).  |
 | nodeSelector | object | `{}` |  |
 | notifiers | object | `{}` |  |
 | persistence.accessModes[0] | string | `"ReadWriteOnce"` |  |

--- a/charts/grafana/templates/networkpolicy.yaml
+++ b/charts/grafana/templates/networkpolicy.yaml
@@ -52,6 +52,10 @@ spec:
         - namespaceSelector:
             {{- toYaml . | nindent 12 }}
         {{- end }}
+        {{- range .Values.networkPolicy.explicitIpBlocks }}
+        - ipBlock:
+            cidr: {{ . | quote }}
+        {{- end }}
         - podSelector:
             matchLabels:
               {{- include "grafana.labels" . | nindent 14 }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -1596,69 +1596,73 @@ imageRenderer:
   extraVolumes: []
 
 networkPolicy:
-  ## @param networkPolicy.enabled Enable creation of NetworkPolicy resources. Only Ingress traffic is filtered for now.
-  ##
+  # -- networkPolicy.enabled Enable creation of NetworkPolicy resources. Only Ingress traffic is filtered for now.
   enabled: false
-  ## @param networkPolicy.allowExternal Don't require client label for connections
-  ## The Policy model to apply. When set to false, only pods with the correct
-  ## client label will have network access to  grafana port defined.
-  ## When true, grafana will accept connections from any source
-  ## (with the correct destination port).
-  ##
+  # --networkPolicy.allowExternal Don't require client label for connections
+  # The Policy model to apply. When set to false, only pods with the correct
+  # client label will have network access to  grafana port defined.
+  # When true, grafana will accept connections from any source
+  # (with the correct destination port).
+  #
   ingress: true
-  ## @param networkPolicy.ingress When true enables the creation
-  ## an ingress network policy
-  ##
+  # -- networkPolicy.ingress When true enables the creation
+  # an ingress network policy
   allowExternal: true
-  ## @param networkPolicy.explicitNamespacesSelector A Kubernetes LabelSelector to explicitly select namespaces from which traffic could be allowed
-  ## If explicitNamespacesSelector is missing or set to {}, only client Pods that are in the networkPolicy's namespace
-  ## and that match other criteria, the ones that have the good label, can reach the grafana.
-  ## But sometimes, we want the grafana to be accessible to clients from other namespaces, in this case, we can use this
-  ## LabelSelector to select these namespaces, note that the networkPolicy's namespace should also be explicitly added.
-  ##
-  ## Example:
-  ## explicitNamespacesSelector:
-  ##   matchLabels:
-  ##     role: frontend
-  ##   matchExpressions:
-  ##    - {key: role, operator: In, values: [frontend]}
-  ##
+  # -- networkPolicy.explicitNamespacesSelector A Kubernetes LabelSelector to explicitly select namespaces from which traffic could be allowed
+  # If explicitNamespacesSelector is missing or set to {}, only client Pods that are in the networkPolicy's namespace
+  # and that match other criteria, the ones that have the good label, can reach the grafana.
+  # But sometimes, we want the grafana to be accessible to clients from other namespaces, in this case, we can use this
+  # LabelSelector to select these namespaces, note that the networkPolicy's namespace should also be explicitly added.
+  # </br>
+  #
+  # Example:
+  #
+  # ```
+  # explicitNamespacesSelector:
+  #   matchLabels:
+  #     role: frontend
+  #   matchExpressions:
+  #    - {key: role, operator: In, values: [frontend]}
+  # ```
   explicitNamespacesSelector: {}
-  ##
-  ##
-  ##
-  ##
-  ##
-  ##
+  # -- networkPolicy.explicitIpBlocks List of CIDR blocks allowed as ingress sources.
+  # Each entry must be a valid CIDR notation string (e.g. 10.0.0.0/8).
+  # When defined, the specified CIDR ranges are added to the ingress `from` rules
+  # using `ipBlock` entries and complement the other configured ingress sources.
+  # </br>
+  #
+  # Example:
+  #
+  # ```
+  # explicitIpBlocks:
+  #   - 35.191.0.0/16
+  #   - 130.211.0.0/22
+  # ```
+  #
+  explicitIpBlocks: []
+
   egress:
-    ## @param networkPolicy.egress.enabled When enabled, an egress network policy will be
-    ## created allowing grafana to connect to external data sources from kubernetes cluster.
+    # -- networkPolicy.egress.enabled When enabled, an egress network policy will be
+    # created allowing grafana to connect to external data sources from kubernetes cluster.
     enabled: false
-    ##
-    ## @param networkPolicy.egress.blockDNSResolution When enabled, DNS resolution will be blocked
-    ## for all pods in the grafana namespace.
+    # -- networkPolicy.egress.blockDNSResolution When enabled, DNS resolution will be blocked
+    # for all pods in the grafana namespace.
     blockDNSResolution: false
-    ##
-    ## @param networkPolicy.egress.ports Add individual ports to be allowed by the egress
+    # -- networkPolicy.egress.ports Add individual ports to be allowed by the egress
     ports: []
-    ## Add ports to the egress by specifying - port: <port number>
-    ## E.X.
-    ## - port: 80
-    ## - port: 443
-    ##
-    ## @param networkPolicy.egress.to Allow egress traffic to specific destinations
+    # Add ports to the egress by specifying - port: <port number>
+    # E.X.
+    # - port: 80
+    # - port: 443
+    #
+    # -- networkPolicy.egress.to Allow egress traffic to specific destinations
     to: []
-    ## Add destinations to the egress by specifying - ipBlock: <CIDR>
-    ## E.X.
-    ## to:
-    ##  - namespaceSelector:
-    ##    matchExpressions:
-  ##    - {key: role, operator: In, values: [grafana]}
-  ##
-  ##
-  ##
-  ##
-  ##
+    # -- destinations to the egress by specifying - ipBlock: <CIDR>
+    # E.X.
+    # to:
+    #  - namespaceSelector:
+    #    matchExpressions:
+    #    - {key: role, operator: In, values: [grafana]}
 
 # Enable backward compatibility of kubernetes where version below 1.13 doesn't have the enableServiceLinks option
 enableKubeBackwardCompatibility: false


### PR DESCRIPTION
<!--
Thank you for contributing to grafana-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/grafana-community/helm-charts/blob/main/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them (see CONSTRIBUTING.md).
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.  Please check the results.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
This change adds the ability to define IP blocks to allow entry to the Grafana pod only for specific IPs.

This is essentially necessary, for example, when we want to allow specific traffic from GCP Health Check IPs when using Gateway API, for example.
#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[grafana]`)
