### PR TITLE
[tempo-distributed] fix: missing newline between zone label and common labels causes invalid YAML

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 2.14.1
+version: 2.14.2
 # renovate: docker=docker.io/grafana/tempo
 appVersion: 2.10.3
 kubeVersion: "^1.25.0-0"

--- a/charts/tempo-distributed/ci/zone-aware-replication-values.yaml
+++ b/charts/tempo-distributed/ci/zone-aware-replication-values.yaml
@@ -1,0 +1,18 @@
+rollout_operator:
+  enabled: true
+
+ingester:
+  replicas: 2
+  zoneAwareReplication:
+    enabled: true
+    topologyKey: kubernetes.io/hostname
+    zones:
+      - name: zone-a
+        nodeSelector:
+          topology.kubernetes.io/zone: zone-a
+      - name: zone-b
+        nodeSelector:
+          topology.kubernetes.io/zone: zone-b
+      - name: zone-c
+        nodeSelector:
+          topology.kubernetes.io/zone: zone-c

--- a/charts/tempo-distributed/templates/ingester/_helpers-ingester.tpl
+++ b/charts/tempo-distributed/templates/ingester/_helpers-ingester.tpl
@@ -70,7 +70,7 @@ name: {{ printf "%s-%s" .component .rolloutZoneName }}
 rollout-group: {{ .component }}
 zone: {{ .rolloutZoneName }}
 {{- end }}
-{{- include "tempo.labels" (dict "ctx" .ctx "component" .component) }}
+{{ include "tempo.labels" (dict "ctx" .ctx "component" .component) }}
 {{- with .ctx.Values.ingester.labels }}
 {{ toYaml . }}
 {{- end }}


### PR DESCRIPTION
## Problem

When zone-aware replication is enabled, `helm template` fails with:

```
YAML parse error on tempo/charts/tempo-distributed/templates/ingester/statefulset-ingester.yaml:
error converting YAML to JSON: yaml: line 10: mapping values are not allowed in this context
```

The root cause is in `ingester.labels` (introduced in #345 / v2.14.0):

```
zone: {{ .rolloutZoneName }}
{{- end }}
{{- include "tempo.labels" (dict "ctx" .ctx "component" .component) }}
```

`{{- end }}` strips the trailing newline from the `zone:` line. Then `{{- include` strips the separating newline between `{{- end }}` and the include. This concatenates the zone value and the first common label on a single line:

```yaml
zone: us-central1-ahelm.sh/chart: tempo-distributed-2.14.1  # invalid YAML
```

## Fix

Remove the leading `-` from `{{- include` → `{{ include`, so the newline after `{{- end }}` is preserved. This matches the whitespace behaviour of the inline labels used in v2.13.0 and earlier.

## Testing

```bash
helm template test charts/tempo-distributed/ \
  --set ingester.zoneAwareReplication.enabled=true \
  --set 'ingester.zoneAwareReplication.zones[0].name=us-central1-a' \
  --set 'ingester.zoneAwareReplication.zones[1].name=us-central1-b' \
  --set 'ingester.zoneAwareReplication.zones[2].name=us-central1-c' \
  --set rollout_operator.enabled=true
```

After fix, labels render correctly:
```yaml
  labels:
    name: ingester-us-central1-a
    rollout-group: ingester
    zone: us-central1-a
    helm.sh/chart: tempo-distributed-2.14.2
    app.kubernetes.io/name: tempo
    ...
```