### PR TITLE
[loki] use rollout-operator to scale ingester zone-b and zone-c

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.1
-version: 13.2.3
+version: 13.2.4
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.1
-version: 13.2.4
+version: 13.2.5
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.1
-version: 13.2.5
+version: 13.2.6
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/templates/ingester/hpa.yaml
+++ b/charts/loki/templates/ingester/hpa.yaml
@@ -2,7 +2,8 @@
 {{- if and $isDistributed (or (not .Values.ingester.zoneAwareReplication.enabled) .Values.ingester.zoneAwareReplication.migration.enabled) }}
 {{- include "loki.hpa" (dict "target" "ingester" "component" .Values.ingester "ctx" .) }}
 {{- else if and $isDistributed .Values.ingester.zoneAwareReplication.enabled }}
-  {{- range $zone := list "zone-a" "zone-b" "zone-c" }}
+  {{- $zones := ternary (list "zone-a") (list "zone-a" "zone-b" "zone-c") .Values.rollout_operator.enabled }}
+  {{- range $zone := $zones }}
 {{- include "loki.hpa" (dict "target" "ingester" "component" $.Values.ingester "ctx" $ "suffix" $zone) }}
   {{- end }}
 {{- end }}

--- a/charts/loki/templates/ingester/so.yaml
+++ b/charts/loki/templates/ingester/so.yaml
@@ -2,7 +2,8 @@
 {{- if and $isDistributed (or (not .Values.ingester.zoneAwareReplication.enabled) .Values.ingester.zoneAwareReplication.migration.enabled) }}
 {{- include "loki.keda" (dict "target" "ingester" "component" .Values.ingester "ctx" .) }}
 {{- else if and $isDistributed .Values.ingester.zoneAwareReplication.enabled }}
-  {{- range $zone := list "zone-a" "zone-b" "zone-c" }}
+  {{- $zones := ternary (list "zone-a") (list "zone-a" "zone-b" "zone-c") .Values.rollout_operator.enabled }}
+  {{- range $zone := $zones }}
 {{- include "loki.keda" (dict "target" "ingester" "component" $.Values.ingester "ctx" $ "suffix" $zone) }}
   {{- end }}
 {{- end }}

--- a/charts/loki/templates/ingester/statefulset-zone.yaml
+++ b/charts/loki/templates/ingester/statefulset-zone.yaml
@@ -18,6 +18,10 @@ metadata:
     {{- end }}
   annotations:
     rollout-max-unavailable: "{{ include "loki.ingester.maxUnavailable" (dict "ctx" $ "replicas" $replicas)}}"
