### PR TITLE
[loki] fix: nil pointer in alerting rules template

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki supporting monolithic, simple scalable, and microservices modes.
 type: application
 appVersion: 3.6.7
-version: 9.2.1
+version: 9.2.2
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/ci/non-default-values.yaml
+++ b/charts/loki/ci/non-default-values.yaml
@@ -82,6 +82,7 @@ gateway:
 monitoring:
   rules:
     enabled: true
+    alerting: true
     additionalGroups:
       - name: "additional-rules"
         rules:

--- a/charts/loki/src/alerts.yaml.tpl
+++ b/charts/loki/src/alerts.yaml.tpl
@@ -5,7 +5,7 @@ groups:
 {{- with .Values.monitoring.rules }}
 {{- $additionalAnnotations := .additionalRuleAnnotations }}
 {{- $additionalLabels := .additionalRuleLabels }}
-{{- if and (not .disabled.LokiRequestErrors) .configs.LokiRequestErrors.enabled }}
+{{- if .configs.LokiRequestErrors.enabled }}
       {{- with .configs.LokiRequestErrors }}
       - alert: "LokiRequestErrors"
         annotations:
@@ -28,7 +28,7 @@ groups:
       {{- end }}
 {{- end }}
 
-{{- if and (not .disabled.LokiRequestPanics) .configs.LokiRequestPanics.enabled }}
+{{- if .configs.LokiRequestPanics.enabled }}
       {{- with .configs.LokiRequestPanics }}
       - alert: "LokiRequestPanics"
         annotations:
@@ -47,7 +47,7 @@ groups:
       {{- end }}
 {{- end }}
 
-{{- if and (not .disabled.LokiRequestLatency) .configs.LokiRequestLatency.enabled }}
+{{- if .configs.LokiRequestLatency.enabled }}
       {{- with .configs.LokiRequestLatency }}
       - alert: "LokiRequestLatency"
         annotations:
@@ -67,7 +67,7 @@ groups:
       {{- end }}
 {{- end }}
 
-{{- if and (not .disabled.LokiTooManyCompactorsRunning) .configs.LokiTooManyCompactorsRunning.enabled }}
+{{- if .configs.LokiTooManyCompactorsRunning.enabled }}
       {{- with .configs.LokiTooManyCompactorsRunning }}
       - alert: "LokiTooManyCompactorsRunning"
         annotations:
@@ -87,7 +87,7 @@ groups:
       {{- end }}
 {{- end }}
 
-{{- if and (not .disabled.LokiCanaryLatency) .configs.LokiCanaryLatency.enabled }}
+{{- if .configs.LokiCanaryLatency.enabled }}
   {{- with .configs.LokiCanaryLatency }}
   - name: "loki_canaries_alerts"
     rules:

--- a/charts/loki/templates/monitoring/loki-alerts.yaml
+++ b/charts/loki/templates/monitoring/loki-alerts.yaml
@@ -17,6 +17,10 @@ metadata:
   namespace: {{ .namespace | default (include "loki.namespace" $) }}
 spec:
   groups:
-  {{- include "loki.ruleGroupToYaml" (tpl ($.Files.Get "src/alerts.yaml.tpl") $ | fromYaml).groups | indent 4 }}
+    {{- range (tpl ($.Files.Get "src/alerts.yaml.tpl") $ | fromYaml).groups }}
+    - name: {{ .name }}
+      rules:
+        {{- toYaml .rules | nindent 8 }}
+    {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION

<!--
Thank you for contributing to grafana-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/grafana-community/helm-charts/blob/main/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them (see CONSTRIBUTING.md).
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.  Please check the results.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Removes broken disabled map lookups from alerts.yaml.tpl that caused a nil pointer error when monitoring.rules.disabled was unset.
Fixes the loki.ruleGroupToYaml include in loki-alerts.yaml to use explicit range loops (same fix as applied to loki-rules.yaml in #201).

#### Which issue this PR fixes

Missed an occurrence in https://github.com/grafana-community/helm-charts/issues/197 

#### Special notes for your reviewer

I dropped the `.disabled.LokiRequestLatency` condition; the `.configs.LokiRequestLatency.enabled` condition serves the same purpose. The `.disabled` was not documented in the values.yaml and threw a nil pointer error when not set.


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
