### PR TITLE
[loki] Fix template error in dashboard configmap

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki supporting monolithic, simple scalable, and microservices modes.
 type: application
 appVersion: 3.6.7
-version: 9.1.1
+version: 9.1.2
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/templates/monitoring/dashboards/configmap.yaml
+++ b/charts/loki/templates/monitoring/dashboards/configmap.yaml
@@ -1,21 +1,21 @@
-{{- if .Values.monitoring.dashboards.enabled }}
+{{- if $.Values.monitoring.dashboards.enabled }}
 {{- range $path, $_ :=  .Files.Glob "src/dashboards/*.json"  }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "loki.dashboardsName" $ }}
-  namespace: {{ .Values.monitoring.dashboards.namespace | default (include "loki.namespace" $) }}
+  namespace: {{ $.Values.monitoring.dashboards.namespace | default (include "loki.namespace" $) }}
   labels:
     {{- include "loki.labels" $ | nindent 4 }}
-    {{- with .Values.monitoring.dashboards.labels }}
+    {{- with $.Values.monitoring.dashboards.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.monitoring.dashboards.annotations }}
+  {{- with $.Values.monitoring.dashboards.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 data:
-  {{ $path | replace "src/dashboards/" | quote }}: {{ $.Files.Get $path | fromJson | toJson | quote }}
+  {{ $path | replace "src/dashboards/" "" | quote }}: {{ $.Files.Get $path | fromJson | toJson | quote }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Summary

- Use `$.Values` instead of `.Values` inside `range` loop in `templates/monitoring/dashboards/configmap.yaml`, fixing the `can't evaluate field Values in type []uint8` error when dashboards are enabled
- Fix missing replacement argument in `replace` call on dashboard data key (was `replace "src/dashboards/"`, now `replace "src/dashboards/" ""`)
- Bump chart version to 9.1.2

Fixes #203