### PR TITLE
[grafana-mcp] add Prometheus metrics and ServiceMonitor support

### DIFF
--- a/charts/grafana-mcp/Chart.yaml
+++ b/charts/grafana-mcp/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana-mcp
-version: 0.7.3
+version: 0.8.0
 # renovate: docker=docker.io/grafana/mcp-grafana
 appVersion: 0.11.2
 kubeVersion: "^1.25.0-0"

--- a/charts/grafana-mcp/templates/deployment.yaml
+++ b/charts/grafana-mcp/templates/deployment.yaml
@@ -126,10 +126,13 @@ spec:
           envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if or (.Values.debug) (.Values.disabledCategories) (.Values.extraArgs) }}
+          {{- if or (.Values.debug) (.Values.metrics.enabled) (.Values.disabledCategories) (.Values.extraArgs) }}
           args:
             {{- if .Values.debug }}
             - -debug
+            {{- end }}
+            {{- if .Values.metrics.enabled }}
+            - --metrics
             {{- end }}
             {{- range .Values.disabledCategories }}
             - --disable-{{ . }}

--- a/charts/grafana-mcp/templates/servicemonitor.yaml
+++ b/charts/grafana-mcp/templates/servicemonitor.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "grafana-mcp.fullname" . }}
+  namespace: {{ include "grafana-mcp.namespace" . }}
+  labels:
+    {{- include "grafana-mcp.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp-server
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "grafana-mcp.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: mcp-server
+  endpoints:
+    - port: mcp-http
+      path: {{ .Values.serviceMonitor.path }}
+      interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- with .Values.serviceMonitor.namespaceSelector }}
+  namespaceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/grafana-mcp/values.yaml
+++ b/charts/grafana-mcp/values.yaml
@@ -220,3 +220,29 @@ extraInitContainers: []
 
 # -- Extra containers
 extraContainers: []
+
+# -- Metrics configuration
+metrics:
+  # -- Enable Prometheus metrics endpoint (adds --metrics flag)
+  enabled: false
+
+# -- ServiceMonitor configuration for Prometheus Operator
+serviceMonitor:
+  # -- Enable ServiceMonitor
+  enabled: false
+  # -- ServiceMonitor labels
+  labels: {}
+  # -- ServiceMonitor annotations
+  annotations: {}
+  # -- Scrape interval
+  interval: 30s
+  # -- Scrape timeout
+  scrapeTimeout: 10s
+  # -- Metrics path
+  path: /metrics
+  # -- Additional relabelings
+  relabelings: []
+  # -- Additional metric relabelings
+  metricRelabelings: []
+  # -- Namespace selector
+  namespaceSelector: {}


### PR DESCRIPTION
## Summary

- Adds `metrics.enabled` value that injects `--metrics` flag into the MCP server, enabling Prometheus metrics at `/metrics` on the existing MCP port
- Adds `serviceMonitor` values block with full configuration (interval, scrapeTimeout, relabelings, metricRelabelings, namespaceSelector)
- Adds `templates/servicemonitor.yaml` for Prometheus Operator ServiceMonitor CRD
- Bumps chart version to `0.8.0`

## Background

The `grafana/mcp-grafana` application added Prometheus metrics support in [grafana/mcp-grafana#506](https://github.com/grafana/mcp-grafana/pull/506), which shipped in `v0.11.0`. This PR exposes that capability via the Helm chart.

## Test plan

- [x] `helm lint charts/grafana-mcp/` passes with no warnings
- [x] `helm template` with `serviceMonitor.enabled=true` and `metrics.enabled=true` renders correct ServiceMonitor and `--metrics` arg
- [x] `helm template` with defaults (both disabled) renders no ServiceMonitor and no `--metrics` arg

🤖 Generated with [Claude Code](https://claude.com/claude-code)