### PR TITLE
[tempo-distributed] Set max_result_limit in config block

### DIFF
--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -1020,6 +1020,10 @@ queryFrontend:
       target_bytes_per_job: 104857600
       # -- The maximum allowed value of spans per span set. 0 disables this limit.
       max_spans_per_span_set: 100
+      # The maximum allowed value of the limit parameter on search requests. If the search request limit parameter
+      # exceeds the value configured here the frontend will return a 400.
+      # The default value is 262144 (256*1024). Set to 0 to disable this limit.
+      max_result_limit: 262144
     # -- Trace by ID lookup configuration
     trace_by_id:
       # -- The number of shards to split a trace by ID query into.
@@ -1603,6 +1607,7 @@ config: |
       target_bytes_per_job: {{ .Values.queryFrontend.config.search.target_bytes_per_job }}
       concurrent_jobs: {{ .Values.queryFrontend.config.search.concurrent_jobs }}
       max_spans_per_span_set: {{ .Values.queryFrontend.config.search.max_spans_per_span_set }}
+      max_result_limit: {{ .Values.queryFrontend.config.search.max_result_limit }}
     trace_by_id:
       query_shards: {{ .Values.queryFrontend.config.trace_by_id.query_shards }}
     metrics:


### PR DESCRIPTION
#### What this PR does / why we need it

This PR adds support for configuring `max_result_limit` in the Helm chart.

Currently, the application supports this setting via `queryFrontend.search`, but the Helm chart does not pass this configuration down to the deployed components. As a result, users cannot configure `max_result_limit` through Helm values even though the application supports it.

This change ensures that `max_result_limit` is properly exposed and passed from Helm values into the base configuration.

#### Special notes for your reviewer

* The default behavior remains unchanged unless `max_result_limit` is explicitly set.
* The implementation follows the existing pattern used for `queryFrontend.search` configuration.
* This aligns Helm chart capabilities with the application's supported configuration.

#### Checklist

* [x] DCO signed
* [x] Chart Version bumped
* [x] Title of the PR starts with chart name (e.g. `[grafana]`)
