### PR TITLE
[grafana] Fix image-renderer service name exceeding 63-char DNS limit

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 11.3.1
+version: 11.3.2
 # renovate: docker=docker.io/grafana/grafana
 appVersion: 12.4.1
 kubeVersion: "^1.25.0-0"

--- a/charts/grafana/templates/_helpers.tpl
+++ b/charts/grafana/templates/_helpers.tpl
@@ -84,6 +84,15 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Create a fully qualified name for image-renderer resources.
+We truncate at 47 chars to reserve space for the longest suffix (-image-renderer, 16 chars)
+so the Service name stays within the 63-char DNS label limit.
+*/}}
+{{- define "grafana.imageRenderer.fullname" -}}
+{{- include "grafana.fullname" . | trunc 47 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "grafana.imageRenderer.labels" -}}

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -1442,7 +1442,7 @@ containers:
         {{- if .Values.imageRenderer.serverURL }}
         value: {{ .Values.imageRenderer.serverURL | quote }}
         {{- else }}
-        value: http://{{ include "grafana.fullname" . }}-image-renderer.{{ include "grafana.namespace" . }}:{{ .Values.imageRenderer.service.port }}/render
+        value: http://{{ include "grafana.imageRenderer.fullname" . }}-image-renderer.{{ include "grafana.namespace" . }}:{{ .Values.imageRenderer.service.port }}/render
         {{- end }}
       - name: GF_RENDERING_CALLBACK_URL
         {{- if .Values.imageRenderer.renderingCallbackURL }}

--- a/charts/grafana/templates/image-renderer-service.yaml
+++ b/charts/grafana/templates/image-renderer-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "grafana.fullname" . }}-image-renderer
+  name: {{ include "grafana.imageRenderer.fullname" . }}-image-renderer
   namespace: {{ include "grafana.namespace" . }}
   labels:
     {{- include "grafana.imageRenderer.labels" . | nindent 4 }}


### PR DESCRIPTION
#### What this PR does / why we need it

When grafana.fullname is close to 63 characters, appending -image-renderer (16 chars) causes the Service name to exceed the 63-character DNS label limit (RFC 1123), making Kubernetes reject the resource creation.
This adds a grafana.imageRenderer.fullname helper that truncates grafana.fullname to 47 characters before appending the suffix, keeping the final Service name within the limit.

#### Special notes for your reviewer
Only the Service name and GF_RENDERING_SERVER_URL (which references the Service DNS) are affected. Other image-renderer resources (Deployment, HPA, NetworkPolicy, etc.) are not DNS labels and follow the 253-char limit, so they don't need this fix.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
