### PR TITLE
[grafana] add shadowBundledPlugins to bypass read-only bundled plugins dir

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 12.1.2
+version: 12.1.3
 # renovate: docker=docker.io/grafana/grafana
 appVersion: 13.0.1
 kubeVersion: "^1.25.0-0"

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 12.1.1
+version: 12.1.2
 # renovate: docker=docker.io/grafana/grafana
 appVersion: 13.0.1
 kubeVersion: "^1.25.0-0"

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -1386,6 +1386,10 @@ containers:
       - name: {{ .name }}
         mountPath: {{ .mountPath }}
       {{- end }}
+      {{- if .Values.shadowBundledPlugins }}
+      - name: shadow-bundled-plugins
+        mountPath: /usr/share/grafana/data/plugins-bundled
+      {{- end }}
     ports:
       - name: {{ .Values.podPortName }}
         containerPort: {{ .Values.service.targetPort }}
@@ -1718,6 +1722,10 @@ volumes:
   {{- end }}
   {{- range .Values.extraEmptyDirMounts }}
   - name: {{ .name }}
+    emptyDir: {}
+  {{- end }}
+  {{- if .Values.shadowBundledPlugins }}
+  - name: shadow-bundled-plugins
     emptyDir: {}
   {{- end }}
   {{- with .Values.extraContainerVolumes }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -179,6 +179,14 @@ extraEmptyDirMounts: []
   # - name: provisioning-notifiers
   #   mountPath: /etc/grafana/provisioning/notifiers
 
+# Shadow `/usr/share/grafana/data/plugins-bundled` with an emptyDir so plugins
+# listed under `plugins:` install cleanly into `/var/lib/grafana/plugins` instead
+# of failing on the read-only bundled directory shipped in the Grafana image.
+# Required for plugins moved out of core in Grafana 13 (e.g. `elasticsearch`,
+# `cloudwatch`) when listed in `plugins:`. Side effect: any bundled plugin not
+# explicitly listed in `plugins:` will not be available.
+shadowBundledPlugins: false
+
 
 # Apply extra labels to common labels.
 extraLabels: {}


### PR DESCRIPTION
#### What this PR does / why we need it

Adds an opt-in value that mounts an emptyDir over `/usr/share/grafana/data/plugins-bundled` so plugins moved out of core in Grafana 13 (e.g. `elasticsearch`) install cleanly into `/var/lib/grafana/plugins` instead of failing with permission denied on the read-only bundled directory shipped in the image.

#### Which issue this PR fixes

- fixes #402

#### Checklist

- [x] DCO signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)