### PR TITLE
[tempo-distributed] add support for separate cache per role

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 2.10.0
+version: 2.11.0
 # renovate: docker=docker.io/grafana/tempo
 appVersion: 2.10.3
 kubeVersion: "^1.25.0-0"

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -411,6 +411,62 @@ config: |
         timeout: 500ms
 ```
 
+### Memcached cache configuration
+
+By default, the chart deploys a single shared memcached StatefulSet (`memcached`) used for all cache roles — bloom filters, parquet footer, and frontend search. This is the simplest setup and works well for most deployments.
+
+#### Default: single shared cache
+
+```yaml
+memcached:
+  enabled: true
+```
+
+All cache roles (bloom, parquet footer, frontend search) point at the same `<release>-memcached` service.
+
+#### Separate one cache role
+
+You can deploy a dedicated memcached cluster for a specific role by enabling the corresponding per-role section. The shared `memcached` cluster remains active for the other roles.
+
+For example, to give bloom filters their own cluster while keeping the rest on the shared one:
+
+```yaml
+memcachedBloom:
+  enabled: true
+  replicas: 2
+```
+
+Available per-role sections:
+
+| Key | Cache role |
+| --- | --- |
+| `memcachedBloom` | Bloom filter cache |
+| `memcachedParquetFooter` | Parquet footer cache |
+| `memcachedFrontendSearch` | Frontend search cache |
+
+#### Fully isolated caches per role
+
+To run a dedicated memcached cluster for every cache role, disable the shared cluster and enable all three per-role clusters:
+
+```yaml
+memcached:
+  enabled: false
+
+memcachedBloom:
+  enabled: true
+  replicas: 2
+
+memcachedParquetFooter:
+  enabled: true
+  replicas: 2
+
+memcachedFrontendSearch:
+  enabled: true
+  replicas: 2
+```
+
+Each role gets its own StatefulSet and Service, and Tempo is configured to use the matching host for every cache type.
+
 ### Enabling gRPC Open Telemetry
 
 gRPC for Open Telemetry is disabled by default, simply flip the bool in the `traces` block to turn it on.

--- a/charts/tempo-distributed/templates/_helpers.tpl
+++ b/charts/tempo-distributed/templates/_helpers.tpl
@@ -168,6 +168,60 @@ Calculate the config from structured and unstructured text input
 {{- end -}}
 
 {{/*
+Build the cache section for tempo.yaml.
+When memcached.enabled is true, auto-generates cache.caches from per-role memcached sections.
+Roles without a dedicated per-role instance fall back to the shared memcached cluster.
+When memcached.enabled is false, outputs the user-defined cache block from values.yaml verbatim.
+*/}}
+{{- define "tempo.cacheConfig" -}}
+{{- $fullname := include "tempo.fullname" . -}}
+{{- $roles := list "parquet-footer" "bloom" "frontend-search" -}}
+{{- $perRoleMap := dict
+    "parquet-footer"  (dict "section" "memcachedParquetFooter"  "component" "memcached-parquet-footer")
+    "bloom"           (dict "section" "memcachedBloom"          "component" "memcached-bloom")
+    "frontend-search" (dict "section" "memcachedFrontendSearch" "component" "memcached-frontend-search") -}}
+{{- if .Values.memcached.enabled -}}
+{{- $sharedRoles := list -}}
+{{- range $role := $roles -}}
+  {{- $mapping := get $perRoleMap $role -}}
+  {{- $vals := index $.Values (get $mapping "section") -}}
+  {{- if not (and $vals (index $vals "enabled")) -}}
+    {{- $sharedRoles = append $sharedRoles $role -}}
+  {{- end -}}
+{{- end -}}
+caches:
+{{- if gt (len $sharedRoles) 0 }}
+  - memcached:
+      host: {{ $fullname }}-memcached
+      service: memcached-client
+      consistent_hash: {{ .Values.memcached.consistentHash }}
+      timeout: {{ .Values.memcached.timeout }}
+    roles:
+    {{- range $sharedRoles }}
+      - {{ . }}
+    {{- end }}
+{{- end }}
+{{- range $role := $roles -}}
+  {{- $mapping := get $perRoleMap $role -}}
+  {{- $sectionName := get $mapping "section" -}}
+  {{- $component   := get $mapping "component" -}}
+  {{- $vals := index $.Values $sectionName -}}
+  {{- if and $vals (index $vals "enabled") }}
+  - memcached:
+      host: {{ $fullname }}-{{ $component }}
+      service: memcached-client
+      consistent_hash: {{ index $vals "consistentHash" }}
+      timeout: {{ index $vals "timeout" }}
+    roles:
+      - {{ $role }}
+  {{- end -}}
+{{- end }}
+{{- else -}}
+{{ toYaml .Values.cache }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Renders the overrides config
 */}}
 {{- define "tempo.overridesConfig" -}}

--- a/charts/tempo-distributed/templates/memcached/_helpers-memcached.tpl
+++ b/charts/tempo-distributed/templates/memcached/_helpers-memcached.tpl
@@ -168,6 +168,9 @@ spec:
   - name: memcached-client
     port: 11211
     targetPort: client
+  - name: http-metrics
+    port: 9150
+    targetPort: http-metrics
   selector:
     {{- include "tempo.selectorLabels" $dict | nindent 4 }}
 {{- end }}

--- a/charts/tempo-distributed/templates/memcached/_helpers-memcached.tpl
+++ b/charts/tempo-distributed/templates/memcached/_helpers-memcached.tpl
@@ -16,6 +16,10 @@ metadata:
   namespace: {{ $.ctx.Release.Namespace }}
   labels:
     {{- include "tempo.labels" $dict | nindent 4 }}
+  {{- with $.memcachedConfig.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ $.memcachedConfig.replicas }}
   revisionHistoryLimit: {{ $.ctx.Values.tempo.revisionHistoryLimit }}
@@ -52,8 +56,15 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       enableServiceLinks: false
+      {{- include "tempo.componentImagePullSecrets" (dict "ctx" $.ctx "component" "memcached-exporter" "noTempoFallback" true) | nindent 6 -}}
+      {{- with $.ctx.Values.memcachedExporter.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.memcachedConfig.initContainers }}
       initContainers:
-        {{- toYaml $.memcachedConfig.initContainers | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - image: {{ include "tempo.imageReference" (dict "ctx" $.ctx "component" "memcached") }}
           imagePullPolicy: {{ $.ctx.Values.memcached.image.pullPolicy }}
@@ -110,6 +121,30 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- if $.ctx.Values.memcachedExporter.enabled }}
+        - args:
+            - --memcached.address=localhost:11211
+            - --web.listen-address=0.0.0.0:9150
+          {{- with $.ctx.Values.memcachedExporter.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: {{ include "tempo.imageReference" (dict "ctx" $.ctx "component" "memcached-exporter") }}
+          imagePullPolicy: {{ $.ctx.Values.memcachedExporter.image.pullPolicy }}
+          name: exporter
+          ports:
+            - containerPort: 9150
+              name: http-metrics
+          resources:
+            {{- toYaml $.ctx.Values.memcachedExporter.resources | nindent 12 }}
+          {{- with $.ctx.Values.tempo.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $.memcachedConfig.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
         {{- with $.memcachedConfig.extraContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/tempo-distributed/templates/memcached/_helpers-memcached.tpl
+++ b/charts/tempo-distributed/templates/memcached/_helpers-memcached.tpl
@@ -1,0 +1,199 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Render a StatefulSet for a per-role memcached cluster.
+Params:
+  ctx            = root context ($)
+  memcachedConfig = per-role values section (e.g. .Values.memcachedBloom)
+  component      = K8s component name (e.g. "memcached-bloom")
+*/}}
+{{- define "tempo.memcached.statefulSet" -}}
+{{- if $.memcachedConfig.enabled }}
+{{ $dict := dict "ctx" $.ctx "component" $.component }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "tempo.resourceName" $dict }}
+  namespace: {{ $.ctx.Release.Namespace }}
+  labels:
+    {{- include "tempo.labels" $dict | nindent 4 }}
+spec:
+  replicas: {{ $.memcachedConfig.replicas }}
+  revisionHistoryLimit: {{ $.ctx.Values.tempo.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "tempo.selectorLabels" $dict | nindent 6 }}
+  serviceName: {{ $.component }}
+  template:
+    metadata:
+      {{- if or $.ctx.Values.tempo.podAnnotations $.memcachedConfig.podAnnotations }}
+      annotations:
+        {{- with $.ctx.Values.tempo.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with $.memcachedConfig.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      labels:
+        {{- include "tempo.labels" $dict | nindent 8 }}
+        {{- with $.ctx.Values.tempo.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with $.memcachedConfig.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- if or ($.memcachedConfig.priorityClassName) ($.ctx.Values.global.priorityClassName) }}
+      priorityClassName: {{ default $.memcachedConfig.priorityClassName $.ctx.Values.global.priorityClassName }}
+      {{- end }}
+      serviceAccountName: {{ include "tempo.serviceAccountName" $.ctx }}
+      {{- with $.ctx.Values.tempo.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      enableServiceLinks: false
+      initContainers:
+        {{- toYaml $.memcachedConfig.initContainers | nindent 8 }}
+      containers:
+        - image: {{ include "tempo.imageReference" (dict "ctx" $.ctx "component" "memcached") }}
+          imagePullPolicy: {{ $.ctx.Values.memcached.image.pullPolicy }}
+          name: memcached
+          {{- if or $.ctx.Values.global.extraArgs $.memcachedConfig.extraArgs }}
+          args:
+            {{- with $.memcachedConfig.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with $.ctx.Values.global.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          ports:
+            - containerPort: 11211
+              name: client
+          {{- if or $.ctx.Values.global.extraEnv $.memcachedConfig.extraEnv }}
+          env:
+            {{- with $.ctx.Values.global.extraEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with $.memcachedConfig.extraEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          {{- if or $.ctx.Values.global.extraEnvFrom $.memcachedConfig.extraEnvFrom }}
+          envFrom:
+            {{- with $.ctx.Values.global.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with $.memcachedConfig.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          {{- with $.memcachedConfig.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $.memcachedConfig.livenessProbe }}
+          livenessProbe:
+            exec:
+              command:
+                - pgrep
+                - memcached
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml $.memcachedConfig.resources | nindent 12 }}
+          {{- with $.ctx.Values.tempo.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $.memcachedConfig.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- with $.memcachedConfig.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- if semverCompare ">= 1.19-0" $.ctx.Capabilities.KubeVersion.Version }}
+      {{- with $.memcachedConfig.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- tpl . $.ctx | nindent 8 }}
+      {{- end }}
+      {{- end }}
+      {{- with $.memcachedConfig.affinity }}
+      affinity:
+        {{- tpl . $.ctx | nindent 8 }}
+      {{- end }}
+      {{- with $.memcachedConfig.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.memcachedConfig.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.memcachedConfig.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  updateStrategy:
+    type: RollingUpdate
+{{- end }}
+{{- end -}}
+
+{{/*
+Render a Service for a per-role memcached cluster.
+Params:
+  ctx            = root context ($)
+  memcachedConfig = per-role values section (e.g. .Values.memcachedBloom)
+  component      = K8s component name (e.g. "memcached-bloom")
+*/}}
+{{- define "tempo.memcached.service" -}}
+{{- if $.memcachedConfig.enabled }}
+{{ $dict := dict "ctx" $.ctx "component" $.component }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "tempo.resourceName" $dict }}
+  namespace: {{ $.ctx.Release.Namespace }}
+  labels:
+    {{- include "tempo.labels" $dict | nindent 4 }}
+  {{- with $.memcachedConfig.service.annotations }}
+  annotations:
+    {{- tpl (toYaml . | nindent 4) $.ctx }}
+  {{- end }}
+spec:
+  ipFamilies: {{ $.ctx.Values.tempo.service.ipFamilies }}
+  ipFamilyPolicy: {{ $.ctx.Values.tempo.service.ipFamilyPolicy }}
+  ports:
+  - name: memcached-client
+    port: 11211
+    targetPort: client
+  selector:
+    {{- include "tempo.selectorLabels" $dict | nindent 4 }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Render a PodDisruptionBudget for a per-role memcached cluster.
+Params:
+  ctx            = root context ($)
+  memcachedConfig = per-role values section (e.g. .Values.memcachedBloom)
+  component      = K8s component name (e.g. "memcached-bloom")
+*/}}
+{{- define "tempo.memcached.pdb" -}}
+{{- if and $.memcachedConfig.enabled (gt (int $.memcachedConfig.replicas) 1) $.memcachedConfig.podDisruptionBudget.enabled }}
+{{ $dict := dict "ctx" $.ctx "component" $.component }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "tempo.resourceName" $dict }}
+  namespace: {{ $.ctx.Release.Namespace }}
+  labels:
+    {{- include "tempo.labels" $dict | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "tempo.selectorLabels" $dict | nindent 6 }}
+  maxUnavailable: {{ $.memcachedConfig.maxUnavailable }}
+{{- end }}
+{{- end -}}

--- a/charts/tempo-distributed/templates/memcached/poddisruptionbudget-memcached-bloom.yaml
+++ b/charts/tempo-distributed/templates/memcached/poddisruptionbudget-memcached-bloom.yaml
@@ -1,0 +1,1 @@
+{{- include "tempo.memcached.pdb" (dict "ctx" $ "memcachedConfig" .Values.memcachedBloom "component" "memcached-bloom") }}

--- a/charts/tempo-distributed/templates/memcached/poddisruptionbudget-memcached-frontend-search.yaml
+++ b/charts/tempo-distributed/templates/memcached/poddisruptionbudget-memcached-frontend-search.yaml
@@ -1,0 +1,1 @@
+{{- include "tempo.memcached.pdb" (dict "ctx" $ "memcachedConfig" .Values.memcachedFrontendSearch "component" "memcached-frontend-search") }}

--- a/charts/tempo-distributed/templates/memcached/poddisruptionbudget-memcached-parquet-footer.yaml
+++ b/charts/tempo-distributed/templates/memcached/poddisruptionbudget-memcached-parquet-footer.yaml
@@ -1,0 +1,1 @@
+{{- include "tempo.memcached.pdb" (dict "ctx" $ "memcachedConfig" .Values.memcachedParquetFooter "component" "memcached-parquet-footer") }}

--- a/charts/tempo-distributed/templates/memcached/service-memcached-bloom.yaml
+++ b/charts/tempo-distributed/templates/memcached/service-memcached-bloom.yaml
@@ -1,0 +1,1 @@
+{{- include "tempo.memcached.service" (dict "ctx" $ "memcachedConfig" .Values.memcachedBloom "component" "memcached-bloom") }}

--- a/charts/tempo-distributed/templates/memcached/service-memcached-frontend-search.yaml
+++ b/charts/tempo-distributed/templates/memcached/service-memcached-frontend-search.yaml
@@ -1,0 +1,1 @@
+{{- include "tempo.memcached.service" (dict "ctx" $ "memcachedConfig" .Values.memcachedFrontendSearch "component" "memcached-frontend-search") }}

--- a/charts/tempo-distributed/templates/memcached/service-memcached-parquet-footer.yaml
+++ b/charts/tempo-distributed/templates/memcached/service-memcached-parquet-footer.yaml
@@ -1,0 +1,1 @@
+{{- include "tempo.memcached.service" (dict "ctx" $ "memcachedConfig" .Values.memcachedParquetFooter "component" "memcached-parquet-footer") }}

--- a/charts/tempo-distributed/templates/memcached/statefulset-memcached-bloom.yaml
+++ b/charts/tempo-distributed/templates/memcached/statefulset-memcached-bloom.yaml
@@ -1,0 +1,1 @@
+{{- include "tempo.memcached.statefulSet" (dict "ctx" $ "memcachedConfig" .Values.memcachedBloom "component" "memcached-bloom") }}

--- a/charts/tempo-distributed/templates/memcached/statefulset-memcached-frontend-search.yaml
+++ b/charts/tempo-distributed/templates/memcached/statefulset-memcached-frontend-search.yaml
@@ -1,0 +1,1 @@
+{{- include "tempo.memcached.statefulSet" (dict "ctx" $ "memcachedConfig" .Values.memcachedFrontendSearch "component" "memcached-frontend-search") }}

--- a/charts/tempo-distributed/templates/memcached/statefulset-memcached-parquet-footer.yaml
+++ b/charts/tempo-distributed/templates/memcached/statefulset-memcached-parquet-footer.yaml
@@ -1,0 +1,1 @@
+{{- include "tempo.memcached.statefulSet" (dict "ctx" $ "memcachedConfig" .Values.memcachedParquetFooter "component" "memcached-parquet-footer") }}

--- a/charts/tempo-distributed/tests/memcached/cache_config_test.yaml
+++ b/charts/tempo-distributed/tests/memcached/cache_config_test.yaml
@@ -94,6 +94,9 @@ tests:
       - matchRegex:
           path: data["tempo.yaml"]
           pattern: "memcached-frontend-search"
+      - notMatchRegex:
+          path: data["tempo.yaml"]
+          pattern: "host: .*-memcached\n"
 
   - it: custom timeout respected for bloom
     set:
@@ -103,3 +106,21 @@ tests:
       - matchRegex:
           path: data["tempo.yaml"]
           pattern: "timeout: 1s"
+
+  - it: custom timeout respected for parquet-footer
+    set:
+      memcachedParquetFooter.enabled: true
+      memcachedParquetFooter.timeout: 2s
+    asserts:
+      - matchRegex:
+          path: data["tempo.yaml"]
+          pattern: "timeout: 2s"
+
+  - it: custom timeout respected for frontend-search
+    set:
+      memcachedFrontendSearch.enabled: true
+      memcachedFrontendSearch.timeout: 750ms
+    asserts:
+      - matchRegex:
+          path: data["tempo.yaml"]
+          pattern: "timeout: 750ms"

--- a/charts/tempo-distributed/tests/memcached/cache_config_test.yaml
+++ b/charts/tempo-distributed/tests/memcached/cache_config_test.yaml
@@ -1,0 +1,105 @@
+# $schema: https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json
+suite: cache config generation
+templates:
+  - configmap-tempo.yaml
+
+tests:
+  - it: default - single shared entry covering all three roles
+    asserts:
+      - matchRegex:
+          path: data["tempo.yaml"]
+          pattern: "host: .*-memcached\n"
+      - matchRegex:
+          path: data["tempo.yaml"]
+          pattern: "parquet-footer"
+      - matchRegex:
+          path: data["tempo.yaml"]
+          pattern: "bloom"
+      - matchRegex:
+          path: data["tempo.yaml"]
+          pattern: "frontend-search"
+      - notMatchRegex:
+          path: data["tempo.yaml"]
+          pattern: "memcached-bloom"
+      - notMatchRegex:
+          path: data["tempo.yaml"]
+          pattern: "memcached-parquet-footer"
+      - notMatchRegex:
+          path: data["tempo.yaml"]
+          pattern: "memcached-frontend-search"
+
+  - it: bloom enabled - bloom gets its own cluster, shared handles remaining roles
+    set:
+      memcachedBloom.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["tempo.yaml"]
+          pattern: "host: .*-memcached\n"
+      - matchRegex:
+          path: data["tempo.yaml"]
+          pattern: "memcached-bloom"
+      - matchRegex:
+          path: data["tempo.yaml"]
+          pattern: "parquet-footer"
+      - matchRegex:
+          path: data["tempo.yaml"]
+          pattern: "frontend-search"
+      - notMatchRegex:
+          path: data["tempo.yaml"]
+          pattern: "memcached-parquet-footer"
+      - notMatchRegex:
+          path: data["tempo.yaml"]
+          pattern: "memcached-frontend-search"
+
+  - it: parquet-footer enabled - parquet-footer gets its own cluster
+    set:
+      memcachedParquetFooter.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["tempo.yaml"]
+          pattern: "memcached-parquet-footer"
+      - matchRegex:
+          path: data["tempo.yaml"]
+          pattern: "bloom"
+      - matchRegex:
+          path: data["tempo.yaml"]
+          pattern: "frontend-search"
+
+  - it: frontend-search enabled - frontend-search gets its own cluster
+    set:
+      memcachedFrontendSearch.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["tempo.yaml"]
+          pattern: "memcached-frontend-search"
+      - matchRegex:
+          path: data["tempo.yaml"]
+          pattern: "bloom"
+      - matchRegex:
+          path: data["tempo.yaml"]
+          pattern: "parquet-footer"
+
+  - it: all three enabled - each role has its own cluster, no shared entry
+    set:
+      memcachedBloom.enabled: true
+      memcachedParquetFooter.enabled: true
+      memcachedFrontendSearch.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["tempo.yaml"]
+          pattern: "memcached-bloom"
+      - matchRegex:
+          path: data["tempo.yaml"]
+          pattern: "memcached-parquet-footer"
+      - matchRegex:
+          path: data["tempo.yaml"]
+          pattern: "memcached-frontend-search"
+
+  - it: custom timeout respected for bloom
+    set:
+      memcachedBloom.enabled: true
+      memcachedBloom.timeout: 1s
+    asserts:
+      - matchRegex:
+          path: data["tempo.yaml"]
+          pattern: "timeout: 1s"

--- a/charts/tempo-distributed/tests/memcached/per_role_statefulset_test.yaml
+++ b/charts/tempo-distributed/tests/memcached/per_role_statefulset_test.yaml
@@ -119,3 +119,125 @@ tests:
       - hasDocuments:
           count: 1
         template: memcached/statefulset-memcached-frontend-search.yaml
+
+  - it: parquet-footer Service rendered with correct name when enabled
+    set:
+      memcachedParquetFooter.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-tempo-memcached-parquet-footer
+        template: memcached/service-memcached-parquet-footer.yaml
+      - equal:
+          path: kind
+          value: Service
+        template: memcached/service-memcached-parquet-footer.yaml
+
+  - it: frontend-search Service rendered with correct name when enabled
+    set:
+      memcachedFrontendSearch.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-tempo-memcached-frontend-search
+        template: memcached/service-memcached-frontend-search.yaml
+      - equal:
+          path: kind
+          value: Service
+        template: memcached/service-memcached-frontend-search.yaml
+
+  - it: parquet-footer PDB not rendered when replicas is 1 (default)
+    set:
+      memcachedParquetFooter.enabled: true
+      memcachedParquetFooter.replicas: 1
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: memcached/poddisruptionbudget-memcached-parquet-footer.yaml
+
+  - it: parquet-footer PDB rendered when replicas > 1
+    set:
+      memcachedParquetFooter.enabled: true
+      memcachedParquetFooter.replicas: 3
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-tempo-memcached-parquet-footer
+        template: memcached/poddisruptionbudget-memcached-parquet-footer.yaml
+
+  - it: frontend-search PDB not rendered when replicas is 1 (default)
+    set:
+      memcachedFrontendSearch.enabled: true
+      memcachedFrontendSearch.replicas: 1
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: memcached/poddisruptionbudget-memcached-frontend-search.yaml
+
+  - it: frontend-search PDB rendered when replicas > 1
+    set:
+      memcachedFrontendSearch.enabled: true
+      memcachedFrontendSearch.replicas: 2
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-tempo-memcached-frontend-search
+        template: memcached/poddisruptionbudget-memcached-frontend-search.yaml
+
+  - it: parquet-footer StatefulSet respects replica count
+    set:
+      memcachedParquetFooter.enabled: true
+      memcachedParquetFooter.replicas: 3
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+        template: memcached/statefulset-memcached-parquet-footer.yaml
+
+  - it: frontend-search StatefulSet respects replica count
+    set:
+      memcachedFrontendSearch.enabled: true
+      memcachedFrontendSearch.replicas: 2
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 2
+        template: memcached/statefulset-memcached-frontend-search.yaml
+
+  - it: per-role StatefulSets use memcached.image
+    set:
+      memcachedParquetFooter.enabled: true
+      memcachedFrontendSearch.enabled: true
+      memcached.image.tag: 1.6.41-alpine
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/memcached:1.6.41-alpine
+        template: memcached/statefulset-memcached-parquet-footer.yaml
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/memcached:1.6.41-alpine
+        template: memcached/statefulset-memcached-frontend-search.yaml
+
+  - it: per-role resources are passed to StatefulSet containers
+    set:
+      memcachedBloom.enabled: true
+      memcachedBloom.resources:
+        requests:
+          cpu: 250m
+          memory: 512Mi
+        limits:
+          memory: 1Gi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 250m
+        template: memcached/statefulset-memcached-bloom.yaml
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 512Mi
+        template: memcached/statefulset-memcached-bloom.yaml
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 1Gi
+        template: memcached/statefulset-memcached-bloom.yaml

--- a/charts/tempo-distributed/tests/memcached/per_role_statefulset_test.yaml
+++ b/charts/tempo-distributed/tests/memcached/per_role_statefulset_test.yaml
@@ -1,0 +1,121 @@
+# $schema: https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json
+suite: per-role memcached StatefulSets
+templates:
+  - memcached/statefulset-memcached-bloom.yaml
+  - memcached/statefulset-memcached-parquet-footer.yaml
+  - memcached/statefulset-memcached-frontend-search.yaml
+  - memcached/service-memcached-bloom.yaml
+  - memcached/service-memcached-parquet-footer.yaml
+  - memcached/service-memcached-frontend-search.yaml
+  - memcached/poddisruptionbudget-memcached-bloom.yaml
+  - memcached/poddisruptionbudget-memcached-parquet-footer.yaml
+  - memcached/poddisruptionbudget-memcached-frontend-search.yaml
+
+tests:
+  - it: no per-role resources rendered when all disabled (default)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: bloom StatefulSet rendered with correct name when enabled
+    set:
+      memcachedBloom.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-tempo-memcached-bloom
+        template: memcached/statefulset-memcached-bloom.yaml
+      - equal:
+          path: kind
+          value: StatefulSet
+        template: memcached/statefulset-memcached-bloom.yaml
+
+  - it: bloom StatefulSet uses memcached.image
+    set:
+      memcachedBloom.enabled: true
+      memcached.image.tag: 1.6.41-alpine
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/memcached:1.6.41-alpine
+        template: memcached/statefulset-memcached-bloom.yaml
+
+  - it: bloom StatefulSet respects replica count
+    set:
+      memcachedBloom.enabled: true
+      memcachedBloom.replicas: 3
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+        template: memcached/statefulset-memcached-bloom.yaml
+
+  - it: bloom Service rendered with correct name
+    set:
+      memcachedBloom.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-tempo-memcached-bloom
+        template: memcached/service-memcached-bloom.yaml
+      - equal:
+          path: kind
+          value: Service
+        template: memcached/service-memcached-bloom.yaml
+
+  - it: bloom PDB not rendered when replicas is 1 (default)
+    set:
+      memcachedBloom.enabled: true
+      memcachedBloom.replicas: 1
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: memcached/poddisruptionbudget-memcached-bloom.yaml
+
+  - it: bloom PDB rendered when replicas > 1
+    set:
+      memcachedBloom.enabled: true
+      memcachedBloom.replicas: 3
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-tempo-memcached-bloom
+        template: memcached/poddisruptionbudget-memcached-bloom.yaml
+      - equal:
+          path: kind
+          value: PodDisruptionBudget
+        template: memcached/poddisruptionbudget-memcached-bloom.yaml
+
+  - it: parquet-footer StatefulSet rendered with correct name when enabled
+    set:
+      memcachedParquetFooter.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-tempo-memcached-parquet-footer
+        template: memcached/statefulset-memcached-parquet-footer.yaml
+
+  - it: frontend-search StatefulSet rendered with correct name when enabled
+    set:
+      memcachedFrontendSearch.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-tempo-memcached-frontend-search
+        template: memcached/statefulset-memcached-frontend-search.yaml
+
+  - it: all three per-role StatefulSets rendered when all enabled
+    set:
+      memcachedBloom.enabled: true
+      memcachedParquetFooter.enabled: true
+      memcachedFrontendSearch.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: memcached/statefulset-memcached-bloom.yaml
+      - hasDocuments:
+          count: 1
+        template: memcached/statefulset-memcached-parquet-footer.yaml
+      - hasDocuments:
+          count: 1
+        template: memcached/statefulset-memcached-frontend-search.yaml

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -1943,6 +1943,8 @@ memcachedExporter:
 memcachedBloom:
   # -- Enable a dedicated memcached cluster for the bloom cache role
   enabled: false
+  # -- Annotations for the memcached-bloom StatefulSet
+  annotations: {}
   # -- Number of replicas for the bloom memcached StatefulSet
   replicas: 1
   # -- Timeout for bloom cache operations
@@ -2028,6 +2030,8 @@ memcachedBloom:
 memcachedParquetFooter:
   # -- Enable a dedicated memcached cluster for the parquet-footer cache role
   enabled: false
+  # -- Annotations for the memcached-parquet-footer StatefulSet
+  annotations: {}
   # -- Number of replicas for the parquet-footer memcached StatefulSet
   replicas: 1
   # -- Timeout for parquet-footer cache operations
@@ -2113,6 +2117,8 @@ memcachedParquetFooter:
 memcachedFrontendSearch:
   # -- Enable a dedicated memcached cluster for the frontend-search cache role
   enabled: false
+  # -- Annotations for the memcached-frontend-search StatefulSet
+  annotations: {}
   # -- Number of replicas for the frontend-search memcached StatefulSet
   replicas: 1
   # -- Timeout for frontend-search cache operations

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -1658,7 +1658,7 @@ config: |
     http_server_read_timeout: {{ .Values.server.http_server_read_timeout }}
     http_server_write_timeout: {{ .Values.server.http_server_write_timeout }}
   cache:
-  {{- toYaml .Values.cache | nindent 2}}
+  {{- include "tempo.cacheConfig" . | nindent 2}}
   storage:
     trace:
       {{- if .Values.storage.trace.block.version }}
@@ -1736,6 +1736,9 @@ server:
 # Use this block to configure caches available throughout the application.
 # Multiple caches can be created and assigned roles which determine how they are used by Tempo.
 # https://grafana.com/docs/tempo/latest/configuration/#cache
+# When memcached.enabled is true (the default), the cache.caches list is auto-generated from the
+# memcached and per-role memcached sections (memcachedBloom, memcachedParquetFooter, memcachedFrontendSearch).
+# When memcached.enabled is false, this block is passed through verbatim to allow configuring external caches.
 cache:
   caches:
     - memcached:
@@ -1831,6 +1834,10 @@ memcached:
   host: memcached
   # Number of replicas for memchached
   replicas: 1
+  # -- Timeout for cache operations
+  timeout: 500ms
+  # -- Enable consistent hashing for cache
+  consistentHash: true
   # -- Additional CLI args for memcached
   extraArgs: []
   # -- Toleration for memcached pods
@@ -1929,6 +1936,262 @@ memcachedExporter:
   resources: {}
   # -- Additional CLI args for the memcached exporter
   extraArgs: []
+
+# -- Configuration for a dedicated memcached cluster for the bloom cache role.
+# When enabled, bloom cache is served by its own memcached StatefulSet.
+# Image is shared with the main `memcached` section.
+memcachedBloom:
+  # -- Enable a dedicated memcached cluster for the bloom cache role
+  enabled: false
+  # -- Number of replicas for the bloom memcached StatefulSet
+  replicas: 1
+  # -- Timeout for bloom cache operations
+  timeout: 500ms
+  # -- Enable consistent hashing for bloom cache
+  consistentHash: true
+  # -- Additional CLI args for memcached
+  extraArgs: []
+  # -- Tolerations for memcached-bloom pods
+  tolerations: []
+  # -- Environment variables to add to memcached-bloom pods
+  extraEnv: []
+  # -- Environment variables from secrets or configmaps to add to memcached-bloom pods
+  extraEnvFrom: []
+  # -- Labels for memcached-bloom pods
+  podLabels: {}
+  # -- Annotations for memcached-bloom pods
+  podAnnotations: {}
+  # -- Resource requests and limits for memcached-bloom
+  resources: {}
+  # -- topologySpread for memcached-bloom pods. Passed through `tpl` and, thus, to be configured as string
+  # @default -- Defaults to allow skew no more than 1 node per AZ
+  topologySpreadConstraints: |
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          {{- include "tempo.selectorLabels" (dict "ctx" . "component" "memcached-bloom") | nindent 6 }}
+  # -- Affinity for memcached-bloom pods. Passed through `tpl` and, thus, to be configured as string
+  # @default -- Hard node and soft zone anti-affinity
+  affinity: |
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              {{- include "tempo.selectorLabels" (dict "ctx" . "component" "memcached-bloom") | nindent 10 }}
+          topologyKey: kubernetes.io/hostname
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                {{- include "tempo.selectorLabels" (dict "ctx" . "component" "memcached-bloom") | nindent 12 }}
+            topologyKey: topology.kubernetes.io/zone
+  # -- Pod Disruption Budget configuration
+  podDisruptionBudget:
+    # -- Enable PodDisruptionBudget for memcached-bloom
+    enabled: true
+  # -- Pod Disruption Budget maxUnavailable
+  maxUnavailable: 1
+  # -- Init containers for the memcached-bloom pod
+  initContainers: []
+  # -- Containers to add to the memcached-bloom pods
+  extraContainers: []
+  # -- Extra volume mounts for memcached-bloom pods
+  extraVolumeMounts: []
+  # -- Extra volumes for memcached-bloom StatefulSet
+  extraVolumes: []
+  service:
+    # -- Annotations for memcached-bloom service
+    annotations: {}
+  # -- configuration for readiness probe for memcached-bloom statefulset
+  readinessProbe:
+    tcpSocket:
+      port: client
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 3
+    failureThreshold: 6
+    successThreshold: 1
+  # -- configuration for liveness probe for memcached-bloom statefulset
+  livenessProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+
+# -- Configuration for a dedicated memcached cluster for the parquet-footer cache role.
+# When enabled, parquet-footer cache is served by its own memcached StatefulSet.
+# Image is shared with the main `memcached` section.
+memcachedParquetFooter:
+  # -- Enable a dedicated memcached cluster for the parquet-footer cache role
+  enabled: false
+  # -- Number of replicas for the parquet-footer memcached StatefulSet
+  replicas: 1
+  # -- Timeout for parquet-footer cache operations
+  timeout: 500ms
+  # -- Enable consistent hashing for parquet-footer cache
+  consistentHash: true
+  # -- Additional CLI args for memcached
+  extraArgs: []
+  # -- Tolerations for memcached-parquet-footer pods
+  tolerations: []
+  # -- Environment variables to add to memcached-parquet-footer pods
+  extraEnv: []
+  # -- Environment variables from secrets or configmaps to add to memcached-parquet-footer pods
+  extraEnvFrom: []
+  # -- Labels for memcached-parquet-footer pods
+  podLabels: {}
+  # -- Annotations for memcached-parquet-footer pods
+  podAnnotations: {}
+  # -- Resource requests and limits for memcached-parquet-footer
+  resources: {}
+  # -- topologySpread for memcached-parquet-footer pods. Passed through `tpl` and, thus, to be configured as string
+  # @default -- Defaults to allow skew no more than 1 node per AZ
+  topologySpreadConstraints: |
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          {{- include "tempo.selectorLabels" (dict "ctx" . "component" "memcached-parquet-footer") | nindent 6 }}
+  # -- Affinity for memcached-parquet-footer pods. Passed through `tpl` and, thus, to be configured as string
+  # @default -- Hard node and soft zone anti-affinity
+  affinity: |
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              {{- include "tempo.selectorLabels" (dict "ctx" . "component" "memcached-parquet-footer") | nindent 10 }}
+          topologyKey: kubernetes.io/hostname
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                {{- include "tempo.selectorLabels" (dict "ctx" . "component" "memcached-parquet-footer") | nindent 12 }}
+            topologyKey: topology.kubernetes.io/zone
+  # -- Pod Disruption Budget configuration
+  podDisruptionBudget:
+    # -- Enable PodDisruptionBudget for memcached-parquet-footer
+    enabled: true
+  # -- Pod Disruption Budget maxUnavailable
+  maxUnavailable: 1
+  # -- Init containers for the memcached-parquet-footer pod
+  initContainers: []
+  # -- Containers to add to the memcached-parquet-footer pods
+  extraContainers: []
+  # -- Extra volume mounts for memcached-parquet-footer pods
+  extraVolumeMounts: []
+  # -- Extra volumes for memcached-parquet-footer StatefulSet
+  extraVolumes: []
+  service:
+    # -- Annotations for memcached-parquet-footer service
+    annotations: {}
+  # -- configuration for readiness probe for memcached-parquet-footer statefulset
+  readinessProbe:
+    tcpSocket:
+      port: client
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 3
+    failureThreshold: 6
+    successThreshold: 1
+  # -- configuration for liveness probe for memcached-parquet-footer statefulset
+  livenessProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+
+# -- Configuration for a dedicated memcached cluster for the frontend-search cache role.
+# When enabled, frontend-search cache is served by its own memcached StatefulSet.
+# Image is shared with the main `memcached` section.
+memcachedFrontendSearch:
+  # -- Enable a dedicated memcached cluster for the frontend-search cache role
+  enabled: false
+  # -- Number of replicas for the frontend-search memcached StatefulSet
+  replicas: 1
+  # -- Timeout for frontend-search cache operations
+  timeout: 500ms
+  # -- Enable consistent hashing for frontend-search cache
+  consistentHash: true
+  # -- Additional CLI args for memcached
+  extraArgs: []
+  # -- Tolerations for memcached-frontend-search pods
+  tolerations: []
+  # -- Environment variables to add to memcached-frontend-search pods
+  extraEnv: []
+  # -- Environment variables from secrets or configmaps to add to memcached-frontend-search pods
+  extraEnvFrom: []
+  # -- Labels for memcached-frontend-search pods
+  podLabels: {}
+  # -- Annotations for memcached-frontend-search pods
+  podAnnotations: {}
+  # -- Resource requests and limits for memcached-frontend-search
+  resources: {}
+  # -- topologySpread for memcached-frontend-search pods. Passed through `tpl` and, thus, to be configured as string
+  # @default -- Defaults to allow skew no more than 1 node per AZ
+  topologySpreadConstraints: |
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          {{- include "tempo.selectorLabels" (dict "ctx" . "component" "memcached-frontend-search") | nindent 6 }}
+  # -- Affinity for memcached-frontend-search pods. Passed through `tpl` and, thus, to be configured as string
+  # @default -- Hard node and soft zone anti-affinity
+  affinity: |
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              {{- include "tempo.selectorLabels" (dict "ctx" . "component" "memcached-frontend-search") | nindent 10 }}
+          topologyKey: kubernetes.io/hostname
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                {{- include "tempo.selectorLabels" (dict "ctx" . "component" "memcached-frontend-search") | nindent 12 }}
+            topologyKey: topology.kubernetes.io/zone
+  # -- Pod Disruption Budget configuration
+  podDisruptionBudget:
+    # -- Enable PodDisruptionBudget for memcached-frontend-search
+    enabled: true
+  # -- Pod Disruption Budget maxUnavailable
+  maxUnavailable: 1
+  # -- Init containers for the memcached-frontend-search pod
+  initContainers: []
+  # -- Containers to add to the memcached-frontend-search pods
+  extraContainers: []
+  # -- Extra volume mounts for memcached-frontend-search pods
+  extraVolumeMounts: []
+  # -- Extra volumes for memcached-frontend-search StatefulSet
+  extraVolumes: []
+  service:
+    # -- Annotations for memcached-frontend-search service
+    annotations: {}
+  # -- configuration for readiness probe for memcached-frontend-search statefulset
+  readinessProbe:
+    tcpSocket:
+      port: client
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 3
+    failureThreshold: 6
+    successThreshold: 1
+  # -- configuration for liveness probe for memcached-frontend-search statefulset
+  livenessProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+
 metaMonitoring:
   # ServiceMonitor configuration
   serviceMonitor:


### PR DESCRIPTION
<!--
Thank you for contributing to grafana-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/grafana-community/helm-charts/blob/main/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them (see CONTRIBUTING.md).
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.  Please check the results.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR adds config for 3 roles of tempo cache, and allows the user to separate which roles gets their own memcache cluster  

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes https://github.com/grafana/helm-charts/issues/3999

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[grafana]`)
