### PR TITLE
[grafana] expose progressDeadlineSeconds for Deployments

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 12.1.1
+version: 12.1.2
 # renovate: docker=docker.io/grafana/grafana
 appVersion: 13.0.1
 kubeVersion: "^1.25.0-0"

--- a/charts/grafana/templates/deployment.yaml
+++ b/charts/grafana/templates/deployment.yaml
@@ -25,6 +25,9 @@ spec:
   strategy:
     {{- toYaml . | trim | nindent 4 }}
   {{- end }}
+  {{- with .Values.progressDeadlineSeconds }}
+  progressDeadlineSeconds: {{ . }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/charts/grafana/templates/image-renderer-deployment.yaml
+++ b/charts/grafana/templates/image-renderer-deployment.yaml
@@ -27,6 +27,9 @@ spec:
   strategy:
     {{- toYaml . | trim | nindent 4 }}
   {{- end }}
+  {{- with .Values.imageRenderer.progressDeadlineSeconds }}
+  progressDeadlineSeconds: {{ . }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -77,6 +77,10 @@ podDisruptionBudget: {}
 deploymentStrategy:
   type: RollingUpdate
 
+## The maximum time in seconds for a Deployment to make progress before it is considered to be failed.
+## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#progress-deadline-seconds
+progressDeadlineSeconds: null
+
 readinessProbe:
   httpGet:
     path: /api/health
@@ -1460,6 +1464,10 @@ revisionHistoryLimit: 10
 ## Add a separate remote image renderer deployment/service
 imageRenderer:
   deploymentStrategy: {}
+  ## The maximum time in seconds for the image renderer Deployment to make progress before it is
+  ## considered to be failed.
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#progress-deadline-seconds
+  progressDeadlineSeconds: null
   # Enable the image-renderer deployment & service
   enabled: false
   replicas: 1


### PR DESCRIPTION
#### What this PR does / why we need it

Adds a `progressDeadlineSeconds` value (and `imageRenderer.progressDeadlineSeconds`) so operators can tune the Deployment progress deadline alongside `--wait` on slow clusters and avoid `ProgressDeadlineExceeded`.

#### Which issue this PR fixes

- fixes #417

#### Checklist

- [x] DCO signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)