### PR TITLE
[loki] fix: recreate job superfluous quotes, wrong rbac

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.1
-version: 13.2.0
+version: 13.2.1
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/templates/monolithic/statefulset-recreate-job.yaml
+++ b/charts/loki/templates/monolithic/statefulset-recreate-job.yaml
@@ -68,7 +68,7 @@ spec:
             - pvc
             - --namespace={{ $newStatefulSet.metadata.namespace }}
             - {{ printf "%s-%s-%d" $template $newStatefulSet.metadata.name $index }}
-            - --type='json'
+            - --type=json
             - '-p=[{"op": "replace", "path": "/spec/resources/requests/storage", "value": "{{ $size }}"}]'
           {{- end }}
         {{- end }}

--- a/charts/loki/templates/monolithic/statefulset-recreate-job.yaml
+++ b/charts/loki/templates/monolithic/statefulset-recreate-job.yaml
@@ -109,7 +109,7 @@ rules:
       - delete
   {{- if $templates }}
   - apiGroups:
-      - v1
+      - ""
     resources:
       - persistentvolumeclaims
     resourceNames:

--- a/charts/loki/templates/monolithic/statefulset-recreate-job.yaml
+++ b/charts/loki/templates/monolithic/statefulset-recreate-job.yaml
@@ -120,6 +120,7 @@ rules:
     {{- end }}
     verbs:
       - patch
+      - get
   {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
<!--
Thank you for contributing to grafana-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/grafana-community/helm-charts/blob/main/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them (see CONTRIBUTING.md).
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.  Please check the results.
-->

<!-- markdownlint-disable-next-line first-line-heading -->

#### What this PR does / why we need it

This removes the superfluous and wrong quotes; kubectl doesn't accept them

Additionally; this fixes the RBAC needed for the job

#### Which issue this PR fixes

#### Special notes for your reviewer

For questions about the RBAC changes, see https://github.com/grafana/helm-charts/pull/4158/changes#r3123177491

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
