### PR TITLE
[tempo-distributed] gate /v1/traces route and ingress on traces.otlp.http.enabled

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 2.17.2
+version: 2.17.3
 # renovate: docker=docker.io/grafana/tempo
 appVersion: 2.10.5
 kubeVersion: "^1.25.0-0"

--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 2.17.3
+version: 2.17.4
 # renovate: docker=docker.io/grafana/tempo
 appVersion: 2.10.5
 kubeVersion: "^1.25.0-0"

--- a/charts/tempo-distributed/templates/_route.tpl
+++ b/charts/tempo-distributed/templates/_route.tpl
@@ -53,6 +53,9 @@ spec:
     {{- if $route.paths }}
     {{- range $svcName, $paths := $route.paths }}
     {{- range $paths }}
+    {{- if and (eq .path "/v1/traces") (not $ctx.Values.traces.otlp.http.enabled) }}
+    {{- /* skip: /v1/traces requires the OTLP HTTP receiver, which is disabled */ -}}
+    {{- else }}
     - matches:
         - path:
             type: {{ .pathType | default "PathPrefix" }}
@@ -60,6 +63,7 @@ spec:
       backendRefs:
         - name: {{ include "tempo.fullname" $ctx }}-{{ $svcName }}
           port: {{ .port | default (include "tempo.serverHttpListenPort" $ctx | trim | int) }}
+    {{- end }}
     {{- end }}
     {{- end }}
     {{- else }}

--- a/charts/tempo-distributed/templates/ingress.yaml
+++ b/charts/tempo-distributed/templates/ingress.yaml
@@ -36,6 +36,9 @@ spec:
         paths:
           {{- range $svcName, $paths := $.Values.ingress.paths }}
             {{- range $paths }}
+            {{- if and (eq .path "/v1/traces") (not $.Values.traces.otlp.http.enabled) }}
+            {{- /* skip: /v1/traces requires the OTLP HTTP receiver, which is disabled */ -}}
+            {{- else }}
           - path: {{ .path }}
             pathType: {{ .pathType | default "Prefix" }}
             backend:
@@ -43,6 +46,7 @@ spec:
                 name: {{ include "tempo.fullname" $ }}-{{ $svcName }}
                 port:
                   number: {{ .port | default (printf "%s" (include "tempo.serverHttpListenPort" $ )) }}
+            {{- end }}
             {{- end }}
           {{- end }}
     {{- end }}

--- a/charts/tempo-distributed/tests/route_test.yaml
+++ b/charts/tempo-distributed/tests/route_test.yaml
@@ -1,0 +1,117 @@
+# $schema: https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json
+suite: route /v1/traces conditional rendering
+templates:
+  - route.yaml
+  - ingress.yaml
+  - configmap-tempo.yaml
+
+set:
+  route.main.enabled: true
+  route.main.parentRefs:
+    - name: gw
+  ingress.enabled: true
+  ingress.hosts:
+    - tempo.example.com
+
+tests:
+  - it: renders /v1/traces with port 4318 in HTTPRoute when OTLP HTTP is enabled
+    set:
+      traces.otlp.http.enabled: true
+    asserts:
+      - template: route.yaml
+        contains:
+          path: spec.rules
+          content:
+            matches:
+              - path:
+                  type: PathPrefix
+                  value: /v1/traces
+            backendRefs:
+              - name: RELEASE-NAME-tempo-distributor
+                port: 4318
+
+  - it: renders /v1/traces with port 4318 in Ingress when OTLP HTTP is enabled
+    set:
+      traces.otlp.http.enabled: true
+    asserts:
+      - template: ingress.yaml
+        contains:
+          path: spec.rules[0].http.paths
+          content:
+            path: /v1/traces
+            pathType: Prefix
+            backend:
+              service:
+                name: RELEASE-NAME-tempo-distributor
+                port:
+                  number: 4318
+
+  - it: omits /v1/traces from HTTPRoute when OTLP HTTP is disabled
+    set:
+      traces.otlp.http.enabled: false
+    asserts:
+      - template: route.yaml
+        notContains:
+          path: spec.rules
+          content:
+            matches:
+              - path:
+                  type: PathPrefix
+                  value: /v1/traces
+            backendRefs:
+              - name: RELEASE-NAME-tempo-distributor
+                port: 4318
+      - template: route.yaml
+        notContains:
+          path: spec.rules
+          content:
+            matches:
+              - path:
+                  type: PathPrefix
+                  value: /v1/traces
+            backendRefs:
+              - name: RELEASE-NAME-tempo-distributor
+                port: 3200
+
+  - it: omits /v1/traces from Ingress when OTLP HTTP is disabled
+    set:
+      traces.otlp.http.enabled: false
+    asserts:
+      - template: ingress.yaml
+        notContains:
+          path: spec.rules[0].http.paths
+          content:
+            path: /v1/traces
+            pathType: Prefix
+            backend:
+              service:
+                name: RELEASE-NAME-tempo-distributor
+                port:
+                  number: 4318
+
+  - it: still renders other distributor paths (e.g. /distributor/ring) when OTLP HTTP is disabled
+    set:
+      traces.otlp.http.enabled: false
+    asserts:
+      - template: route.yaml
+        contains:
+          path: spec.rules
+          content:
+            matches:
+              - path:
+                  type: PathPrefix
+                  value: /distributor/ring
+            backendRefs:
+              - name: RELEASE-NAME-tempo-distributor
+                port: 3200
+      - template: ingress.yaml
+        contains:
+          path: spec.rules[0].http.paths
+          content:
+            path: /distributor/ring
+            pathType: Prefix
+            backend:
+              service:
+                name: RELEASE-NAME-tempo-distributor
+                port:
+                  number: 3200

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -3336,6 +3336,8 @@ route:
         - path: /v1/traces
           # -- pathType for the match (e.g. PathPrefix, Exact)
           pathType: PathPrefix
+          # -- OTLP HTTP receiver port. This path is only rendered when traces.otlp.http.enabled is true.
+          port: 4318
         - path: /distributor/ring
           pathType: PathPrefix
         - path: /ingester/ring


### PR DESCRIPTION
#### What this PR does / why we need it

Adds the missing `port: 4318` to the route default for `/v1/traces` (matching ingress) and skips the path in both route and ingress templates when the OTLP HTTP receiver is disabled, so the chart no longer silently misroutes `/v1/traces` to the HTTP API server port.

#### Which issue this PR fixes

- fixes #414

#### Checklist

- [x] DCO signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)