### PR TITLE
[grafana] fix spelling: seperate→separate, handeled→handled

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 11.2.2
+version: 11.2.3
 # renovate: docker=docker.io/grafana/grafana
 appVersion: 12.4.0
 kubeVersion: "^1.25.0-0"

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -1299,7 +1299,7 @@ containers:
       {{- with .Values.datasources }}
       {{- $datasources := . }}
       {{- range (keys . | sortAlpha) }}
-      {{- if (or (hasKey (index $datasources .) "secret")) }} {{/*check if current datasource should be handeled as secret */}}
+      {{- if (or (hasKey (index $datasources .) "secret")) }} {{/*check if current datasource should be handled as secret */}}
       - name: config-secret
         mountPath: "/etc/grafana/provisioning/datasources/{{ . }}"
         subPath: {{ . | quote }}
@@ -1313,7 +1313,7 @@ containers:
       {{- with .Values.notifiers }}
       {{- $notifiers := . }}
       {{- range (keys . | sortAlpha) }}
-      {{- if (or (hasKey (index $notifiers .) "secret")) }} {{/*check if current notifier should be handeled as secret */}}
+      {{- if (or (hasKey (index $notifiers .) "secret")) }} {{/*check if current notifier should be handled as secret */}}
       - name: config-secret
         mountPath: "/etc/grafana/provisioning/notifiers/{{ . }}"
         subPath: {{ . | quote }}
@@ -1327,7 +1327,7 @@ containers:
       {{- with .Values.alerting }}
       {{- $alertingmap := .}}
       {{- range (keys . | sortAlpha) }}
-      {{- if (or (hasKey (index $.Values.alerting .) "secret") (hasKey (index $.Values.alerting .) "secretFile")) }} {{/*check if current alerting entry should be handeled as secret */}}
+      {{- if (or (hasKey (index $.Values.alerting .) "secret") (hasKey (index $.Values.alerting .) "secretFile")) }} {{/*check if current alerting entry should be handled as secret */}}
       - name: config-secret
         mountPath: "/etc/grafana/provisioning/alerting/{{ . }}"
         subPath: {{ . | quote }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -1439,7 +1439,7 @@ namespaceOverride: ""
 ##
 revisionHistoryLimit: 10
 
-## Add a seperate remote image renderer deployment/service
+## Add a separate remote image renderer deployment/service
 imageRenderer:
   deploymentStrategy: {}
   # Enable the image-renderer deployment & service


### PR DESCRIPTION
## Summary

Fix spelling typos flagged by codespell (super-linter NATURAL_LANGUAGE check):

- `charts/grafana/values.yaml:1442` — `seperate` → `separate`
- `charts/grafana/templates/_pod.tpl:1302,1316,1330` — `handeled` → `handled`

## Test plan

- [ ] Super Linter passes with no NATURAL_LANGUAGE errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)