### PR TITLE
[tempo-distributed] Wrap various values with tpl

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 2.17.5
+version: 2.17.6
 # renovate: docker=docker.io/grafana/tempo
 appVersion: 2.10.5
 kubeVersion: "^1.25.0-0"

--- a/charts/tempo-distributed/templates/admin-api/admin-api-dep.yaml
+++ b/charts/tempo-distributed/templates/admin-api/admin-api-dep.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       serviceAccountName: {{ template "tempo.serviceAccountName" . }}
       {{- if .Values.adminApi.priorityClassName }}
-      priorityClassName: {{ .Values.adminApi.priorityClassName }}
+      priorityClassName: {{ tpl .Values.adminApi.priorityClassName . }}
       {{- end }}
       securityContext:
         {{- toYaml .Values.adminApi.securityContext | nindent 8 }}

--- a/charts/tempo-distributed/templates/enterprise-federation-frontend/deployment-federation-frontend.yaml
+++ b/charts/tempo-distributed/templates/enterprise-federation-frontend/deployment-federation-frontend.yaml
@@ -44,7 +44,7 @@ spec:
         {{- end }}
     spec:
       {{- if or (.Values.enterpriseFederationFrontend.priorityClassName) (.Values.global.priorityClassName) }}
-      priorityClassName: {{ default .Values.enterpriseFederationFrontend.priorityClassName .Values.global.priorityClassName }}
+      priorityClassName: {{ tpl (default .Values.enterpriseFederationFrontend.priorityClassName .Values.global.priorityClassName) . }}
       {{- end }}
       serviceAccountName: {{ include "tempo.serviceAccountName" . }}
       {{- with .Values.tempo.podSecurityContext }}

--- a/charts/tempo-distributed/templates/enterprise-gateway/gateway-dep.yaml
+++ b/charts/tempo-distributed/templates/enterprise-gateway/gateway-dep.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       serviceAccountName: {{ template "tempo.serviceAccountName" . }}
       {{- if .Values.enterpriseGateway.priorityClassName }}
-      priorityClassName: {{ .Values.enterpriseGateway.priorityClassName }}
+      priorityClassName: {{ tpl .Values.enterpriseGateway.priorityClassName . }}
       {{- end }}
       securityContext:
         {{- toYaml .Values.enterpriseGateway.securityContext | nindent 8 }}

--- a/charts/tempo-distributed/templates/enterprise-gateway/gateway-ingress.yaml
+++ b/charts/tempo-distributed/templates/enterprise-gateway/gateway-ingress.yaml
@@ -14,7 +14,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 spec:
   {{- with .Values.enterpriseGateway.ingress.ingressClassName }}
-  ingressClassName: {{ . }}
+  ingressClassName: {{ tpl . $ }}
   {{- end }}
   {{- if .Values.enterpriseGateway.ingress.tls }}
   tls:

--- a/charts/tempo-distributed/templates/enterprise-gateway/gateway-ingress.yaml
+++ b/charts/tempo-distributed/templates/enterprise-gateway/gateway-ingress.yaml
@@ -30,7 +30,7 @@ spec:
   {{- end }}
   rules:
     {{- range .Values.enterpriseGateway.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ tpl .host $ | quote }}
       http:
         paths:
           {{- range .paths }}

--- a/charts/tempo-distributed/templates/enterprise-gateway/gateway-ingress.yaml
+++ b/charts/tempo-distributed/templates/enterprise-gateway/gateway-ingress.yaml
@@ -34,7 +34,7 @@ spec:
       http:
         paths:
           {{- range .paths }}
-          - path: {{ .path }}
+          - path: {{ tpl .path $ }}
             pathType: {{ .pathType }}
             backend:
               service:

--- a/charts/tempo-distributed/templates/enterprise-gateway/gateway-ingress.yaml
+++ b/charts/tempo-distributed/templates/enterprise-gateway/gateway-ingress.yaml
@@ -21,10 +21,10 @@ spec:
     {{- range .Values.enterpriseGateway.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ tpl . $ | quote }}
         {{- end }}
       {{- with .secretName }}
