### PR TITLE
[grafana] Existing image renderer token secret

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 12.0.1
+version: 12.1.0
 # renovate: docker=docker.io/grafana/grafana
 appVersion: 13.0.0
 kubeVersion: "^1.25.0-0"

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -1453,7 +1453,7 @@ containers:
       - name: GF_RENDERING_RENDERER_TOKEN
         valueFrom:
           secretKeyRef:
-            name: {{ include "grafana.imageRenderer.fullname" . }}-image-renderer
+            name: {{ .Values.imageRenderer.existingSecret | default (printf "%s-image-renderer" (include "grafana.imageRenderer.fullname" .)) }}
             key: token
       {{- end }}
       - name: GF_PATHS_DATA

--- a/charts/grafana/templates/image-renderer-deployment.yaml
+++ b/charts/grafana/templates/image-renderer-deployment.yaml
@@ -91,6 +91,13 @@ spec:
           env:
             - name: HTTP_PORT
               value: {{ .Values.imageRenderer.service.targetPort | quote }}
+          {{- if .Values.imageRenderer.service.enabled }}
+            - name: AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.imageRenderer.existingSecret | default (printf "%s-image-renderer" (include "grafana.imageRenderer.fullname" .)) }}
+                  key: token
+          {{- end }}
           {{- if .Values.imageRenderer.serviceMonitor.enabled }}
             - name: ENABLE_METRICS
               value: "true"

--- a/charts/grafana/templates/image-renderer-secret.yaml
+++ b/charts/grafana/templates/image-renderer-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.imageRenderer.enabled .Values.imageRenderer.service.enabled }}
+{{- if and .Values.imageRenderer.enabled .Values.imageRenderer.service.enabled (not .Values.imageRenderer.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -1476,6 +1476,8 @@ imageRenderer:
   renderingCallbackURL: ""
   # Token used for authentication between Grafana and the remote image renderer.
   token: ""
+  # Use an existing secret for the image renderer token. Must contain a key named "token".
+  existingSecret: ""
   image:
     # -- The Docker registry
     registry: docker.io


### PR DESCRIPTION
<!--
Thank you for contributing to grafana-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/grafana-community/helm-charts/blob/main/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them (see CONTRIBUTING.md).
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.  Please check the results.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR allows existing secrets for the image renderer token. I added this because the helm lookup function doesn't work when it's running in ArgoCD, so we are getting a new secret every time regardless of whether it exists or not.

It also configures the secret token in the image renderer container using the `AUTH_TOKEN` environment variable (mentioned in [docs](https://grafana.com/docs/grafana/latest/setup-grafana/image-rendering/#security)), as it was missing before.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
