### PR TITLE
[tempo-distributed] inherit missing labels `global.commonLabels` into  ingestor

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 2.6.5
+version: 2.6.6
 # renovate: docker=docker.io/grafana/tempo
 appVersion: 2.10.3
 kubeVersion: "^1.25.0-0"

--- a/charts/tempo-distributed/templates/ingester/_helpers-ingester.tpl
+++ b/charts/tempo-distributed/templates/ingester/_helpers-ingester.tpl
@@ -70,6 +70,9 @@ name: {{ printf "%s-%s" .component .rolloutZoneName }}
 rollout-group: {{ .component }}
 zone: {{ .rolloutZoneName }}
 {{- end }}
+{{- with .ctx.Values.global.commonLabels }}
+{{ toYaml . }}
+{{- end }}
 helm.sh/chart: {{ include "tempo.chart" .ctx }}
 app.kubernetes.io/name: {{ include "tempo.name" .ctx }}
 app.kubernetes.io/instance: {{ .ctx.Release.Name }}


### PR DESCRIPTION
Add `global.commonLabels` to the ingester.labels template definition to ensure consistent label propagation across all components. 

While other components has it as they follow `tempo.labels` templating which has it ie, [reference_helpers.tpl#L115](https://github.com/grafana-community/helm-charts/blob/main/charts/tempo-distributed/templates/_helpers.tpl#L115)