### PR TITLE
[tempo-distributed] Auto-inject GOMEMLIMIT from container memory limit

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 2.11.0
+version: 2.12.0
 # renovate: docker=docker.io/grafana/tempo
 appVersion: 2.10.3
 kubeVersion: "^1.25.0-0"

--- a/charts/tempo-distributed/templates/_helpers.tpl
+++ b/charts/tempo-distributed/templates/_helpers.tpl
@@ -342,6 +342,61 @@ Cluster name that shows up in dashboard metrics
 {{ (include "tempo.calculatedConfig" . | fromYaml).cluster_name | default .Release.Name }}
 {{- end -}}
 
+{{- define "tempo.memoryToMiB" -}}
+{{- $mem := . | toString -}}
+{{- if hasSuffix "Gi" $mem -}}
+  {{- mulf ((trimSuffix "Gi" $mem) | float64) 1024 | int -}}
+{{- else if hasSuffix "Mi" $mem -}}
+  {{- (trimSuffix "Mi" $mem) | int -}}
+{{- else if hasSuffix "G" $mem -}}
+  {{- mulf ((trimSuffix "G" $mem) | float64) 953.6743164 | int -}}
+{{- else if hasSuffix "M" $mem -}}
+  {{- mulf ((trimSuffix "M" $mem) | float64) 0.9536743164 | int -}}
+{{- else if hasSuffix "Ki" $mem -}}
+  {{- divf ((trimSuffix "Ki" $mem) | float64) 1024 | int -}}
+{{- else -}}
+  {{- divf ($mem | float64) 1048576 | int -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Build the env block for a Tempo component, auto-injecting GOMEMLIMIT and GOGC.
+
+Arguments (passed as a dict):
+  extraEnv  - already-concatenated extraEnv list for this component
+  resources - the component's resources block (.Values.<component>.resources)
+  factor    - fraction of memory limit for GOMEMLIMIT (default 0.85)
+  gogc      - value for GOGC env var (default 80)
+
+When the memory limit is not set, or GOMEMLIMIT is already defined in extraEnv,
+the list is returned unchanged so users retain full control.
+*/}}
+{{- define "tempo.componentEnv" -}}
+{{- $envList := .extraEnv | default list -}}
+{{- $resources := .resources | default dict -}}
+{{- $factor := .factor | default 0.85 | float64 -}}
+{{- $gogc := .gogc | default 80 | int -}}
+{{- $hasGomemlimit := false -}}
+{{- $hasGogc := false -}}
+{{- range $envList -}}
+  {{- if eq .name "GOMEMLIMIT" -}}{{- $hasGomemlimit = true -}}{{- end -}}
+  {{- if eq .name "GOGC" -}}{{- $hasGogc = true -}}{{- end -}}
+{{- end -}}
+{{- $memLimit := dig "limits" "memory" "" $resources -}}
+{{- if and (not $hasGomemlimit) $memLimit -}}
+  {{- $mib := include "tempo.memoryToMiB" $memLimit | int -}}
+  {{- $goMemMib := mulf ($mib | float64) $factor | int -}}
+  {{- $envList = append $envList (dict "name" "GOMEMLIMIT" "value" (printf "%dMiB" $goMemMib)) -}}
+{{- end -}}
+{{- if not $hasGogc -}}
+  {{- $envList = append $envList (dict "name" "GOGC" "value" ($gogc | toString)) -}}
+{{- end -}}
+{{- with $envList | uniq -}}
+env:
+  {{- toYaml . | nindent 2 }}
+{{- end -}}
+{{- end -}}
+
 {{- define "tempo.statefulset.recreateOnSizeChangeHook" -}}
   {{- $renderedStatefulSets := list -}}
   {{- range $renderedStatefulSet := include (print .context.Template.BasePath .pathToStatefulsetTemplate) .context | splitList "---" -}}

--- a/charts/tempo-distributed/templates/admin-api/admin-api-dep.yaml
+++ b/charts/tempo-distributed/templates/admin-api/admin-api-dep.yaml
@@ -86,15 +86,7 @@ spec:
             {{- toYaml .Values.adminApi.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.adminApi.containerSecurityContext | nindent 12 }}
