### PR TITLE
[loki] Allow metrics ciliumnetworkpolicy only from namespace

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.1
-version: 13.1.2
+version: 13.1.3
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/templates/ciliumnetworkpolicy.yaml
+++ b/charts/loki/templates/ciliumnetworkpolicy.yaml
@@ -91,7 +91,7 @@ spec:
     - ports: 
       - port: http-metrics
         protocol: TCP
-  {{- if .Values.networkPolicy.metrics.cidrs }}
+  {{- if or .Values.networkPolicy.metrics.cidrs .Values.networkPolicy.metrics.namespaceSelector }}
     {{- range $cidr := .Values.networkPolicy.metrics.cidrs }}
     toCIDR:
     - {{ $cidr }}

--- a/charts/loki/templates/ciliumnetworkpolicy.yaml
+++ b/charts/loki/templates/ciliumnetworkpolicy.yaml
@@ -62,7 +62,7 @@ spec:
       {{- include "loki.selectorLabels" . | nindent 6 }}
   ingress:
   - toPorts:
-    - ports: 
+    - ports:
       - port: http
         protocol: TCP
   {{- if .Values.networkPolicy.ingress.namespaceSelector }}
@@ -88,7 +88,7 @@ spec:
       {{- include "loki.selectorLabels" . | nindent 6 }}
   ingress:
   - toPorts:
-    - ports: 
+    - ports:
       - port: http-metrics
         protocol: TCP
   {{- if or .Values.networkPolicy.metrics.cidrs .Values.networkPolicy.metrics.namespaceSelector }}
@@ -120,7 +120,7 @@ spec:
       {{- include "loki.backendSelectorLabels" . | nindent 6 }}
   egress:
   - toPorts:
-    - ports: 
+    - ports:
       - port: "{{ .Values.networkPolicy.alertmanager.port }}"
         protocol: TCP
   {{- if .Values.networkPolicy.alertmanager.namespaceSelector }}
@@ -148,7 +148,7 @@ spec:
   egress:
   - toPorts:
     - ports:
-      {{- range $port := .Values.networkPolicy.externalStorage.ports }} 
+      {{- range $port := .Values.networkPolicy.externalStorage.ports }}
       - port: "{{ $port }}"
         protocol: TCP
       {{- end }}
@@ -226,7 +226,7 @@ spec:
       {{- include "loki.selectorLabels" . | nindent 6 }}
   egress:
   - toPorts:
-    - ports: 
+    - ports:
       - port: "{{ .Values.networkPolicy.discovery.port }}"
         protocol: TCP
   {{- if .Values.networkPolicy.discovery.namespaceSelector }}


### PR DESCRIPTION
<!--
Thank you for contributing to grafana-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/grafana-community/helm-charts/blob/main/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them (see CONTRIBUTING.md).
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.  Please check the results.
-->

cc @TheRealNoob @jkroepke @jplitza

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
Previously, setting .Values.networkPolicy.metrics.cidrs to a non-empty list was required to include the configured .Values.networkPolicy.metrics.namespaceSelector

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer
I followed what was done in the networkpolicy.yaml file (https://github.com/grafana/loki/pull/17555)

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