-      secretName: {{ . }}
+      secretName: {{ tpl . $ }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/tempo-distributed/templates/gateway/deployment-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/deployment-gateway.yaml
@@ -40,7 +40,7 @@ spec:
         {{- end }}
     spec:
       {{- if or (.Values.gateway.priorityClassName) (.Values.global.priorityClassName) }}
-      priorityClassName: {{ default .Values.gateway.priorityClassName .Values.global.priorityClassName }}
+      priorityClassName: {{ tpl (default .Values.gateway.priorityClassName .Values.global.priorityClassName) . }}
       {{- end }}
       serviceAccountName: {{ include "tempo.serviceAccountName" . }}
       {{- with .Values.tempo.podSecurityContext }}

--- a/charts/tempo-distributed/templates/gateway/deployment-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/deployment-gateway.yaml
@@ -160,7 +160,7 @@ spec:
         {{- if .Values.gateway.nginxConfig.ssl }}
         - name: gateway-tls
           secret:
-            secretName: {{ .Values.gateway.nginxConfig.tlsSecretName }}
+            secretName: {{ tpl .Values.gateway.nginxConfig.tlsSecretName . }}
         {{- end }}
         {{- if .Values.gateway.extraVolumes }}
         {{- toYaml .Values.gateway.extraVolumes | nindent 8 }}

--- a/charts/tempo-distributed/templates/gateway/ingress-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/ingress-gateway.yaml
@@ -21,7 +21,7 @@ metadata:
   {{- end }}
 spec:
   {{- with .Values.gateway.ingress.ingressClassName }}
-  ingressClassName: {{ . }}
+  ingressClassName: {{ tpl . $ }}
   {{- end }}
   {{- if .Values.gateway.ingress.tls }}
   tls:

--- a/charts/tempo-distributed/templates/gateway/ingress-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/ingress-gateway.yaml
@@ -37,7 +37,7 @@ spec:
   {{- end }}
   rules:
     {{- range .Values.gateway.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ tpl .host $ | quote }}
       http:
         paths:
           {{- range .paths }}

--- a/charts/tempo-distributed/templates/gateway/ingress-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/ingress-gateway.yaml
@@ -41,7 +41,7 @@ spec:
       http:
         paths:
           {{- range .paths }}
-          - path: {{ .path }}
+          - path: {{ tpl .path $ }}
             pathType: {{ .pathType }}
             backend:
               service:

--- a/charts/tempo-distributed/templates/gateway/ingress-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/ingress-gateway.yaml
@@ -28,10 +28,10 @@ spec:
     {{- range .Values.gateway.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ tpl . $ | quote }}
         {{- end }}
       {{- with .secretName }}
-      secretName: {{ . }}
+      secretName: {{ tpl . $ }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/tempo-distributed/templates/ingester/statefulset-ingester.yaml
+++ b/charts/tempo-distributed/templates/ingester/statefulset-ingester.yaml
@@ -61,7 +61,7 @@ spec:
         {{- end }}
     spec:
       {{- if or (.Values.ingester.priorityClassName) (.Values.global.priorityClassName) }}
-      priorityClassName: {{ default .Values.ingester.priorityClassName .Values.global.priorityClassName }}
+      priorityClassName: {{ tpl (default .Values.ingester.priorityClassName .Values.global.priorityClassName) . }}
       {{- end }}
       serviceAccountName: {{ include "tempo.serviceAccountName" . }}
       {{- with .Values.tempo.podSecurityContext }}

--- a/charts/tempo-distributed/templates/ingress.yaml
+++ b/charts/tempo-distributed/templates/ingress.yaml
@@ -22,10 +22,10 @@ spec:
     {{- range . }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ tpl . $ | quote }}
         {{- end }}
       {{- with .secretName }}
-      secretName: {{ . }}
+      secretName: {{ tpl . $ }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/tempo-distributed/templates/ingress.yaml
+++ b/charts/tempo-distributed/templates/ingress.yaml
@@ -39,7 +39,7 @@ spec:
             {{- if and (eq .path "/v1/traces") (not $.Values.traces.otlp.http.enabled) }}
             {{- /* skip: /v1/traces requires the OTLP HTTP receiver, which is disabled */ -}}
             {{- else }}
-          - path: {{ .path }}
+          - path: {{ tpl .path $ }}
             pathType: {{ .pathType | default "Prefix" }}
             backend:
               service:

--- a/charts/tempo-distributed/templates/ingress.yaml
+++ b/charts/tempo-distributed/templates/ingress.yaml
@@ -31,7 +31,7 @@ spec:
   {{- end }}
   rules:
     {{- range $.Values.ingress.hosts }}
-    - host: {{ . | quote }}
+    - host: {{ tpl . $ | quote }}
       http:
         paths:
           {{- range $svcName, $paths := $.Values.ingress.paths }}

--- a/charts/tempo-distributed/templates/ingress.yaml
+++ b/charts/tempo-distributed/templates/ingress.yaml
@@ -15,7 +15,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   {{- with .Values.ingress.ingressClassName }}
-  ingressClassName: {{ . }}
+  ingressClassName: {{ tpl . $ }}
   {{- end -}}
   {{- with .Values.ingress.tls }}
   tls:

--- a/charts/tempo-distributed/templates/memcached/_helpers-memcached.tpl
+++ b/charts/tempo-distributed/templates/memcached/_helpers-memcached.tpl
@@ -48,7 +48,7 @@ spec:
         {{- end }}
     spec:
       {{- if or ($.memcachedConfig.priorityClassName) ($.ctx.Values.global.priorityClassName) }}
-      priorityClassName: {{ default $.memcachedConfig.priorityClassName $.ctx.Values.global.priorityClassName }}
+      priorityClassName: {{ tpl (default $.memcachedConfig.priorityClassName $.ctx.Values.global.priorityClassName) $.ctx }}
       {{- end }}
       serviceAccountName: {{ include "tempo.serviceAccountName" $.ctx }}
       {{- with $.ctx.Values.tempo.podSecurityContext }}

--- a/charts/tempo-distributed/templates/memcached/statefulset-memcached.yaml
+++ b/charts/tempo-distributed/templates/memcached/statefulset-memcached.yaml
@@ -39,7 +39,7 @@ spec:
         {{- end }}
     spec:
       {{- if or (.Values.memcached.priorityClassName) (.Values.global.priorityClassName) }}
-      priorityClassName: {{ default .Values.memcached.priorityClassName .Values.global.priorityClassName }}
+      priorityClassName: {{ tpl (default .Values.memcached.priorityClassName .Values.global.priorityClassName) . }}
       {{- end }}
       serviceAccountName: {{ include "tempo.serviceAccountName" . }}
       {{- with .Values.tempo.podSecurityContext }}

--- a/charts/tempo-distributed/templates/metrics-generator/deployment-metrics-generator.yaml
+++ b/charts/tempo-distributed/templates/metrics-generator/deployment-metrics-generator.yaml
@@ -38,7 +38,7 @@ spec:
         {{- end }}
     spec:
       {{- if or (.Values.metricsGenerator.priorityClassName) (.Values.global.priorityClassName) }}
-      priorityClassName: {{ default .Values.metricsGenerator.priorityClassName .Values.global.priorityClassName }}
+      priorityClassName: {{ tpl (default .Values.metricsGenerator.priorityClassName .Values.global.priorityClassName) . }}
       {{- end }}
       serviceAccountName: {{ include "tempo.serviceAccountName" . }}
       {{- with .Values.tempo.podSecurityContext }}

--- a/charts/tempo-distributed/templates/metrics-generator/statefulset-metrics-generator.yaml
+++ b/charts/tempo-distributed/templates/metrics-generator/statefulset-metrics-generator.yaml
@@ -47,7 +47,7 @@ spec:
         {{- end }}
     spec:
       {{- if or (.Values.metricsGenerator.priorityClassName) (.Values.global.priorityClassName) }}
-      priorityClassName: {{ default .Values.metricsGenerator.priorityClassName .Values.global.priorityClassName }}
+      priorityClassName: {{ tpl (default .Values.metricsGenerator.priorityClassName .Values.global.priorityClassName) . }}
       {{- end }}
       serviceAccountName: {{ include "tempo.serviceAccountName" . }}
       {{- with .Values.tempo.podSecurityContext }}

--- a/charts/tempo-distributed/templates/provisioner/provisioner-job.yaml
+++ b/charts/tempo-distributed/templates/provisioner/provisioner-job.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       serviceAccountName: {{ include "tempo.resourceName" (dict "ctx" . "component" "provisioner") }}
       {{- if .Values.provisioner.priorityClassName }}
-      priorityClassName: {{ .Values.provisioner.priorityClassName }}
+      priorityClassName: {{ tpl .Values.provisioner.priorityClassName . }}
       {{- end }}
       securityContext:
         {{- toYaml .Values.provisioner.securityContext | nindent 8 }}

--- a/charts/tempo-distributed/templates/provisioner/provisioner-job.yaml
+++ b/charts/tempo-distributed/templates/provisioner/provisioner-job.yaml
@@ -53,7 +53,7 @@ spec:
               /usr/bin/provisioner \
                 -bootstrap-path=/bootstrap \
                 -cluster-name={{ include "tempo.clusterName" $ }} \
-                -api-url={{ $.Values.provisioner.apiUrl }} \
+                -api-url={{ tpl $.Values.provisioner.apiUrl $ }} \
                 -tenant={{ $tenant.name }} \
                 -access-policy=write-{{ $tenant.name }}:{{ $tenant.name }}:traces:write \
                 -access-policy=read-{{ $tenant.name }}:{{ $tenant.name }}:traces:read \
@@ -90,8 +90,8 @@ spec:
               # In this case, the admin resources have already been created, the provisioner job
               # does not write the token files to the bootstrap mount.
               # Therefore, secrets are only created if the respective token files exist.
-              # Note: the following bash commands should always return a success status code. 
-              # Therefore, in case the token file does not exist, the first clause of the 
+              # Note: the following bash commands should always return a success status code.
+              # Therefore, in case the token file does not exist, the first clause of the
               # or-operation is successful.
               {{- $secretPrefix := .Values.provisioner.provisionedSecretPrefix | default (include "tempo.resourceName" (dict "ctx" . "component" "token")) }}
               {{- range .Values.provisioner.additionalTenants }}
@@ -119,7 +119,7 @@ spec:
       volumes:
         - name: admin-token
           secret:
-            secretName: {{ .Values.tokengenJob.adminTokenSecret }}
+            secretName: {{ tpl .Values.tokengenJob.adminTokenSecret . }}
         - name: bootstrap
           emptyDir: {}
         {{- if .Values.provisioner.extraVolumes }}

--- a/charts/tempo-distributed/templates/query-frontend/ingress-query-frontend.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/ingress-query-frontend.yaml
@@ -29,7 +29,7 @@ spec:
   {{- end }}
   rules:
     {{- range .Values.queryFrontend.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ tpl .host $ | quote }}
       http:
         paths:
           {{- range .paths }}

--- a/charts/tempo-distributed/templates/query-frontend/ingress-query-frontend.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/ingress-query-frontend.yaml
@@ -13,7 +13,7 @@ metadata:
   {{- end }}
 spec:
   {{- with .Values.queryFrontend.ingress.ingressClassName }}
-  ingressClassName: {{ . }}
+  ingressClassName: {{ tpl . $ }}
   {{- end }}
   {{- if .Values.queryFrontend.ingress.tls }}
   tls:

--- a/charts/tempo-distributed/templates/query-frontend/ingress-query-frontend.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/ingress-query-frontend.yaml
@@ -33,7 +33,7 @@ spec:
       http:
         paths:
           {{- range .paths }}
-          - path: {{ .path }}
+          - path: {{ tpl .path $ }}
             pathType: {{ .pathType }}
             backend:
               service:

--- a/charts/tempo-distributed/templates/query-frontend/ingress-query-frontend.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/ingress-query-frontend.yaml
@@ -20,10 +20,10 @@ spec:
     {{- range .Values.queryFrontend.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      {{- with .secretName }}
-      secretName: {{ . }}
+        - {{ tpl . $ | quote }}
+          {{- end }}
+        {{- with .secretName }}
+        secretName: {{ tpl . $ }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/tempo-distributed/templates/tokengen/tokengen-job.yaml
+++ b/charts/tempo-distributed/templates/tokengen/tokengen-job.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       serviceAccountName: {{ include "tempo.resourceName" (dict "ctx" . "component" "tokengen") }}
       {{- if .Values.tokengenJob.priorityClassName }}
-      priorityClassName: {{ .Values.tokengenJob.priorityClassName }}
+      priorityClassName: {{ tpl .Values.tokengenJob.priorityClassName . }}
       {{- end }}
       securityContext:
         {{- toYaml .Values.tokengenJob.securityContext | nindent 8 }}

--- a/charts/tempo-distributed/templates/tokengen/tokengen-job.yaml
+++ b/charts/tempo-distributed/templates/tokengen/tokengen-job.yaml
@@ -95,7 +95,7 @@ spec:
               if cat /shared/admin-token; then
                 echo "Admin token generated successfully and is readable"
                 # Create or update the secret with the admin token
-                kubectl create secret generic {{ .Values.tokengenJob.adminTokenSecret }} \
+                kubectl create secret generic {{ tpl .Values.tokengenJob.adminTokenSecret . }} \
                   --from-file=token=/shared/admin-token \
                   --dry-run=client -o yaml | kubectl apply -f -
                 echo "Admin token secret created/updated successfully"


### PR DESCRIPTION
Adds a `tpl` call to many user-provided configuration options for tempo-distributed. This allows users of the chart to more easily reuse values across this chart and others they might use.

Closes #370.

- **feat(tempo-distributed): wrap ingress gateway host with tpl**
- **feat(tempo-distributed): wrap ingress rule hosts with tpl**
- **feat(tempo-distributed): wrap URL and secret name fields with tpl**
- **feat(tempo-distributed): wrap ingress TLS hosts and secretName with tpl**
- **feat(tempo-distributed): wrap ingressClassName with tpl**
- **feat(tempo-distributed): wrap ingress path values with tpl**
- **feat(tempo-distributed): wrap priorityClassName fields with tpl**
