### PR TITLE
changelog pagination

### DIFF
--- a/changelog/index.html
+++ b/changelog/index.html
@@ -976,14 +976,13 @@
 
             // Load first chart or chart from URL
             const urlParams = getUrlParams();
+            currentPage++;
+            isLoadingMore = false;
             if (urlParams.chart && charts.has(urlParams.chart)) {
                 selectChart(urlParams.chart, currentOwner, currentRepo);
             } else {
                 selectChart(Array.from(charts).sort()[0], currentOwner, currentRepo);
             }
-
-            currentPage++;
-            isLoadingMore = false;
 
         } catch (error) {
             showError(error.message);


### PR DESCRIPTION
Problem

On initial page load, loadMoreReleases() sets isLoadingMore = true before fetching releases from the GitHub API. After the fetch completes, it calls selectChart() → renderReleases() to build the initial DOM — but isLoadingMore is still true at that point. renderReleases reads this flag when stamping the "Load More Releases" button, so it renders it in the disabled "Loading..." state.

The reset isLoadingMore = false happened after selectChart() returned, so no re-render was triggered. The result: the button was permanently stuck as "Loading..." on every page load, making it impossible to paginate through releases without a hard refresh.

Fix

Move currentPage++ and isLoadingMore = false to before the selectChart() calls. This ensures renderReleases reads the correct flag state (false) when constructing the button DOM on initial load.