### PR TITLE
[loki] Fix Cilium NetworkPolicy bugs causing security vulnerabilities

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.1
-version: 13.2.0
+version: 13.2.1
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/templates/ciliumnetworkpolicy.yaml
+++ b/charts/loki/templates/ciliumnetworkpolicy.yaml
@@ -11,10 +11,12 @@ spec:
   endpointSelector: {}
   egress:
   - toEndpoints:
-    - {}
+    - matchLabels:
+        "k8s:io.kubernetes.pod.namespace": {{ include "loki.namespace" . }}
   ingress:
   - fromEndpoints:
-    - {}
+    - matchLabels:
+        "k8s:io.kubernetes.pod.namespace": {{ include "loki.namespace" . }}
 
 ---
 apiVersion: cilium.io/v2

--- a/charts/loki/templates/ciliumnetworkpolicy.yaml
+++ b/charts/loki/templates/ciliumnetworkpolicy.yaml
@@ -38,7 +38,9 @@ spec:
       - port: "53"
         protocol: TCP
     toEndpoints:
-    - {}
+    - matchLabels:
+        "k8s:io.kubernetes.pod.namespace": kube-system
+        k8s-app: kube-dns
 
 ---
 apiVersion: cilium.io/v2


### PR DESCRIPTION
<!--
Thank you for contributing to grafana-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/grafana-community/helm-charts/blob/main/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them (see CONTRIBUTING.md).
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.  Please check the results.
-->

<!-- markdownlint-disable-next-line first-line-heading -->

@jkroepke

#### What this PR does / why we need it
This PR fixes two bugs in the Cilium NetworkPolicy template that render the policies ineffective and create security vulnerabilities:

**DNS egress policy doesn't work**: The loki-egress-dns policy uses ```toEndpoints: [{}]``` which is ambiguous and doesn't properly allow DNS queries to CoreDNS. Fixed by explicitly targeting CoreDNS pods using Cilium identity labels (following this example: https://docs.cilium.io/en/latest/security/policy/kubernetes/#example-cnp-egress-to-kube-system)

**Namespace-only policy allows traffic from anywhere**: The policy uses ```fromEndpoints: [{}]``` which in Cilium means "from any endpoint in any namespace", not "same namespace only" like in Kubernetes NetworkPolicy. Fixed by using Cilium identity label k8s:io.kubernetes.pod.namespace to explicitly restrict to the same namespace.

Impact: Without these fixes, the Cilium NetworkPolicy flavor is essentially non-functional - DNS doesn't work and the namespace-only policy provides no isolation.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer
Breaking change consideration: The namespace-only policy fix will actually start enforcing restrictions that were previously not enforced. Users may need to add explicit allow policies for cross-namespace traffic (e.g., Grafana accessing Loki).

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
