### PR TITLE
[grafana] Image Renderer: Add option to configure healthcheck path

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 11.2.1
+version: 11.2.2
 # renovate: docker=docker.io/grafana/grafana
 appVersion: 12.4.0
 kubeVersion: "^1.25.0-0"

--- a/charts/grafana/templates/image-renderer-deployment.yaml
+++ b/charts/grafana/templates/image-renderer-deployment.yaml
@@ -86,7 +86,7 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: {{ .Values.imageRenderer.healthcheckPath }}
               port: {{ .Values.imageRenderer.service.portName }}
           env:
             - name: HTTP_PORT

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -1514,6 +1514,8 @@ imageRenderer:
   hostAliases: []
   # image-renderer deployment priority class
   priorityClassName: ''
+  # Path to the healthcheck endpoint. On Image Renderer v5.0.0 or newer, this is '/healthz'. Older versions use '/'.
+  healthcheckPath: '/healthz'
   service:
     # Enable the image-renderer service
     enabled: true


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

From v5.0.0 we changed the Image Renderer's (IR) healthcheck path to be `/healthz` rather than `/`.

With this PR that path is configurable for those using an older version of IR.

#### Which issue this PR fixes

Fixes: https://github.com/grafana-community/helm-charts/issues/106

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[grafana]`)
