### PR TITLE
[tempo-distributed] fix: Added missing ServiceMonitors for memcachedBloom, memcachedParquetFooter and memcachedFrontendSearch

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 2.15.0
+version: 2.15.1
 # renovate: docker=docker.io/grafana/tempo
 appVersion: 2.10.4
 kubeVersion: "^1.25.0-0"

--- a/charts/tempo-distributed/templates/memcached/servicemonitor-memcached-bloom.yaml
+++ b/charts/tempo-distributed/templates/memcached/servicemonitor-memcached-bloom.yaml
@@ -1,0 +1,1 @@
+{{- include "tempo.lib.serviceMonitor" (dict "ctx" $ "component" "memcached-bloom") }}

--- a/charts/tempo-distributed/templates/memcached/servicemonitor-memcached-frontend-search.yaml
+++ b/charts/tempo-distributed/templates/memcached/servicemonitor-memcached-frontend-search.yaml
@@ -1,0 +1,1 @@
+{{- include "tempo.lib.serviceMonitor" (dict "ctx" $ "component" "memcached-frontend-search") }}

--- a/charts/tempo-distributed/templates/memcached/servicemonitor-memcached-parquet-footer.yaml
+++ b/charts/tempo-distributed/templates/memcached/servicemonitor-memcached-parquet-footer.yaml
@@ -1,0 +1,1 @@
+{{- include "tempo.lib.serviceMonitor" (dict "ctx" $ "component" "memcached-parquet-footer") }}

--- a/charts/tempo-distributed/tests/memcached/per_role_statefulset_test.yaml
+++ b/charts/tempo-distributed/tests/memcached/per_role_statefulset_test.yaml
@@ -1,12 +1,16 @@
 # $schema: https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json
 suite: per-role memcached StatefulSets
 templates:
+  - lib/service-monitor.tpl
   - memcached/statefulset-memcached-bloom.yaml
   - memcached/statefulset-memcached-parquet-footer.yaml
   - memcached/statefulset-memcached-frontend-search.yaml
   - memcached/service-memcached-bloom.yaml
   - memcached/service-memcached-parquet-footer.yaml
   - memcached/service-memcached-frontend-search.yaml
+  - memcached/servicemonitor-memcached-bloom.yaml
+  - memcached/servicemonitor-memcached-parquet-footer.yaml
+  - memcached/servicemonitor-memcached-frontend-search.yaml
   - memcached/poddisruptionbudget-memcached-bloom.yaml
   - memcached/poddisruptionbudget-memcached-parquet-footer.yaml
   - memcached/poddisruptionbudget-memcached-frontend-search.yaml
@@ -62,6 +66,20 @@ tests:
           path: kind
           value: Service
         template: memcached/service-memcached-bloom.yaml
+
+  - it: bloom ServiceMonitor rendered with correct name
+    set:
+      memcachedBloom.enabled: true
+      metaMonitoring.serviceMonitor.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-tempo-memcached-bloom
+        template: memcached/servicemonitor-memcached-bloom.yaml
+      - equal:
+          path: kind
+          value: ServiceMonitor
+        template: memcached/servicemonitor-memcached-bloom.yaml
 
   - it: bloom PDB not rendered when replicas is 1 (default)
     set:
@@ -133,6 +151,20 @@ tests:
           value: Service
         template: memcached/service-memcached-parquet-footer.yaml
 
+  - it: parquet-footer ServiceMonitor rendered with correct name when enabled
+    set:
+      memcachedParquetFooter.enabled: true
+      metaMonitoring.serviceMonitor.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-tempo-memcached-parquet-footer
+        template: memcached/servicemonitor-memcached-parquet-footer.yaml
+      - equal:
+          path: kind
+          value: ServiceMonitor
+        template: memcached/servicemonitor-memcached-parquet-footer.yaml
+
   - it: frontend-search Service rendered with correct name when enabled
     set:
       memcachedFrontendSearch.enabled: true
@@ -145,6 +177,21 @@ tests:
           path: kind
           value: Service
         template: memcached/service-memcached-frontend-search.yaml
+
+  - it: frontend-search ServiceMonitor rendered with correct name when enabled
+    set:
+      memcachedFrontendSearch.enabled: true
+      metaMonitoring.serviceMonitor.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-tempo-memcached-frontend-search
+        template: memcached/servicemonitor-memcached-frontend-search.yaml
+      - equal:
+          path: kind
+          value: ServiceMonitor
+        template: memcached/servicemonitor-memcached-frontend-search.yaml
+
 
   - it: parquet-footer PDB not rendered when replicas is 1 (default)
     set:


### PR DESCRIPTION
<!--
Thank you for contributing to grafana-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/grafana-community/helm-charts/blob/main/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them (see CONTRIBUTING.md).
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.  Please check the results.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

fix: Added missing ServiceMonitors for memcachedBloom, memcachedParquetFooter and memcachedFrontendSearch

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
