### PR TITLE
[loki] Fix passing nodeSelector to zone-aware ingesters

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.1
-version: 11.4.7
+version: 11.4.8
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/templates/_pod.tpl
+++ b/charts/loki/templates/_pod.tpl
@@ -110,9 +110,11 @@ spec:
     {{- tpl ( . | toYaml) $ctx | nindent 4 }}
     {{- end }}
   {{- end }}
-  {{- if (dig "zoneAwareReplication" (printf "zone%s" (upper (splitList "-" $rolloutZoneName | last))) "extraNodeSelector" nil $component) }}
+  {{- if $rolloutZoneName }}
+  {{- with (dig "zoneAwareReplication" (printf "zone%s" (upper (splitList "-" $rolloutZoneName | last))) "nodeSelector" nil $component) }}
   nodeSelector:
     {{- tpl ( . | toYaml) $ctx | nindent 4 }}
+  {{- end }}
   {{- else }}
   {{- with (coalesce $component.nodeSelector .Values.defaults.nodeSelector .Values.loki.nodeSelector) }}
   nodeSelector:

--- a/charts/loki/tests/ingester/zone_test.yaml
+++ b/charts/loki/tests/ingester/zone_test.yaml
@@ -473,33 +473,39 @@ tests:
         documentIndex: 2
         template: ingester/statefulset-ingester-zone.yaml
 
-  - it: should not apply zoneA nodeSelector key to pod nodeSelector (current behavior)
+  - it: should apply zoneA nodeSelector to pod nodeSelector for zone-a
     set:
       ingester.zoneAwareReplication.zoneA.nodeSelector:
         topology.kubernetes.io/zone: zone-a
     asserts:
-      - notExists:
+      - equal:
           path: spec.template.spec.nodeSelector
+          value:
+            topology.kubernetes.io/zone: zone-a
         documentIndex: 0
         template: ingester/statefulset-ingester-zone.yaml
 
-  - it: should not apply zoneB nodeSelector key to pod nodeSelector (current behavior)
+  - it: should apply zoneB nodeSelector to pod nodeSelector for zone-b
     set:
       ingester.zoneAwareReplication.zoneB.nodeSelector:
         topology.kubernetes.io/zone: zone-b
     asserts:
-      - notExists:
+      - equal:
           path: spec.template.spec.nodeSelector
+          value:
+            topology.kubernetes.io/zone: zone-b
         documentIndex: 1
         template: ingester/statefulset-ingester-zone.yaml
 
-  - it: should not apply zoneC nodeSelector key to pod nodeSelector (current behavior)
+  - it: should apply zoneC nodeSelector to pod nodeSelector for zone-c
     set:
       ingester.zoneAwareReplication.zoneC.nodeSelector:
         topology.kubernetes.io/zone: zone-c
     asserts:
-      - notExists:
+      - equal:
           path: spec.template.spec.nodeSelector
+          value:
+            topology.kubernetes.io/zone: zone-c
         documentIndex: 2
         template: ingester/statefulset-ingester-zone.yaml
 


### PR DESCRIPTION
<!--
Thank you for contributing to grafana-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/grafana-community/helm-charts/blob/main/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them (see CONTRIBUTING.md).
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.  Please check the results.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Passing of nodeSelector to zone-aware ingesters stopped working after #290. Fixed passing those values to pod template and adjusted tests. It was strange too see tests validating incorrect behaviour.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #318 

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
