### PR TITLE
[tempo-distributed] fix: re-wire dnsConfigOverides in shared pod template

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 2.17.4
+version: 2.17.5
 # renovate: docker=docker.io/grafana/tempo
 appVersion: 2.10.5
 kubeVersion: "^1.25.0-0"

--- a/charts/tempo-distributed/templates/_pod.tpl
+++ b/charts/tempo-distributed/templates/_pod.tpl
@@ -41,6 +41,11 @@ spec:
   hostAliases:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- $dnsOverride := $component.dnsConfigOverides | default dict }}
+  {{- if and $dnsOverride.enabled $dnsOverride.dnsConfig }}
+  dnsConfig:
+    {{- toYaml $dnsOverride.dnsConfig | nindent 4 }}
+  {{- end }}
   {{- with $component.initContainers }}
   initContainers:
     {{- if kindIs "slice" . }}

--- a/charts/tempo-distributed/tests/compactor/deployment_test.yaml
+++ b/charts/tempo-distributed/tests/compactor/deployment_test.yaml
@@ -279,3 +279,53 @@ tests:
           content:
             name: tempo-compactor-store
             emptyDir: {}
+
+  - it: dnsConfigOverides disabled by default - no dnsConfig rendered
+    template: compactor/deployment-compactor.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.dnsConfig
+
+  - it: dnsConfigOverides.enabled=true renders dnsConfig from default body
+    template: compactor/deployment-compactor.yaml
+    set:
+      compactor.dnsConfigOverides.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.dnsConfig
+          value:
+            options:
+              - name: ndots
+                value: "3"
+
+  - it: dnsConfigOverides.enabled=true with custom dnsConfig body
+    template: compactor/deployment-compactor.yaml
+    set:
+      compactor.dnsConfigOverides.enabled: true
+      compactor.dnsConfigOverides.dnsConfig:
+        nameservers:
+          - 8.8.8.8
+        options:
+          - name: ndots
+            value: "1"
+    asserts:
+      - equal:
+          path: spec.template.spec.dnsConfig
+          value:
+            nameservers:
+              - 8.8.8.8
+            options:
+              - name: ndots
+                value: "1"
+
+  - it: dnsConfigOverides.enabled=false renders no dnsConfig even with body set
+    template: compactor/deployment-compactor.yaml
+    set:
+      compactor.dnsConfigOverides.enabled: false
+      compactor.dnsConfigOverides.dnsConfig:
+        options:
+          - name: ndots
+            value: "3"
+    asserts:
+      - notExists:
+          path: spec.template.spec.dnsConfig


### PR DESCRIPTION
#### What this PR does / why we need it

[PR #362](https://github.com/grafana-community/helm-charts/pull/362) (v2.16.5) introduced `templates/_pod.tpl` and migrated the compactor + querier to use it. PRs #363 and #381 then moved query-frontend, backend-scheduler, and backend-worker to the same helper.

In doing so, the per-component `dnsConfigOverides` handling that previously lived in `templates/compactor/deployment-compactor.yaml` (and similar) was **not carried over to `_pod.tpl`**. The result: `dnsConfigOverides` is still documented in `values.yaml` for `compactor`, `backendScheduler`, and `backendWorker`, but `grep -rn dnsConfig templates/` returns 0 hits in v2.17.4. Setting `compactor.dnsConfigOverides.enabled: true` is a pure no-op today.

Reproduce on `main`:

```bash
helm template tempo charts/tempo-distributed/ \
  --set compactor.dnsConfigOverides.enabled=true \
  | grep -c dnsConfig
# 0
```

This PR re-wires `dnsConfigOverides` in the shared `tempo.podTemplate` helper so any component using the helper that has a `dnsConfigOverides` block can opt into a custom `dnsConfig`. The helper safe-defaults to an empty dict, so components without the field (querier, distributor, query-frontend) are unaffected.

After the fix:

```bash
helm template tempo charts/tempo-distributed/ --set compactor.dnsConfigOverides.enabled=true | grep -A4 dnsConfig
      dnsConfig:
        options:
        - name: ndots
          value: "3"
```

Tests added in `tests/compactor/deployment_test.yaml`:
- disabled by default → no dnsConfig rendered
- enabled with default body → renders ndots=3
- enabled with custom body → renders the custom dnsConfig (nameservers + options)
- enabled=false with body set → no dnsConfig rendered

All 153 chart tests pass:

```bash
helm unittest charts/tempo-distributed/ -f 'tests/**/*_test.yaml'
# Tests: 153 passed, 153 total
```

#### Which issue this PR fixes

Regression introduced by [#362](https://github.com/grafana-community/helm-charts/pull/362). No existing issue filed.

#### Checklist

- [x] DCO signed
- [x] Chart Version bumped (2.17.4 → 2.17.5)
- [x] Title of the PR starts with chart name (e.g. `[tempo-distributed]`)
