### PR TITLE
[loki] Fix loki simple scalable workload names (#385)

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.1
-version: 13.2.0
+version: 13.2.1
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/templates/backend/_helpers.tpl
+++ b/charts/loki/templates/backend/_helpers.tpl
@@ -2,7 +2,11 @@
 backend fullname
 */}}
 {{- define "loki.backendFullname" -}}
+{{- if .Values.backend.useOldObjectNames -}}
 {{ include "loki.name" . }}-backend
+{{- else -}}
+{{ include "loki.fullname" . }}-backend
+{{- end -}}
 {{- end }}
 
 {{/*

--- a/charts/loki/templates/read/_helpers.tpl
+++ b/charts/loki/templates/read/_helpers.tpl
@@ -2,7 +2,7 @@
 read fullname
 */}}
 {{- define "loki.readFullname" -}}
-{{ include "loki.name" . }}-read
+{{ include "loki.fullname" . }}-read
 {{- end }}
 
 {{/*

--- a/charts/loki/templates/write/_helpers.tpl
+++ b/charts/loki/templates/write/_helpers.tpl
@@ -2,7 +2,11 @@
 write fullname
 */}}
 {{- define "loki.writeFullname" -}}
+{{- if .Values.write.useOldObjectNames -}}
 {{ include "loki.name" . }}-write
