### PR TITLE
[loki] fix querier PDB: use effective replicas when HPA or KEDA autoscaling is enabled

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.1
-version: 9.3.6
+version: 9.3.7
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/templates/querier/poddisruptionbudget-querier.yaml
+++ b/charts/loki/templates/querier/poddisruptionbudget-querier.yaml
@@ -1,7 +1,13 @@
 {{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
-{{- if and $isDistributed (gt (int .Values.querier.replicas) 1) }}
+{{- $effectiveReplicas := .Values.querier.replicas -}}
+{{- if .Values.querier.autoscaling.enabled -}}
+  {{- $effectiveReplicas = .Values.querier.autoscaling.minReplicas -}}
+{{- else if .Values.querier.kedaAutoscaling.enabled -}}
+  {{- $effectiveReplicas = .Values.querier.kedaAutoscaling.minReplicas -}}
+{{- end -}}
+{{- if and $isDistributed (gt (int $effectiveReplicas) 1) }}
 {{- if kindIs "invalid" .Values.querier.maxUnavailable }}
-{{- fail "`.Values.querier.maxUnavailable` must be set when `.Values.querier.replicas` is greater than 1." }}
+{{- fail "`.Values.querier.maxUnavailable` must be set when effective querier replicas is greater than 1." }}
 {{- else }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget

--- a/charts/loki/tests/querier/pdb_test.yaml
+++ b/charts/loki/tests/querier/pdb_test.yaml
@@ -1,0 +1,67 @@
+suite: querier PodDisruptionBudget
+templates:
+  - templates/querier/poddisruptionbudget-querier.yaml
+set:
+  deploymentMode: Distributed
+  loki.storage.type: gcs
+  loki.storage.bucketNames.chunks: test
+  loki.storage.bucketNames.ruler: test
+  loki.storage.bucketNames.admin: test
+tests:
+  - it: should not render PDB when replicas is 0 and no autoscaling
+    set:
+      querier.replicas: 0
+      querier.autoscaling.enabled: false
+      querier.kedaAutoscaling.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render PDB when static replicas > 1
+    set:
+      querier.replicas: 3
+      querier.maxUnavailable: 1
+      querier.autoscaling.enabled: false
+      querier.kedaAutoscaling.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+
+  - it: should render PDB when HPA is enabled with minReplicas > 1
+    set:
+      querier.replicas: 0
+      querier.maxUnavailable: 1
+      querier.autoscaling.enabled: true
+      querier.autoscaling.minReplicas: 3
+      querier.kedaAutoscaling.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+
+  - it: should render PDB when KEDA is enabled with minReplicas > 1
+    set:
+      querier.replicas: 0
+      querier.maxUnavailable: 1
+      querier.autoscaling.enabled: false
+      querier.kedaAutoscaling.enabled: true
+      querier.kedaAutoscaling.minReplicas: 3
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+
+  - it: should not render PDB when KEDA minReplicas is 1
+    set:
+      querier.replicas: 0
+      querier.maxUnavailable: 1
+      querier.autoscaling.enabled: false
+      querier.kedaAutoscaling.enabled: true
+      querier.kedaAutoscaling.minReplicas: 1
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
## What this PR does / why we need it

When HPA or KEDA autoscaling is active for the querier, `.Values.querier.replicas` is `0` (the autoscaler owns the replica count). The PDB template gated creation on `gt .Values.querier.replicas 1`, which was always `false` when autoscaling was enabled — so the PDB was silently never created.

This PR computes an `$effectiveReplicas` value from the active autoscaler's `minReplicas`:

- `querier.autoscaling.enabled` → use `querier.autoscaling.minReplicas`
- `querier.kedaAutoscaling.enabled` → use `querier.kedaAutoscaling.minReplicas`  
- Neither → fall back to `querier.replicas` (existing behaviour, no regression)

## Which issue this PR fixes

Related to #234 (KEDA autoscaling for querier) — the PDB disappears when switching from HPA to KEDA because both set `replicas: 0`.

Also related to #232 (pod template helper for PDBs) which approaches the same problem space.

## Special notes for your reviewer

The fix is intentionally minimal — only `poddisruptionbudget-querier.yaml` is changed. The same pattern could be applied to other components that gain autoscaling support in the future.

## Checklist

- [x] DCO signed
- [x] Chart Version bumped (`9.3.6` → `9.3.7`)
- [x] Title of the PR starts with chart name (`[loki]`)
- [x] helm-unittest tests added for all four cases (no autoscaling, HPA, KEDA, KEDA minReplicas=1)