### PR TITLE
[loki] Set gateway metrics default image registry separately

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.1
-version: 13.2.1
+version: 13.2.2
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.1
-version: 13.2.0
+version: 13.2.1
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -1337,7 +1337,8 @@ gateway:
     # -- Whether gateway metrics should be exported
     enabled: true
     image:
-      repository: "ghcr.io/jkroepke/access-log-exporter"
+      registry: ghcr.io
+      repository: "jkroepke/access-log-exporter"
       tag: "0.3.10"
       pullPolicy: IfNotPresent
     resources:


### PR DESCRIPTION
#### What this PR does / why we need it

Across the chart the `loki.image` macro is used to generate full image references. It supports registry overrides with `global.registry`, **but** this only works if an image value not already include the registry. 

This PR moves the registry included in `.Values.gateway.metrics.image` into `.Values.gateway.metrics.registry`. This restores the ability to override the registry separately, while keeping the default unchanged.

#### Which issue this PR fixes

#### Special notes for your reviewer

#### Checklist

- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
