### PR TITLE
[loki] Don't create ingester zone services when zone-aware replicatio…

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.1
-version: 11.4.8
+version: 11.4.9
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/templates/ingester/service.yaml
+++ b/charts/loki/templates/ingester/service.yaml
@@ -1,9 +1,10 @@
 {{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
 {{- if $isDistributed }}
 {{- include "loki.service" (dict "target" "ingester" "component" .Values.ingester "ctx" .) }}
-
+{{- if .Values.ingester.zoneAwareReplication.enabled }}
 {{- range $zone := list "zone-a" "zone-b" "zone-c" }}
 ---
 {{- include "loki.service" (dict "target" "ingester" "component" $.Values.ingester "ctx" $ "rolloutZoneName" $zone "serviceEnabled" false "publishNotReadyAddresses" false) }}
+{{- end }}
 {{- end }}
 {{- end -}}


### PR DESCRIPTION
#### What this PR does / why we need it

This PR fixes a regression introduced in #290 where zone-aware replication services are created even when `ingester.zoneAwareReplication.enabled=false`.  Essentially this just restores the [previous logic](https://github.com/grafana-community/helm-charts/blob/loki-11.2.1/charts/loki/templates/ingester/service-ingester-zone-a-headless.yaml#L2) from the individual zone service templates.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[grafana]`)
