### PR TITLE
[loki] document additionalRules accepts filter-only HTTPRoute rules

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.1
-version: 13.2.3
+version: 13.2.4
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.1
-version: 13.2.4
+version: 13.2.5
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -1282,7 +1282,21 @@ gateway:
       # - name: my-gateway
       #   namespace: gateway-namespace
       # -- Additional rules to prepend before the default catch-all rule.
-      # Useful for advanced routing logic (e.g. header-based routing or auth policies).
+      # Each entry is rendered into spec.rules as written (templating is supported),
+      # so any HTTPRoute/GRPCRoute rule shape is accepted — including filter-only rules
+      # with no backendRefs (e.g. RequestRedirect, URLRewrite).
+      # Useful for advanced routing logic (e.g. header-based routing, auth policies, redirects).
+      # Note: the chart-generated rule that points at the gateway service is always rendered
+      # for this route — additionalRules are prepended, not a replacement.
+      # Example HTTP-to-HTTPS redirect:
+      #   additionalRules:
+      #     - filters:
+      #         - type: RequestRedirect
+      #           requestRedirect:
+      #             scheme: https
+      #             statusCode: 301
+      #       matches:
+      #         - path: { type: PathPrefix, value: / }
       additionalRules: []
       # -- Matches for the default rule. Defaults to match all paths.
       matches:
@@ -1481,13 +1495,19 @@ route:
     hostnames: []
     # -- Parent references for the route (required for Gateway API)
     parentRefs: []
-    # -- Additional rules to prepend before the generated path-routing rules
+    # -- Additional rules to prepend before the generated path-routing rules.
+    # Each entry is rendered into spec.rules as written (templating is supported),
+    # so any HTTPRoute/GRPCRoute rule shape is accepted — including filter-only rules
+    # with no backendRefs (e.g. RequestRedirect, URLRewrite).
     additionalRules: []
     # -- Backend port override for all generated rules.
     # When unset, GRPCRoute automatically uses loki.server.grpc_listen_port (default 9095)
     # and all other kinds use loki.server.http_listen_port (default 3100).
     backendPort: null
     # -- Paths routed to each Loki service group. The target service depends on the deployment mode.
+    # To produce a route that contains only `additionalRules` and no chart-generated path rules
+    # (for example, a dedicated HTTP-to-HTTPS redirect route), set every entry below to an empty
+    # list — e.g. `distributor: []`, `queryFrontend: []`, `ruler: []`, `compactor: []`.
     paths:
       # -- Paths that are exposed by Loki Distributor.
       # If deployment mode is Distributed, the requests are forwarded to the service: `{{"loki.distributorFullname"}}`.


### PR DESCRIPTION
#### What this PR does / why we need it

Clarifies in `values.yaml` that route `additionalRules` entries are rendered into `spec.rules` as written, so filter-only rules without `backendRefs` (e.g. `RequestRedirect`, `URLRewrite`) are valid. Documents that emptying every `paths.<service>` list under `route.<name>` produces a route containing only `additionalRules` — addressing the underlying need in #404 without redesigning the existing API.

#### Which issue this PR fixes

- fixes #404

#### Checklist

- [x] DCO signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)