### PR TITLE
[loki] Set `FOLDER_ANNOTATION` in Distributed & SingleBinary modes

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki supporting monolithic, simple scalable, and microservices modes.
 type: application
 appVersion: 3.6.7
-version: 6.56.1
+version: 6.57.0
 home: https://grafana-community.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki/templates/ruler/statefulset-ruler.yaml
+++ b/charts/loki/templates/ruler/statefulset-ruler.yaml
@@ -147,6 +147,10 @@ spec:
             {{- end }}
             - name: FOLDER
               value: "{{ .Values.sidecar.rules.folder }}"
+            {{- if .Values.sidecar.rules.folderAnnotation }}
+            - name: FOLDER_ANNOTATION
+              value: "{{ .Values.sidecar.rules.folderAnnotation }}"
+            {{- end }}
             - name: RESOURCE
               value: {{ quote .Values.sidecar.rules.resource }}
             {{- if .Values.sidecar.enableUniqueFilenames }}

--- a/charts/loki/templates/single-binary/statefulset.yaml
+++ b/charts/loki/templates/single-binary/statefulset.yaml
@@ -171,6 +171,10 @@ spec:
             {{- end }}
             - name: FOLDER
               value: "{{ .Values.sidecar.rules.folder }}"
+            {{- if .Values.sidecar.rules.folderAnnotation }}
+            - name: FOLDER_ANNOTATION
+              value: "{{ .Values.sidecar.rules.folderAnnotation }}"
+            {{- end }}
             - name: RESOURCE
               value: {{ quote .Values.sidecar.rules.resource }}
             {{- if .Values.sidecar.enableUniqueFilenames }}


### PR DESCRIPTION
#### What this PR does / why we need it

https://github.com/grafana/loki/pull/13289 added a chart value (`sidecar.rules.folderAnnotation`) that sets `FOLDER_ANNOTATION` on the rules sidecar. However, it only set that environment variable on loki-backend in SimpleScalable mode.

This PR sets `FOLDER_ANNOTATION` even in SIngleBinary and Distributed deployment modes

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[grafana]`)