-          {{- if or .Values.global.extraEnv .Values.adminApi.env }}
-          env:
-            {{- with .Values.global.extraEnv }}
-              {{ toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with .Values.adminApi.env }}
-              {{ toYaml . | nindent 12 }}
-            {{- end }}
-          {{- end }}
+          {{- include "tempo.componentEnv" (dict "extraEnv" (concat .Values.global.extraEnv .Values.adminApi.env) "resources" .Values.adminApi.resources "factor" .Values.global.goSettings.goMemLimitFactor "gogc" .Values.global.goSettings.gogc) | nindent 10 }}
           envFrom:
             {{- with .Values.global.extraEnvFrom }}
               {{- toYaml . | nindent 12 }}

--- a/charts/tempo-distributed/templates/compactor/deployment-compactor.yaml
+++ b/charts/tempo-distributed/templates/compactor/deployment-compactor.yaml
@@ -76,15 +76,7 @@ spec:
               name: http-metrics
             - containerPort: {{ include "tempo.memberlistBindPort" . }}
               name: http-memberlist
-          {{- if or .Values.global.extraEnv .Values.compactor.extraEnv }}
-          env:
-            {{- with .Values.global.extraEnv }}
-              {{ toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with .Values.compactor.extraEnv }}
-              {{ toYaml . | nindent 12 }}
-            {{- end }}
-          {{- end }}
+          {{- include "tempo.componentEnv" (dict "extraEnv" (concat .Values.global.extraEnv .Values.compactor.extraEnv) "resources" .Values.compactor.resources "factor" .Values.global.goSettings.goMemLimitFactor "gogc" .Values.global.goSettings.gogc) | nindent 10 }}
           {{- if or .Values.global.extraEnvFrom .Values.compactor.extraEnvFrom }}
           envFrom:
             {{- with .Values.compactor.extraEnvFrom }}

--- a/charts/tempo-distributed/templates/distributor/deployment-distributor.yaml
+++ b/charts/tempo-distributed/templates/distributor/deployment-distributor.yaml
@@ -119,15 +119,7 @@ spec:
               name: opencensus
               protocol: TCP
             {{- end }}
-          {{- if or .Values.global.extraEnv .Values.distributor.extraEnv }}
-          env:
-            {{- with .Values.global.extraEnv }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with .Values.distributor.extraEnv }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
-          {{- end }}
+          {{- include "tempo.componentEnv" (dict "extraEnv" (concat .Values.global.extraEnv .Values.distributor.extraEnv) "resources" .Values.distributor.resources "factor" .Values.global.goSettings.goMemLimitFactor "gogc" .Values.global.goSettings.gogc) | nindent 10 }}
           {{- if or .Values.global.extraEnvFrom .Values.distributor.extraEnvFrom }}
           envFrom:
             {{- with .Values.distributor.extraEnvFrom }}

--- a/charts/tempo-distributed/templates/enterprise-federation-frontend/deployment-federation-frontend.yaml
+++ b/charts/tempo-distributed/templates/enterprise-federation-frontend/deployment-federation-frontend.yaml
@@ -73,15 +73,7 @@ spec:
           ports:
             - containerPort: 3200
               name: http-metrics
-          {{- if or .Values.global.extraEnv .Values.enterpriseFederationFrontend.extraEnv }}
-          env:
-            {{- with .Values.global.extraEnv }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with .Values.enterpriseFederationFrontend.extraEnv }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
-          {{- end }}
+          {{- include "tempo.componentEnv" (dict "extraEnv" (concat .Values.global.extraEnv .Values.enterpriseFederationFrontend.extraEnv) "resources" .Values.enterpriseFederationFrontend.resources "factor" .Values.global.goSettings.goMemLimitFactor "gogc" .Values.global.goSettings.gogc) | nindent 10 }}
           {{- if or .Values.global.extraEnvFrom .Values.enterpriseFederationFrontend.extraEnvFrom }}
           envFrom:
             {{- with .Values.enterpriseFederationFrontend.extraEnvFrom }}

--- a/charts/tempo-distributed/templates/enterprise-gateway/gateway-dep.yaml
+++ b/charts/tempo-distributed/templates/enterprise-gateway/gateway-dep.yaml
@@ -78,13 +78,7 @@ spec:
             {{- toYaml .Values.enterpriseGateway.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.enterpriseGateway.containerSecurityContext | nindent 12 }}
-          env:
-            {{- with .Values.global.extraEnv }}
-              {{ toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with .Values.enterpriseGateway.env }}
-              {{ toYaml . | nindent 12 }}
-            {{- end }}
+          {{- include "tempo.componentEnv" (dict "extraEnv" (concat .Values.global.extraEnv .Values.enterpriseGateway.env) "resources" .Values.enterpriseGateway.resources "factor" .Values.global.goSettings.goMemLimitFactor "gogc" .Values.global.goSettings.gogc) | nindent 10 }}
           envFrom:
             {{- with .Values.global.extraEnvFrom }}
               {{- toYaml . | nindent 12 }}

