### PR TITLE
[grafana] allow overriding dashboard title for downloaded dashboards

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 11.3.2
+version: 11.3.3
 # renovate: docker=docker.io/grafana/grafana
 appVersion: 12.4.1
 kubeVersion: "^1.25.0-0"

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -153,6 +153,7 @@ dashboards:
       file: dashboards/custom-dashboard.json
     prometheus-stats:
       # Ref: https://grafana.com/dashboards/2
+      # title: My Custom Title   # optional; when set for a downloaded dashboard (gnetId or url), overrides the title displayed in Grafana
       gnetId: 2
       revision: 2
       datasource: Prometheus

--- a/charts/grafana/templates/_config.tpl
+++ b/charts/grafana/templates/_config.tpl
@@ -132,6 +132,14 @@ download_dashboards.sh: |
   {{- if $value.b64content }}
     | base64 -d \
   {{- end }}
+  {{- /*
+  Overrides original title with a custom title.
+  Deterministic search as title is generally indented with 2 spaces, 4 spaces or a tab.
+  Escape characters that may be wrongly interpreted by sed: backslash (\), double backslash (\\), and ampersand (&).
+  */}}
+  {{- if $value.title }}
+    | sed -E '/^(\t|  |    )"title":/ s#"title": *"[^"]*"#"title": "{{ $value.title | replace "\\" "\\\\" | replace "\"" "\\\"" | replace "&" "\\&" }}"#' \
+  {{- end }}
   > "{{- if $dpPath -}}{{ $dpPath }}{{- else -}}/var/lib/grafana/dashboards/{{ $provider }}{{- end -}}/{{ $key }}.json"
     {{ end }}
   {{- end }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -835,6 +835,8 @@ defaultCurlOptions: "-skf"
 ## ref: https://grafana.com/dashboards
 ##
 ## dashboards per provider, use provider name as key.
+## For dashboards downloaded via gnetId or url, the optional "title" key overrides
+## the dashboard title in the downloaded JSON so the UI displays your custom title.
 ##
 dashboards: {}
   # default:
@@ -844,6 +846,7 @@ dashboards: {}
   #   custom-dashboard:
   #     file: dashboards/custom-dashboard.json
   #   prometheus-stats:
+  #     title: My Custom Dashboard Title   # optional; overrides the dashboard title in the downloaded JSON
   #     gnetId: 2
   #     revision: 2
   #     datasource: Prometheus


### PR DESCRIPTION
<!--
Thank you for contributing to grafana-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/grafana-community/helm-charts/blob/main/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them (see CONSTRIBUTING.md).
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.  Please check the results.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Adds support for overriding the dashboard title when dashboards are downloaded via `gnetId` or `url`.

When the optional `title` key is set in values for such a dashboard, the `download_dashboards.sh` script rewrites the root `title` field in the downloaded `JSON` so that the Grafana UI displays the configured title instead of the original one from Grafana.com (or the remote URL).

- **Template** (`_config.tpl`): conditional `sed` step in the download pipeline that targets only the root-level `title` (by indentation), with proper escaping for JSON and sed (`\`, `"`, `&`).
- **Docs**: `title` documented in `values.yaml` (dashboards section) and in `README.md` (Import dashboards).
- **Version**: chart version bumped to `11.3.3` (patch, non-breaking).

#### Which issue this PR fixes

None.

#### Special notes for your reviewer

- No new dependencies: the init container image (curlimages/curl) is unchanged; the title override is done with `sed` only.
- Root title is matched by indentation (`^\t"title":`, `^  "title":`, `^    "title":`) so panel/variable titles are not modified.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