+    {{- if and $.Values.rollout_operator.enabled (ne $zone "zone-a") }}
+    grafana.com/rollout-mirror-replicas-from-resource-name: {{ include "loki.ingesterFullname" $ }}-zone-a
+    grafana.com/rollout-mirror-replicas-from-resource-kind: StatefulSet
+    {{- end }}
     {{- with $.Values.loki.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -25,7 +29,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-{{- if and (not $.Values.ingester.autoscaling.enabled) (not $.Values.ingester.kedaAutoscaling.enabled) }}
+{{- if and (not $.Values.ingester.autoscaling.enabled) (not $.Values.ingester.kedaAutoscaling.enabled) (or (eq $zone "zone-a") (not $.Values.rollout_operator.enabled)) }}
   replicas: {{ $replicas }}
 {{- end }}
   podManagementPolicy: Parallel

--- a/charts/loki/tests/ingester/rollout_operator_test.yaml
+++ b/charts/loki/tests/ingester/rollout_operator_test.yaml
@@ -1,0 +1,174 @@
+# $schema: https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json
+suite: ingester rollout-operator integration
+templates:
+  - ingester/statefulset-zone.yaml
+  - ingester/hpa.yaml
+  - ingester/so.yaml
+  - config.yaml
+set:
+  deploymentMode: Distributed
+  loki.useTestSchema: true
+  loki.storage.bucketNames.chunks: chunks
+  loki.storage.bucketNames.ruler: ruler
+  loki.storage.bucketNames.admin: admin
+  ingester.zoneAwareReplication.enabled: true
+  ingester.replicas: 3
+
+tests:
+  # ── HPA suppression ──────────────────────────────────────────────────────────
+
+  - it: renders an HPA per zone when rollout-operator is disabled
+    set:
+      ingester.autoscaling.enabled: true
+      ingester.autoscaling.maxReplicas: 3
+      rollout_operator.enabled: false
+    asserts:
+      - template: ingester/hpa.yaml
+        hasDocuments:
+          count: 3
+
+  - it: renders only the zone-a HPA when rollout-operator is enabled
+    set:
+      ingester.autoscaling.enabled: true
+      ingester.autoscaling.maxReplicas: 3
+      rollout_operator.enabled: true
+    asserts:
+      - template: ingester/hpa.yaml
+        hasDocuments:
+          count: 1
+      - template: ingester/hpa.yaml
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-loki-ingester-zone-a
+
+  - it: renders a ScaledObject per zone when rollout-operator is disabled
+    set:
+      ingester.kedaAutoscaling.enabled: true
+      ingester.kedaAutoscaling.maxReplicas: 3
+      ingester.kedaAutoscaling.triggers:
+        - type: cpu
+          metricType: Utilization
+          metadata:
+            value: "60"
+      rollout_operator.enabled: false
+    asserts:
+      - template: ingester/so.yaml
+        hasDocuments:
+          count: 3
+
+  - it: renders only the zone-a ScaledObject when rollout-operator is enabled
+    set:
+      ingester.kedaAutoscaling.enabled: true
+      ingester.kedaAutoscaling.maxReplicas: 3
+      ingester.kedaAutoscaling.triggers:
+        - type: cpu
+          metricType: Utilization
+          metadata:
+            value: "60"
+      rollout_operator.enabled: true
+    asserts:
+      - template: ingester/so.yaml
+        hasDocuments:
+          count: 1
+      - template: ingester/so.yaml
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-loki-ingester-zone-a
+
+  # ── Mirror-replicas annotations ──────────────────────────────────────────────
+
+  - it: does not add mirror-replicas annotations when rollout-operator is disabled
+    set:
+      rollout_operator.enabled: false
+    asserts:
+      - template: ingester/statefulset-zone.yaml
+        notExists:
+          path: metadata.annotations["grafana.com/rollout-mirror-replicas-from-resource-name"]
+        documentIndex: 0
+      - template: ingester/statefulset-zone.yaml
+        notExists:
+          path: metadata.annotations["grafana.com/rollout-mirror-replicas-from-resource-name"]
+        documentIndex: 1
+      - template: ingester/statefulset-zone.yaml
+        notExists:
+          path: metadata.annotations["grafana.com/rollout-mirror-replicas-from-resource-name"]
+        documentIndex: 2
+
+  - it: adds mirror-replicas annotations on zone-b and zone-c only when rollout-operator is enabled
+    set:
+      rollout_operator.enabled: true
+    asserts:
+      # zone-a: no mirror annotations
+      - template: ingester/statefulset-zone.yaml
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-loki-ingester-zone-a
+        documentIndex: 0
+      - template: ingester/statefulset-zone.yaml
+        notExists:
+          path: metadata.annotations["grafana.com/rollout-mirror-replicas-from-resource-name"]
+        documentIndex: 0
+      # zone-b: mirrors from zone-a
+      - template: ingester/statefulset-zone.yaml
+        equal:
+          path: metadata.annotations["grafana.com/rollout-mirror-replicas-from-resource-name"]
+          value: RELEASE-NAME-loki-ingester-zone-a
+        documentIndex: 1
+      - template: ingester/statefulset-zone.yaml
+        equal:
+          path: metadata.annotations["grafana.com/rollout-mirror-replicas-from-resource-kind"]
+          value: StatefulSet
+        documentIndex: 1
+      # zone-c: mirrors from zone-a
+      - template: ingester/statefulset-zone.yaml
+        equal:
+          path: metadata.annotations["grafana.com/rollout-mirror-replicas-from-resource-name"]
+          value: RELEASE-NAME-loki-ingester-zone-a
+        documentIndex: 2
+      - template: ingester/statefulset-zone.yaml
+        equal:
+          path: metadata.annotations["grafana.com/rollout-mirror-replicas-from-resource-kind"]
+          value: StatefulSet
+        documentIndex: 2
+
+  # ── replicas suppression on zone-b/c ─────────────────────────────────────────
+
+  - it: omits spec.replicas on zone-b and zone-c when rollout-operator is enabled (no autoscaler)
+    set:
+      rollout_operator.enabled: true
+      ingester.autoscaling.enabled: false
+      ingester.kedaAutoscaling.enabled: false
+    asserts:
+      # zone-a still has replicas (operator is the source of truth, but Helm seeds it)
+      - template: ingester/statefulset-zone.yaml
+        exists:
+          path: spec.replicas
+        documentIndex: 0
+      # zone-b/c: replicas omitted, operator mirrors from zone-a
+      - template: ingester/statefulset-zone.yaml
+        notExists:
+          path: spec.replicas
+        documentIndex: 1
+      - template: ingester/statefulset-zone.yaml
+        notExists:
+          path: spec.replicas
+        documentIndex: 2
+
+  - it: keeps replicas on all zones when rollout-operator is disabled and no autoscaler
+    set:
+      rollout_operator.enabled: false
+      ingester.autoscaling.enabled: false
+      ingester.kedaAutoscaling.enabled: false
+    asserts:
+      - template: ingester/statefulset-zone.yaml
+        exists:
+          path: spec.replicas
+        documentIndex: 0
+      - template: ingester/statefulset-zone.yaml
+        exists:
+          path: spec.replicas
+        documentIndex: 1
+      - template: ingester/statefulset-zone.yaml
+        exists:
+          path: spec.replicas
+        documentIndex: 2


### PR DESCRIPTION
#### What this PR does / why we need it

When `rollout_operator.enabled` and `ingester.zoneAwareReplication.enabled` are both true, only render the zone-a HPA/ScaledObject and add `grafana.com/rollout-mirror-replicas-from-resource-*` annotations on zone-b and zone-c so the operator mirrors the replica count from zone-a. `spec.replicas` is also omitted on zone-b/c so ArgoCD/Helm do not fight the operator.

#### Which issue this PR fixes

- fixes #409

#### Checklist

- [x] DCO signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)