### PR TITLE
[tempo-distributed] Make gateway work with IPv6

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 2.15.0
+version: 2.15.2
 # renovate: docker=docker.io/grafana/tempo
 appVersion: 2.10.4
 kubeVersion: "^1.25.0-0"

--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 2.15.2
+version: 2.15.1
 # renovate: docker=docker.io/grafana/tempo
 appVersion: 2.10.4
 kubeVersion: "^1.25.0-0"

--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 2.15.1
+version: 2.15.2
 # renovate: docker=docker.io/grafana/tempo
 appVersion: 2.10.4
 kubeVersion: "^1.25.0-0"

--- a/charts/tempo-distributed/templates/gateway/service-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/service-gateway.yaml
@@ -21,6 +21,8 @@ spec:
   {{- if and (eq "LoadBalancer" .Values.gateway.service.type) .Values.gateway.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.gateway.service.loadBalancerIP }}
   {{- end }}
+  ipFamilies: {{ .Values.tempo.service.ipFamilies }}
+  ipFamilyPolicy: {{ .Values.tempo.service.ipFamilyPolicy }}
   ports:
     - name: http-metrics
       port: {{ .Values.gateway.service.port }}

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -2622,6 +2622,8 @@ gateway:
     tlsSecretName: ''
     # -- Allows overriding the DNS resolver address nginx will use
     resolver: ''
+    # -- Configures whether or not NGINX bind IPv6
+    enableIPv6: false
     # -- Config file contents for Nginx. Passed through the `tpl` function to allow templating
     # @default -- See values.yaml
     file: |
@@ -2671,6 +2673,9 @@ gateway:
 
         server {
           listen             8080 {{- if .Values.gateway.nginxConfig.ssl }} ssl{{- end }};
+          {{- if .Values.gateway.nginxConfig.enableIPv6 }}
+          listen             [::]:8080 {{- if .Values.gateway.nginxConfig.ssl }} ssl{{- end }};
+          {{- end }}
 
           {{- if .Values.streamOverHTTPEnabled }}
           http2 on;


### PR DESCRIPTION
#### What this PR does / why we need it

When tempo-distributed is deployed into an IPv6 environment within an Istio mesh the gateway pod fails the readiness probe (through the istio-proxy) and connection refused error messages are reported in the istio proxy logs.

Fix this by adding a listen directive for IPv6 to the nginx config file.

#### Special notes for your reviewer

Logic was taken and adapted from the mimir-distributed chart.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
