### PR TITLE
[grafana-mcp] Add terminationGracePeriodSeconds support

### DIFF
--- a/charts/grafana-mcp/Chart.yaml
+++ b/charts/grafana-mcp/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana-mcp
-version: 0.10.0
+version: 0.11.0
 # renovate: docker=docker.io/grafana/mcp-grafana
 appVersion: 0.12.0
 kubeVersion: "^1.25.0-0"

--- a/charts/grafana-mcp/templates/deployment.yaml
+++ b/charts/grafana-mcp/templates/deployment.yaml
@@ -60,6 +60,9 @@ spec:
       {{- with .Values.schedulerName }}
       schedulerName: {{ . }}
       {{- end }}
+      {{- with .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
       {{- if or .Values.initContainers .Values.extraInitContainers }}
       initContainers:
         {{- with .Values.initContainers }}

--- a/charts/grafana-mcp/values.yaml
+++ b/charts/grafana-mcp/values.yaml
@@ -235,6 +235,9 @@ runtimeClassName: ""
 # -- Scheduler name
 schedulerName: ""
 
+# -- Termination grace period in seconds (defaults to Kubernetes' default of 30s when unset)
+terminationGracePeriodSeconds: ""
+
 # -- Host aliases
 hostAliases: []
 


### PR DESCRIPTION
## Summary

Expose `terminationGracePeriodSeconds` as a configurable value on the `grafana-mcp` Deployment. Leaving it unset preserves the Kubernetes default of 30s.

## Why

Useful for deployments that:

- Run the MCP server behind a sidecar (e.g. an auth proxy) that needs to drain connections on SIGTERM.
- Configure a `lifecycle.preStop` hook that delays container exit for load balancer deregistration.

In those cases the default 30s budget can be tight, especially for long-running MCP tool calls that should be given a chance to complete via `server.Shutdown()`.

## Changes

- `templates/deployment.yaml`: emit `terminationGracePeriodSeconds` under `spec.template.spec` when the value is set. Gating pattern (`{{- with .Values.X }}`) matches neighboring optional fields like `schedulerName`, `priorityClassName`, `runtimeClassName`.
- `values.yaml`: new documented field (empty default, preserving the k8s default of 30s).
- `Chart.yaml`: bump `version` 0.10.0 → 0.11.0 (additive change, no breaking behavior).

## Testing

Verified locally with `helm v4.1.4`:

**1. `helm lint` passes**

```console
$ helm lint charts/grafana-mcp -f charts/grafana-mcp/ci/default-values.yaml
==> Linting charts/grafana-mcp
1 chart(s) linted, 0 chart(s) failed
```

**2. Default render omits the field (preserves current behavior — k8s default of 30s applies)**

```console
$ helm template test charts/grafana-mcp -f charts/grafana-mcp/ci/default-values.yaml | grep terminationGracePeriodSeconds
# (no output, exit 1)
```

**3. `--set terminationGracePeriodSeconds=60` renders the field under `spec.template.spec`**

```yaml
    spec:
      serviceAccountName: test-grafana-mcp
      automountServiceAccountToken: true
      securityContext:
        fsGroup: 1000
        runAsGroup: 1000
        runAsNonRoot: true
        runAsUser: 1000
      terminationGracePeriodSeconds: 60
      containers:
```

**4. Larger integer values work (tested with 300)**

```yaml
      terminationGracePeriodSeconds: 300
      containers:
```

**5. `diff` between default render and `--set terminationGracePeriodSeconds=60` is a single added line** — confirms no other manifest changes

```
93a94
>       terminationGracePeriodSeconds: 60
```

**6. `kubectl apply --dry-run=client` validates the rendered manifests**

```console
$ helm template test charts/grafana-mcp -f charts/grafana-mcp/ci/default-values.yaml --set terminationGracePeriodSeconds=60 | kubectl apply --dry-run=client -f -
serviceaccount/test-grafana-mcp created (dry run)
secret/test-grafana-mcp created (dry run)
service/test-grafana-mcp created (dry run)
deployment.apps/test-grafana-mcp created (dry run)
```

**7. Second CI profile (`ci/with-affinity-values.yaml`) renders clean both without and with the new value set.**

## Checklist

- [x] `helm lint` passes against both CI values files.
- [x] Default render preserves current behavior (field omitted).
- [x] Explicit value renders correctly at the right location and indentation.
- [x] `kubectl apply --dry-run=client` validates rendered manifests.
- [x] Commit signed off (DCO).
- [x] SemVer minor bump (additive feature).
- [x] Single chart changed.
- [x] PR title follows `[chart-name] ...` convention.