### PR TITLE
[loki] fix(singleBinary): singleBinary.podDisruptionBudget ignored

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.1
-version: 9.5.0
+version: 9.5.1
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/templates/single-binary/pdb.yaml
+++ b/charts/loki/templates/single-binary/pdb.yaml
@@ -1,17 +1,24 @@
 {{- $isSingleBinary := eq (include "loki.deployment.isSingleBinary" .) "true" -}}
 {{- if $isSingleBinary -}}
-{{- /* In older Loki helm chart version, the singleBinary PDB was configured through
-.Values.podDisruptionBudget. To avoid breaking change, we merge the two dict together,
-and .Values.podDisruptionBudget will override .Values.singleBinary.podDisruptionBudget if both are set.
-loki.pdb template helper expect the PDB configuration to be in the podDisruptionBudget dict,
-so we merge it into the component dict before passing to the template helper.
+{{- /*
+In older Loki helm chart version, the singleBinary PDB was configured through
+.Values.podDisruptionBudget (now deprecated). To avoid breaking change, deep-merge both dicts with
+.Values.podDisruptionBudget taking precedence over .Values.singleBinary.podDisruptionBudget.
+
+The helper expects the PDB config to be located at <component>.podDisruptionBudget so that's where we merge to.
+
+The base of enabled: true ensures old-format values (which lacked the enabled key) still render a PDB.
 */ -}}
 {{- include "loki.pdb" (dict
     "target" "single-binary"
     "component" (mergeOverwrite
         (dict)
         .Values.singleBinary
-        (dict "podDisruptionBudget" .Values.podDisruptionBudget)
+        (dict "podDisruptionBudget" (mergeOverwrite
+            (dict "enabled" true)
+            .Values.singleBinary.podDisruptionBudget
+            .Values.podDisruptionBudget
+        ))
     )
     "ctx" .
     "name" (include "loki.fullname" .)


### PR DESCRIPTION
#### What this PR does / why we need it

https://github.com/grafana-community/helm-charts/pull/248 fixed an issue where `.Values.podDisruptionBudget` was not backwards compatible for singleBinary.  It forgot to merge it with the new `.Values.singleBinary.podDisruptionBudget` so anything defined there was ignored.  This fixes that and continues with the intent that older config has higher priority.

Tested by helm template commands modifying some of the ci/ examples.

#### Which issue this PR fixes

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
