### PR TITLE
[loki] Use common PDB template for ingester

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.1
-version: 11.4.11
+version: 11.4.12
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/templates/_pdb.tpl
+++ b/charts/loki/templates/_pdb.tpl
@@ -11,6 +11,9 @@ PDB helper
   {{- $target := .target }}
   {{- $ctx := .ctx }}
   {{- $component := .component }}
+  {{- $suffix := .suffix }}
+  {{- $extraMatchLabels := .extraMatchLabels }}
+  {{- $extraMatchExpressions := .extraMatchExpressions }}
   {{- with $ctx }}
     {{- $podDisruptionBudget := dict }}
     {{- if hasKey $component "maxUnavailable"}}
@@ -23,7 +26,7 @@ PDB helper
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "loki.resourceName" (dict "ctx" $ctx "component" $target) }}
+  name: {{ include "loki.resourceName" (dict "ctx" $ctx "component" $target "suffix" $suffix) }}
   namespace: {{ include "loki.namespace" $ctx }}
   {{- with $component.podDisruptionBudget.annotations }}
   annotations:
@@ -41,6 +44,13 @@ spec:
     matchLabels:
       {{- include "loki.selectorLabels" $ctx | nindent 6 }}
       app.kubernetes.io/component: {{ $target }}
+    {{- with $extraMatchLabels }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with $extraMatchExpressions }}
+    matchExpressions:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/loki/templates/ingester/pdb-zone.yaml
+++ b/charts/loki/templates/ingester/pdb-zone.yaml
@@ -1,21 +1,7 @@
 {{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
-{{- if and $isDistributed (gt (int .Values.ingester.replicas) 1) (.Values.ingester.zoneAwareReplication.enabled) }}
-{{- if kindIs "invalid" .Values.ingester.maxUnavailable }}
-{{- fail "`.Values.ingester.maxUnavailable` must be set when `.Values.ingester.replicas` is greater than 1." }}
-{{- else }}
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: {{ include "loki.ingesterFullname" . }}-rollout
-  namespace: {{ include "loki.namespace" . }}
-  labels:
-    {{- include "loki.ingesterLabels" . | nindent 4 }}
-spec:
-  selector:
-    matchLabels:
-      rollout-group: {{ include "loki.prefixRolloutGroup" . }}ingester
-  {{- with .Values.ingester.maxUnavailable }}
-  maxUnavailable: {{ . }}
-  {{- end }}
-{{- end }}
+{{- if and $isDistributed (.Values.ingester.zoneAwareReplication.enabled) }}
+{{- $extraMatchLabels := dict
+  "rollout-group" (printf "%singester" (include "loki.prefixRolloutGroup" .))
+-}}
+{{- include "loki.pdb" (dict "target" "ingester" "component" .Values.ingester "ctx" . "suffix" "rollout" "extraMatchLabels" $extraMatchLabels) }}
 {{- end }}

--- a/charts/loki/templates/ingester/pdb.yaml
+++ b/charts/loki/templates/ingester/pdb.yaml
@@ -1,27 +1,9 @@
 {{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
-{{- if and $isDistributed (gt (int .Values.ingester.replicas) 1) (or (not .Values.ingester.zoneAwareReplication.enabled) .Values.ingester.zoneAwareReplication.migration.enabled) }}
-{{- if kindIs "invalid" .Values.ingester.maxUnavailable }}
-{{- fail "`.Values.ingester.maxUnavailable` must be set when `.Values.ingester.replicas` is greater than 1." }}
-{{- else }}
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: {{ include "loki.ingesterFullname" . }}
-  namespace: {{ include "loki.namespace" . }}
-  labels:
-    {{- include "loki.ingesterLabels" . | nindent 4 }}
-spec:
-  selector:
-    matchLabels:
-      {{- include "loki.ingesterSelectorLabels" . | nindent 6 }}
-    {{/* zone aware ingesters get their own pod disruption budget, ignore them here */}}
-    matchExpressions:
-      - key: rollout-group
-        operator: NotIn
-        values:
-          - '{{ include "loki.prefixRolloutGroup" . }}ingester'
-  {{- with .Values.ingester.maxUnavailable }}
-  maxUnavailable: {{ . }}
-  {{- end }}
-{{- end }}
+{{- if and $isDistributed (or (not .Values.ingester.zoneAwareReplication.enabled) .Values.ingester.zoneAwareReplication.migration.enabled) }}
+{{- $extraMatchExpressions := list (dict
+  "key" "rollout-group"
+  "operator" "NotIn"
+  "values" (list (printf "%singester" (include "loki.prefixRolloutGroup" .)))
+) -}}
+{{- include "loki.pdb" (dict "target" "ingester" "component" .Values.ingester "ctx" . "extraMatchExpressions" $extraMatchExpressions) }}
 {{- end }}

--- a/charts/loki/tests/ingester/pdb_test.yaml
+++ b/charts/loki/tests/ingester/pdb_test.yaml
@@ -1,0 +1,86 @@
+suite: ingester PodDisruptionBudget
+templates:
+  - templates/ingester/pdb.yaml
+set:
+  deploymentMode: Distributed
+  loki.useTestSchema: true
+  loki.storage.bucketNames.chunks: chunks
+  loki.storage.bucketNames.ruler: ruler
+  loki.storage.bucketNames.admin: admin
+  ingester.zoneAwareReplication.enabled: false
+  ingester.replicas: 3
+  ingester.maxUnavailable: 1
+  ingester.podDisruptionBudget.enabled: true
+tests:
+  - it: should not render when zoneAwareReplication is enabled and migration is disabled
+    set:
+      ingester.zoneAwareReplication.enabled: true
+      ingester.zoneAwareReplication.migration.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render when zoneAwareReplication is disabled
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+
+  - it: should render when migration is enabled
+    set:
+      ingester.zoneAwareReplication.enabled: true
+      ingester.zoneAwareReplication.migration.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should not render when replicas is 1
+    set:
+      ingester.replicas: 1
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when podDisruptionBudget is disabled
+    set:
+      ingester.podDisruptionBudget.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should have correct name
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-loki-ingester
+
+  - it: should have correct selector with matchExpressions
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/name: loki
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/component: ingester
+      - contains:
+          path: spec.selector.matchExpressions
+          content:
+            key: rollout-group
+            operator: NotIn
+            values:
+              - ingester
+
+  - it: should use maxUnavailable from deprecated field
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+
+  - it: should use podDisruptionBudget.maxUnavailable when set
+    set:
+      ingester.podDisruptionBudget.maxUnavailable: 2
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 2

--- a/charts/loki/tests/ingester/pdb_zone_test.yaml
+++ b/charts/loki/tests/ingester/pdb_zone_test.yaml
@@ -1,0 +1,71 @@
+suite: ingester zone-aware PodDisruptionBudget
+templates:
+  - templates/ingester/pdb-zone.yaml
+set:
+  deploymentMode: Distributed
+  loki.useTestSchema: true
+  loki.storage.bucketNames.chunks: chunks
+  loki.storage.bucketNames.ruler: ruler
+  loki.storage.bucketNames.admin: admin
+  ingester.zoneAwareReplication.enabled: true
+  ingester.replicas: 3
+  ingester.maxUnavailable: 1
+  ingester.podDisruptionBudget.enabled: true
+tests:
+  - it: should not render when zoneAwareReplication is disabled
+    set:
+      ingester.zoneAwareReplication.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render when zoneAwareReplication is enabled and replicas > 1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+
+  - it: should not render when replicas is 1
+    set:
+      ingester.replicas: 1
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when podDisruptionBudget is disabled
+    set:
+      ingester.podDisruptionBudget.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should have correct name with rollout suffix
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-loki-ingester-rollout
+
+  - it: should have correct selector with standard labels and rollout-group
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/name: loki
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/component: ingester
+            rollout-group: ingester
+
+  - it: should use maxUnavailable from deprecated field
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+
+  - it: should use podDisruptionBudget.maxUnavailable when set
+    set:
+      ingester.podDisruptionBudget.maxUnavailable: 2
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 2


### PR DESCRIPTION


<!--
Thank you for contributing to grafana-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/grafana-community/helm-charts/blob/main/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them (see CONTRIBUTING.md).
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.  Please check the results.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Followup to #232. Ingester PDBs uses common PDB template now.

#### Which issue this PR fixes

Ingester values around PDB implied that it uses common PDB template, but in fact it was still using custom PDB template that didn't use new `ingester.podDisruptionBudget` values.

#### Special notes for your reviewer

Common template had to be extended to enable extra matchLabels and matchExpressions and passing suffix to PDBs name.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
