### PR TITLE
[loki] fix lokiCanary.annotations regression and add podAnnotations

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.1
-version: 13.2.3
+version: 13.2.4
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.1
-version: 13.2.4
+version: 13.2.5
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/templates/loki-canary/daemonset.yaml
+++ b/charts/loki/templates/loki-canary/daemonset.yaml
@@ -8,6 +8,12 @@ metadata:
   namespace: {{ include "loki.namespace" $ }}
   labels:
     {{- include "loki-canary.labels" $ | nindent 4 }}
+  {{- if or (not (empty .Values.loki.annotations)) (not (empty .Values.lokiCanary.annotations)) }}
+  annotations:
+    {{- with merge (dict) .Values.loki.annotations .Values.lokiCanary.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/loki/tests/canary/annotations_test.yaml
+++ b/charts/loki/tests/canary/annotations_test.yaml
@@ -1,0 +1,70 @@
+# $schema: https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json
+suite: loki canary annotations
+templates:
+  - loki-canary/daemonset.yaml
+  - config.yaml
+
+set:
+  deploymentMode: SingleBinary
+  loki.useTestSchema: true
+  loki.storage.bucketNames.chunks: chunks
+  loki.storage.bucketNames.ruler: ruler
+  loki.storage.bucketNames.admin: admin
+
+tests:
+  - it: does not render annotations on the DaemonSet by default
+    asserts:
+      - template: loki-canary/daemonset.yaml
+        notExists:
+          path: metadata.annotations
+
+  - it: renders lokiCanary.annotations on the DaemonSet metadata
+    set:
+      lokiCanary.annotations:
+        canary-annotation: canary-value
+    asserts:
+      - template: loki-canary/daemonset.yaml
+        equal:
+          path: metadata.annotations.canary-annotation
+          value: canary-value
+
+  - it: merges loki.annotations and lokiCanary.annotations on the DaemonSet metadata
+    set:
+      loki.annotations:
+        common-annotation: common-value
+      lokiCanary.annotations:
+        canary-annotation: canary-value
+    asserts:
+      - template: loki-canary/daemonset.yaml
+        equal:
+          path: metadata.annotations.common-annotation
+          value: common-value
+      - template: loki-canary/daemonset.yaml
+        equal:
+          path: metadata.annotations.canary-annotation
+          value: canary-value
+
+  - it: loki.annotations takes precedence over lokiCanary.annotations on conflict
+    set:
+      loki.annotations:
+        shared-annotation: from-loki
+      lokiCanary.annotations:
+        shared-annotation: from-canary
+    asserts:
+      - template: loki-canary/daemonset.yaml
+        equal:
+          path: metadata.annotations.shared-annotation
+          value: from-loki
+
+  - it: renders lokiCanary.podAnnotations on the pod template only
+    set:
+      lokiCanary.podAnnotations:
+        pod-annotation: pod-value
+    asserts:
+      - template: loki-canary/daemonset.yaml
+        equal:
+          path: spec.template.metadata.annotations.pod-annotation
+          value: pod-value
+      - template: loki-canary/daemonset.yaml
+        notExists:
+          path: metadata.annotations

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -799,6 +799,8 @@ lokiCanary:
   labelname: pod
   # -- Additional annotations for the `loki-canary` Daemonset
   annotations: {}
+  # -- Additional annotations for each `loki-canary` pod
+  podAnnotations: {}
   # -- Additional labels for each `loki-canary` pod
   podLabels: {}
   service:


### PR DESCRIPTION
#### What this PR does / why we need it

Restores `lokiCanary.annotations` on the DaemonSet metadata (silently broken since 11.4.0 / commit 14ccfeed when the canary moved to the shared pod template) and adds a new `lokiCanary.podAnnotations` value for pod-level annotations, matching the convention used by every other component.

#### Which issue this PR fixes

- fixes #407

#### Checklist

- [x] DCO signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)