--- a/charts/tempo-distributed/templates/ingester/statefulset-ingester.yaml
+++ b/charts/tempo-distributed/templates/ingester/statefulset-ingester.yaml
@@ -99,15 +99,7 @@ spec:
               containerPort: {{ include "tempo.memberlistBindPort" . }}
             - name: http-metrics
               containerPort: 3200
-          {{- if or .Values.global.extraEnv .Values.ingester.extraEnv }}
-          env:
-            {{- with .Values.global.extraEnv }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with .Values.ingester.extraEnv }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
-          {{- end }}
+          {{- include "tempo.componentEnv" (dict "extraEnv" (concat .Values.global.extraEnv .Values.ingester.extraEnv) "resources" .Values.ingester.resources "factor" .Values.global.goSettings.goMemLimitFactor "gogc" .Values.global.goSettings.gogc) | nindent 10 }}
           {{- if or .Values.global.extraEnvFrom .Values.ingester.extraEnvFrom }}
           envFrom:
             {{- with .Values.global.extraEnvFrom }}

--- a/charts/tempo-distributed/templates/metrics-generator/deployment-metrics-generator.yaml
+++ b/charts/tempo-distributed/templates/metrics-generator/deployment-metrics-generator.yaml
@@ -71,15 +71,7 @@ spec:
             - name: {{ .name | quote }}
               containerPort: {{ .port }}
             {{- end }}
-          {{- if or .Values.global.extraEnv .Values.metricsGenerator.extraEnv }}
-          env:
-            {{- with .Values.global.extraEnv }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with .Values.metricsGenerator.extraEnv }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
-          {{- end }}
+          {{- include "tempo.componentEnv" (dict "extraEnv" (concat .Values.global.extraEnv .Values.metricsGenerator.extraEnv) "resources" .Values.metricsGenerator.resources "factor" .Values.global.goSettings.goMemLimitFactor "gogc" .Values.global.goSettings.gogc) | nindent 10 }}
           {{- if or .Values.global.extraEnvFrom .Values.metricsGenerator.extraEnvFrom }}
           envFrom:
             {{- with .Values.global.extraEnvFrom }}

--- a/charts/tempo-distributed/templates/metrics-generator/statefulset-metrics-generator.yaml
+++ b/charts/tempo-distributed/templates/metrics-generator/statefulset-metrics-generator.yaml
@@ -80,15 +80,7 @@ spec:
             - name: {{ .name | quote }}
               containerPort: {{ .port }}
             {{- end }}
-          {{- if or .Values.global.extraEnv .Values.metricsGenerator.extraEnv }}
-          env:
-            {{- with .Values.global.extraEnv }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with .Values.metricsGenerator.extraEnv }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
-          {{- end }}
+          {{- include "tempo.componentEnv" (dict "extraEnv" (concat .Values.global.extraEnv .Values.metricsGenerator.extraEnv) "resources" .Values.metricsGenerator.resources "factor" .Values.global.goSettings.goMemLimitFactor "gogc" .Values.global.goSettings.gogc) | nindent 10 }}
           {{- if or .Values.global.extraEnvFrom .Values.metricsGenerator.extraEnvFrom }}
           envFrom:
             {{- with .Values.global.extraEnvFrom }}

--- a/charts/tempo-distributed/templates/querier/deployment-querier.yaml
+++ b/charts/tempo-distributed/templates/querier/deployment-querier.yaml
@@ -77,15 +77,7 @@ spec:
               protocol: TCP
             - containerPort: 3200
               name: http-metrics
-          {{- if or .Values.global.extraEnv .Values.querier.extraEnv }}
-          env:
-            {{- with .Values.global.extraEnv }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with .Values.querier.extraEnv }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
-          {{- end }}
+          {{- include "tempo.componentEnv" (dict "extraEnv" (concat .Values.global.extraEnv .Values.querier.extraEnv) "resources" .Values.querier.resources "factor" .Values.global.goSettings.goMemLimitFactor "gogc" .Values.global.goSettings.gogc) | nindent 10 }}
           {{- if or .Values.global.extraEnvFrom .Values.querier.extraEnvFrom }}
           envFrom:
             {{- with .Values.global.extraEnvFrom }}