+{{- else -}}
+{{ include "loki.fullname" . }}-write
+{{- end -}}
 {{- end }}
 
 {{/*

--- a/charts/loki/tests/backend/statefulset_test.yaml
+++ b/charts/loki/tests/backend/statefulset_test.yaml
@@ -87,6 +87,10 @@ tests:
           value: Parallel
         template: backend/statefulset.yaml
       - equal:
+          path: metadata.name
+          value: loki-backend
+        template: backend/statefulset.yaml
+      - equal:
           path: spec.serviceName
           value: loki-backend-headless
         template: backend/statefulset.yaml
@@ -97,6 +101,19 @@ tests:
       - equal:
           path: spec.selector.matchLabels["app.kubernetes.io/component"]
           value: backend
+        template: backend/statefulset.yaml
+
+  - it: should set expected statefulset name according to useOldObjectNames flag
+    set:
+      backend.useOldObjectNames: false
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-loki-backend
+        template: backend/statefulset.yaml
+      - equal:
+          path: spec.serviceName
+          value: RELEASE-NAME-loki-backend-headless
         template: backend/statefulset.yaml
 
   - it: should render backend podAnnotations in pod template annotations

--- a/charts/loki/tests/write/hpa_test.yaml
+++ b/charts/loki/tests/write/hpa_test.yaml
@@ -31,8 +31,25 @@ tests:
           path: spec.scaleTargetRef.kind
           value: StatefulSet
       - equal:
+          path: spec.scaleTargetRef.name
+          value: loki-write
+      - equal:
           path: spec.metrics[0].resource.name
           value: cpu
+
+  - it: should name the HPA scaleTargetRef according to useOldObjectNames flag
+    set:
+      write.useOldObjectNames: false
+      write:
+        autoscaling:
+          minReplicas: 2
+          maxReplicas: 6
+          targetCPUUtilizationPercentage: 60
+    asserts:
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: RELEASE-NAME-loki-write
+
 
   - it: should render memory metric when targetMemoryUtilizationPercentage is set
     set:

--- a/charts/loki/tests/write/statefulset_test.yaml
+++ b/charts/loki/tests/write/statefulset_test.yaml
@@ -1,0 +1,197 @@
+# $schema: https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json
+suite: write statefulset
+templates:
+  - write/statefulset.yaml
+  - config.yaml
+set:
+  deploymentMode: SimpleScalable
+  loki.useTestSchema: true
+  loki.storage.bucketNames.chunks: chunks
+  loki.storage.bucketNames.ruler: ruler
+  loki.storage.bucketNames.admin: admin
+
+tests:
+  - it: should not render when deploymentMode is not scalable
+    set:
+      deploymentMode: Distributed
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: write/statefulset.yaml
+
+  - it: should render one StatefulSet in simple scalable mode
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: write/statefulset.yaml
+      - isKind:
+          of: StatefulSet
+        template: write/statefulset.yaml
+
+  - it: should set expected metadata labels
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: write
+        template: write/statefulset.yaml
+      - equal:
+          path: metadata.labels["app.kubernetes.io/part-of"]
+          value: memberlist
+        template: write/statefulset.yaml
+
+  - it: should merge common and component statefulset annotations
+    set:
+      loki.annotations:
+        loki-annotation: loki-value
+      write.annotations:
+        write-annotation: write-value
+    asserts:
+      - equal:
+          path: metadata.annotations["loki-annotation"]
+          value: loki-value
+        template: write/statefulset.yaml
+      - equal:
+          path: metadata.annotations["write-annotation"]
+          value: write-value
+        template: write/statefulset.yaml
+
+  - it: should set replicas from write.replicas
+    set:
+      write.replicas: 5
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 5
+        template: write/statefulset.yaml
+
+  - it: should omit replicas when autoscaling is enabled
+    set:
+      write.autoscaling.enabled: true
+    asserts:
+      - notExists:
+          path: spec.replicas
+        template: write/statefulset.yaml
+
+  - it: should omit replicas when kedaAutoscaling is enabled
+    set:
+      write.kedaAutoscaling.enabled: true
+    asserts:
+      - notExists:
+          path: spec.replicas
+        template: write/statefulset.yaml
+
+  - it: should set expected statefulset spec fields
+    asserts:
+      - equal:
+          path: spec.podManagementPolicy
+          value: Parallel
+        template: write/statefulset.yaml
+      - equal:
+          path: metadata.name
+          value: loki-write
+        template: write/statefulset.yaml
+      - equal:
+          path: spec.serviceName
+          value: loki-write-headless
+        template: write/statefulset.yaml
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 10
+        template: write/statefulset.yaml
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: write
+        template: write/statefulset.yaml
+
+  - it: should set expected statefulset name according to useOldObjectNames flag
+    set:
+      write.useOldObjectNames: false
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-loki-write
+      - equal:
+          path: spec.serviceName
+          value: RELEASE-NAME-loki-write-headless
+        template: write/statefulset.yaml
+
+  - it: should render write podAnnotations in pod template annotations
+    set:
+      write.podAnnotations:
+        custom-annotation: custom-value
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["custom-annotation"]
+          value: custom-value
+        template: write/statefulset.yaml
+
+  - it: should render volumeClaimTemplates when volumeClaimsEnabled is true
+    set:
+      write.persistence.volumeClaimsEnabled: true
+      write.persistence.size: 25Gi
+    asserts:
+      - exists:
+          path: spec.volumeClaimTemplates
+        template: write/statefulset.yaml
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.name
+          value: data
+        template: write/statefulset.yaml
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
+          value: 25Gi
+        template: write/statefulset.yaml
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.accessModes[0]
+          value: ReadWriteOnce
+        template: write/statefulset.yaml
+
+  - it: should not render volumeClaimTemplates when volumeClaimsEnabled is false
+    set:
+      write.persistence.volumeClaimsEnabled: false
+    asserts:
+      - notExists:
+          path: spec.volumeClaimTemplates
+        template: write/statefulset.yaml
+
+  - it: should render PVC annotations labels selector storageClass and volumeAttributesClassName when configured
+    set:
+      write.persistence.annotations:
+        pvc-annotation: pvc-value
+      write.persistence.labels:
+        pvc-label: pvc-value
+      write.persistence.selector:
+        matchLabels:
+          volume: loki-write-storage
+      write.persistence.storageClass: gp3
+      write.persistence.volumeAttributesClassName: bronze
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.annotations["pvc-annotation"]
+          value: pvc-value
+        template: write/statefulset.yaml
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.labels["pvc-label"]
+          value: pvc-value
+        template: write/statefulset.yaml
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.selector.matchLabels.volume
+          value: loki-write-storage
+        template: write/statefulset.yaml
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: gp3
+        template: write/statefulset.yaml
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.volumeAttributesClassName
+          value: bronze
+        template: write/statefulset.yaml
+
+  - it: should render empty storageClassName when persistence.storageClass is dash
+    set:
+      write.persistence.storageClass: "-"
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: ""
+        template: write/statefulset.yaml

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -1952,6 +1952,8 @@ write:
     labels: {}
     # -- Set this toggle to false to opt out of automounting API credentials for the service account
     automountServiceAccountToken: true
+  # -- Toggle to disable usage of Chart.Name prefix for this component
+  useOldObjectNames: true
 
 # --  Configuration for the read pod(s)
 read:
@@ -2310,6 +2312,9 @@ backend:
     labels: {}
     # -- Set this toggle to false to opt out of automounting API credentials for the service account
     automountServiceAccountToken: true
+  # -- Toggle to disable usage of Chart.Name prefix for this component
+  useOldObjectNames: true
+
 ######################################################################################################################
 #
 # Microservices Mode


### PR DESCRIPTION
- Workload templates now using template loki.fullnme

Signed-off-by: Eifoen <35534229+Eifoen@users.noreply.github.com

<!--
Thank you for contributing to grafana-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/grafana-community/helm-charts/blob/main/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them (see CONTRIBUTING.md).
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.  Please check the results.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
Loki simple scalable deploymentMode workloads read, write and backend used template "loki.name" instead of the correct "loki.fullname". This lead to HPAs not selecting the workloads and naming colision when deployed multiple times in the same namespace.

#### Which issue this PR fixes
- fixes #385

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
