### PR TITLE
[loki] Do not set graceful_shutdown_timeout

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.1
-version: 13.2.3
+version: 13.2.4
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -519,7 +519,6 @@ loki:
   tenants: []
   # -- Check https://grafana.com/docs/loki/latest/configuration/#server for more info on the server configuration.
   server:
-    graceful_shutdown_timeout: 5s
     grpc_listen_port: 9095
     grpc_server_min_time_between_pings: '10s'
     grpc_server_ping_without_stream_allowed: true


### PR DESCRIPTION
#### What this PR does / why we need it

The [PR](https://github.com/grafana-community/helm-charts/pull/346) set `graceful_shutdown_timeout: 5s` even if the [default](https://grafana.com/docs/loki/latest/configure/#server) is `30s`.

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