--- a/charts/tempo-distributed/templates/query-frontend/deployment-query-frontend.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/deployment-query-frontend.yaml
@@ -76,15 +76,7 @@ spec:
               name: http-metrics
             - containerPort: 9095
               name: grpc
-          {{- if or .Values.global.extraEnv .Values.queryFrontend.extraEnv }}
-          env:
-            {{- with .Values.global.extraEnv }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with .Values.queryFrontend.extraEnv }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
-          {{- end }}
+          {{- include "tempo.componentEnv" (dict "extraEnv" (concat .Values.global.extraEnv .Values.queryFrontend.extraEnv) "resources" .Values.queryFrontend.resources "factor" .Values.global.goSettings.goMemLimitFactor "gogc" .Values.global.goSettings.gogc) | nindent 10 }}
           {{- if or .Values.global.extraEnvFrom .Values.queryFrontend.extraEnvFrom }}
           envFrom:
             {{- with .Values.global.extraEnvFrom }}

--- a/charts/tempo-distributed/templates/tokengen/tokengen-job.yaml
+++ b/charts/tempo-distributed/templates/tokengen/tokengen-job.yaml
@@ -75,13 +75,7 @@ spec:
             {{- if .Values.tokengenJob.extraVolumeMounts }}
               {{ toYaml .Values.tokengenJob.extraVolumeMounts | nindent 12 }}
             {{- end }}
-          env:
-            {{- with .Values.global.extraEnv }}
-              {{ toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with .Values.tokengenJob.env }}
-              {{ toYaml . | nindent 12 }}
-            {{- end }}
+          {{- include "tempo.componentEnv" (dict "extraEnv" (concat .Values.global.extraEnv .Values.tokengenJob.env) "resources" .Values.tokengenJob.resources "factor" .Values.global.goSettings.goMemLimitFactor "gogc" .Values.global.goSettings.gogc) | nindent 10 }}
           envFrom:
             {{- with .Values.global.extraEnvFrom }}
               {{- toYaml . | nindent 12 }}

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -22,6 +22,14 @@ global:
   dnsService: 'kube-dns'
   # -- configures DNS service namespace
   dnsNamespace: 'kube-system'
+  goSettings:
+    # -- Fraction of the container memory limit used to compute GOMEMLIMIT (e.g. 0.85 = 85%).
+    # Set to 0 to disable automatic GOMEMLIMIT injection.
+    goMemLimitFactor: 0.85
+    # -- Value to set for GOGC alongside GOMEMLIMIT. Lowering below the default of 100 reduces
+    # heap growth between GC cycles, working in tandem with GOMEMLIMIT to smooth memory usage.
+    # Set to 0 to disable automatic GOGC injection.
+    gogc: 80
   # -- Common environment variables to add to all pods directly managed by this chart.
   # scope: admin-api, compactor, distributor, enterprise-federation-frontend, gateway, ingester, memcached, metrics-generator, querier, query-frontend, tokengen
   extraEnv: []


### PR DESCRIPTION
## Summary
- Automatically inject `GOMEMLIMIT` env var for all Tempo Go components when a container memory limit is configured and `GOMEMLIMIT` is not already set by the user
- Injects `GOGC=80` by default alongside `GOMEMLIMIT` to smooth memory usage
- Adds `global.goSettings` config block with `goMemLimitFactor` (default 0.85) and `gogc` (default 80)
- Mirrors the approach from the loki chart (#230)

## Behaviour

| Scenario | Result |
|---|---|
| Memory limit set, `GOMEMLIMIT` absent | Inject `GOMEMLIMIT = floor(limit_MiB × 0.85)` + `GOGC=80` |
| `GOMEMLIMIT` already in `extraEnv` | User value preserved |
| No memory limit set | Only `GOGC=80` injected |

## Components updated
- distributor, ingester, compactor, querier, query-frontend, metrics-generator (deploy + statefulset), enterprise-federation-frontend, admin-api, enterprise-gateway, tokengen

**Skipped** (non-Go containers): gateway (nginx), memcached, provisioner

## Test plan
- [x] `make helm-unittest` — all 297 tests pass
- [x] Verified `GOMEMLIMIT=1740MiB` rendered for distributor with `resources.limits.memory=2Gi`
- [x] Verified user-defined `GOMEMLIMIT` is preserved when explicitly set
- [x] Verified gateway (nginx) and memcached are not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)