### PR TITLE
[loki] Allow lokiCanary to be run without user/pass/tenant automatically being injected

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki supporting monolithic, simple scalable, and microservices modes.
 type: application
 appVersion: 3.6.7
-version: 9.2.0
+version: 9.3.0
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/templates/loki-canary/daemonset.yaml
+++ b/charts/loki/templates/loki-canary/daemonset.yaml
@@ -56,10 +56,10 @@ spec:
             - -addr={{- default (include "loki.host" $) .lokiurl }}
             - -labelname={{ .labelname }}
             - -labelvalue=$(POD_NAME)
-            {{- if $.Values.loki.auth_enabled }}
-            - -user={{ dig "selfMonitoring" "tenant" "name" $.Values.lokiCanary.tenant.name $.Values.monitoring }}
-            - -tenant-id={{ dig "selfMonitoring" "tenant" "name" $.Values.lokiCanary.tenant.name $.Values.monitoring }}
-            - -pass={{ dig "selfMonitoring" "tenant" "password" $.Values.lokiCanary.tenant.password $.Values.monitoring }}
+            {{- if $.Values.loki.auth_enabled and $.Values.lokiCanary.auth.enabled }}
+            - -user={{ dig "selfMonitoring" "tenant" "name" $.Values.lokiCanary.auth.name $.Values.monitoring }}
+            - -tenant-id={{ dig "selfMonitoring" "tenant" "name" $.Values.lokiCanary.auth.name $.Values.monitoring }}
+            - -pass={{ dig "selfMonitoring" "tenant" "password" $.Values.lokiCanary.auth.password $.Values.monitoring }}
             {{- end }}
             {{- if .push }}
             - -push=true

--- a/charts/loki/templates/loki-canary/daemonset.yaml
+++ b/charts/loki/templates/loki-canary/daemonset.yaml
@@ -56,7 +56,7 @@ spec:
             - -addr={{- default (include "loki.host" $) .lokiurl }}
             - -labelname={{ .labelname }}
             - -labelvalue=$(POD_NAME)
-            {{- if $.Values.loki.auth_enabled and $.Values.lokiCanary.auth.enabled }}
+            {{- if and $.Values.loki.auth_enabled $.Values.lokiCanary.auth.enabled }}
             - -user={{ dig "selfMonitoring" "tenant" "name" $.Values.lokiCanary.auth.name $.Values.monitoring }}
             - -tenant-id={{ dig "selfMonitoring" "tenant" "name" $.Values.lokiCanary.auth.name $.Values.monitoring }}
             - -pass={{ dig "selfMonitoring" "tenant" "password" $.Values.lokiCanary.auth.password $.Values.monitoring }}

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -727,6 +727,14 @@ lokiCanary:
   push: true
   # -- If set overwrites the default value set by loki.host helper function. Use this if gateway not enabled.
   lokiurl: null
+  # -- Authentication information for loki canary
+  auth:
+    # -- If authentication should be enabled. Requires loki.auth_enabled to be enabled as well.
+    enabled: true
+    # -- Name of the tenant for loki-canary
+    name: "self-monitoring"
+    # -- Password of the gateway for Basic auth for loki-canary
+    password: null
   # -- The name of the label to look for at loki when doing the checks.
   labelname: pod
   # -- Additional annotations for the `loki-canary` Daemonset
@@ -792,12 +800,6 @@ lokiCanary:
       maxUnavailable: 1
   # -- Replicas for `loki-canary` when using a Deployment
   replicas: 1
-  # -- Tenant to use for loki-canary
-  tenant:
-    # -- Name of the tenant for loki-canary
-    name: "self-monitoring"
-    # -- Password of the gateway for Basic auth for loki-canary
-    password: null
 ######################################################################################################################
 #
 # Service Accounts and Kubernetes RBAC


### PR DESCRIPTION
<!--
Thank you for contributing to grafana-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/grafana-community/helm-charts/blob/main/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them (see CONSTRIBUTING.md).
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.  Please check the results.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This allows disabling of the auto injection authentication parameters. This is required for us to be able to inject bearer token authentication (PR pending: https://github.com/grafana/loki/pull/20660). I hesitate to implement bearer token directly since it's not yet merged.

This was originally implemented in https://github.com/grafana/loki/pull/20723 but never merged. The implementation also got way easier since we don't really have selfMonitoring anymore.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

This renames `lokiCanary.tenant.*` to `lokiCanary.auth` for better functionality clarification. As this was only yesterday implemented in #187, it felt "okish" to break.

Please let me know if you prefer to not rename it.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
