### PR TITLE
[grafana] Support templating in Route annotations

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 11.3.3
+version: 11.3.4
 # renovate: docker=docker.io/grafana/grafana
 appVersion: 12.4.1
 kubeVersion: "^1.25.0-0"

--- a/charts/grafana/templates/route.yaml
+++ b/charts/grafana/templates/route.yaml
@@ -6,7 +6,7 @@ kind: {{ $route.kind | default "HTTPRoute" }}
 metadata:
   {{- with $route.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
   name: {{ template "grafana.fullname" $ }}{{ if ne $name "main" }}-{{ $name }}{{ end }}
   namespace: {{ template "grafana.namespace" $ }}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Enable template rendering in Route annotations by replacing `toYaml` with `tpl` to allow dynamic values in annotation fields.

#### Which issue this PR fixes

- fixes #194 

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[grafana]`)
