### PR TITLE
[tempo-distributed] cleanup: drop dead K8s version guards

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 2.17.6
+version: 2.17.7
 # renovate: docker=docker.io/grafana/tempo
 appVersion: 2.10.5
 kubeVersion: "^1.25.0-0"

--- a/charts/tempo-distributed/templates/_helpers.tpl
+++ b/charts/tempo-distributed/templates/_helpers.tpl
@@ -143,17 +143,6 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
-Return the appropriate apiVersion for HorizontalPodAutoscaler.
-*/}}
-{{- define "tempo.hpa.apiVersion" -}}
-  {{- if and (.Capabilities.APIVersions.Has "autoscaling/v2") (semverCompare ">=1.23-0" .Capabilities.KubeVersion.Version) -}}
-    {{- print "autoscaling/v2" -}}
-  {{- else -}}
-    {{- print "autoscaling/v2beta1" -}}
-  {{- end -}}
-{{- end -}}
-
-{{/*
 Resource name template
 */}}
 {{- define "tempo.resourceName" -}}

--- a/charts/tempo-distributed/templates/_pod.tpl
+++ b/charts/tempo-distributed/templates/_pod.tpl
@@ -122,11 +122,9 @@ spec:
     {{- end }}
     {{- end }}
   terminationGracePeriodSeconds: {{ $component.terminationGracePeriodSeconds }}
-  {{- if semverCompare ">= 1.19-0" .Capabilities.KubeVersion.Version }}
   {{- with $component.topologySpreadConstraints }}
   topologySpreadConstraints:
     {{- tpl . $ctx | nindent 4 }}
-  {{- end }}
   {{- end }}
   {{- with $component.affinity }}
   affinity:

--- a/charts/tempo-distributed/templates/admin-api/admin-api-dep.yaml
+++ b/charts/tempo-distributed/templates/admin-api/admin-api-dep.yaml
@@ -99,11 +99,9 @@ spec:
         {{- end }}
       nodeSelector:
         {{- toYaml .Values.adminApi.nodeSelector | nindent 8 }}
-      {{- if semverCompare ">= 1.19-0" .Capabilities.KubeVersion.Version }}
       {{- with .Values.adminApi.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- tpl . $ | nindent 8 }}
-      {{- end }}
       {{- end }}
       {{- with .Values.adminApi.affinity }}
       affinity:

--- a/charts/tempo-distributed/templates/backend-worker/hpa.yaml
+++ b/charts/tempo-distributed/templates/backend-worker/hpa.yaml
@@ -1,6 +1,5 @@
 {{- if and .Values.backendScheduler.enabled .Values.backendWorker.autoscaling.enabled .Values.backendWorker.autoscaling.hpa.enabled }}
-{{- $apiVersion := include "tempo.hpa.apiVersion" . -}}
-apiVersion: {{ $apiVersion }}
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "tempo.resourceName" (dict "ctx" . "component" "backend-worker") }}
@@ -23,24 +22,16 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if (eq $apiVersion "autoscaling/v2") }}
         target:
           type: Utilization
           averageUtilization: {{ . }}
-        {{- else }}
-        targetAverageUtilization: {{ . }}
-        {{- end }}
   {{- end }}
   {{- with .Values.backendWorker.autoscaling.hpa.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
-        {{- if (eq $apiVersion "autoscaling/v2") }}
         target:
           type: Utilization
           averageUtilization: {{ . }}
-        {{- else }}
-        targetAverageUtilization: {{ . }}
-        {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/compactor/hpa.yaml
+++ b/charts/tempo-distributed/templates/compactor/hpa.yaml
@@ -1,6 +1,5 @@
 {{- if and (not .Values.backendScheduler.enabled) .Values.compactor.autoscaling.enabled .Values.compactor.autoscaling.hpa.enabled }}
-{{- $apiVersion := include "tempo.hpa.apiVersion" . -}}
-apiVersion: {{ $apiVersion }}
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "tempo.resourceName" (dict "ctx" . "component" "compactor") }}
@@ -23,24 +22,16 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if (eq $apiVersion "autoscaling/v2") }}
         target:
           type: Utilization
           averageUtilization: {{ . }}
-        {{- else }}
-        targetAverageUtilization: {{ . }}
-        {{- end }}
   {{- end }}
   {{- with .Values.compactor.autoscaling.hpa.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
-        {{- if (eq $apiVersion "autoscaling/v2") }}
         target:
           type: Utilization
           averageUtilization: {{ . }}
-        {{- else }}
-        targetAverageUtilization: {{ . }}
-        {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/distributor/hpa.yaml
+++ b/charts/tempo-distributed/templates/distributor/hpa.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.distributor.autoscaling.enabled }}
-{{- $apiVersion := include "tempo.hpa.apiVersion" . -}}
-apiVersion: {{ $apiVersion }}
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "tempo.resourceName" (dict "ctx" . "component" "distributor") }}
@@ -23,24 +22,16 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if (eq $apiVersion "autoscaling/v2") }}
         target:
           type: Utilization
           averageUtilization: {{ . }}
-        {{- else }}
-        targetAverageUtilization: {{ . }}
-        {{- end }}
   {{- end }}
   {{- with .Values.distributor.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
-        {{- if (eq $apiVersion "autoscaling/v2") }}
         target:
           type: Utilization
           averageUtilization: {{ . }}
-        {{- else }}
-        targetAverageUtilization: {{ . }}
-        {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/enterprise-federation-frontend/hpa.yaml
+++ b/charts/tempo-distributed/templates/enterprise-federation-frontend/hpa.yaml
@@ -1,6 +1,5 @@
 {{- if and .Values.enterprise.enabled .Values.enterpriseFederationFrontend.enabled .Values.enterpriseFederationFrontend.autoscaling.enabled }}
-{{- $apiVersion := include "tempo.hpa.apiVersion" . -}}
-apiVersion: {{ $apiVersion }}
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "tempo.resourceName" (dict "ctx" . "component" "enterprise-federation-frontend") }}
@@ -19,24 +18,16 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if (eq $apiVersion "autoscaling/v2") }}
         target:
           type: Utilization
           averageUtilization: {{ . }}
-        {{- else }}
-        targetAverageUtilization: {{ . }}
-        {{- end }}
   {{- end }}
   {{- with .Values.enterpriseFederationFrontend.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
-        {{- if (eq $apiVersion "autoscaling/v2") }}
         target:
           type: Utilization
           averageUtilization: {{ . }}
-        {{- else }}
-        targetAverageUtilization: {{ . }}
-        {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/enterprise-gateway/gateway-dep.yaml
+++ b/charts/tempo-distributed/templates/enterprise-gateway/gateway-dep.yaml
@@ -91,11 +91,9 @@ spec:
         {{- end }}
       nodeSelector:
         {{- toYaml .Values.enterpriseGateway.nodeSelector | nindent 8 }}
-      {{- if semverCompare ">= 1.19-0" .Capabilities.KubeVersion.Version }}
       {{- with .Values.enterpriseGateway.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- tpl . $ | nindent 8 }}
-      {{- end }}
       {{- end }}
       {{- with .Values.enterpriseGateway.affinity }}
       affinity:

--- a/charts/tempo-distributed/templates/gateway/deployment-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/deployment-gateway.yaml
@@ -121,11 +121,9 @@ spec:
         {{- with .Values.gateway.extraContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- if semverCompare ">= 1.19-0" .Capabilities.KubeVersion.Version }}
       {{- with .Values.gateway.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- tpl . $ | nindent 8 }}
-      {{- end }}
       {{- end }}
       {{- with .Values.gateway.affinity }}
       affinity:

--- a/charts/tempo-distributed/templates/gateway/hpa.yaml
+++ b/charts/tempo-distributed/templates/gateway/hpa.yaml
@@ -1,6 +1,5 @@
 {{- if and .Values.gateway.enabled .Values.gateway.autoscaling.enabled }}
-{{- $apiVersion := include "tempo.hpa.apiVersion" . -}}
-apiVersion: {{ $apiVersion }}
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "tempo.resourceName" (dict "ctx" . "component" "gateway") }}
@@ -23,24 +22,16 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if (eq $apiVersion "autoscaling/v2") }}
         target:
           type: Utilization
           averageUtilization: {{ . }}
-        {{- else }}
-        targetAverageUtilization: {{ . }}
-        {{- end }}
   {{- end }}
   {{- with .Values.gateway.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
-        {{- if (eq $apiVersion "autoscaling/v2") }}
         target:
           type: Utilization
           averageUtilization: {{ . }}
-        {{- else }}
-        targetAverageUtilization: {{ . }}
-        {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/ingester/hpa.yaml
+++ b/charts/tempo-distributed/templates/ingester/hpa.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.ingester.autoscaling.enabled }}
-{{- $apiVersion := include "tempo.hpa.apiVersion" . -}}
-apiVersion: {{ $apiVersion }}
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "tempo.resourceName" (dict "ctx" . "component" "ingester") }}
@@ -23,24 +22,16 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if (eq $apiVersion "autoscaling/v2") }}
         target:
           type: Utilization
           averageUtilization: {{ . }}
-        {{- else }}
-        targetAverageUtilization: {{ . }}
-        {{- end }}
   {{- end }}
   {{- with .Values.ingester.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
-        {{- if (eq $apiVersion "autoscaling/v2") }}
         target:
           type: Utilization
           averageUtilization: {{ . }}
-        {{- else }}
-        targetAverageUtilization: {{ . }}
-        {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/ingester/statefulset-ingester.yaml
+++ b/charts/tempo-distributed/templates/ingester/statefulset-ingester.yaml
@@ -141,11 +141,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.ingester.terminationGracePeriodSeconds }}
-      {{- if semverCompare ">= 1.19-0" .Capabilities.KubeVersion.Version }}
       {{- with .Values.ingester.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- tpl . $ | nindent 8 }}
-      {{- end }}
       {{- end }}
       {{- if eq $zoneName ""}}
       {{- with $rolloutZone.affinity }}

--- a/charts/tempo-distributed/templates/memcached/_helpers-memcached.tpl
+++ b/charts/tempo-distributed/templates/memcached/_helpers-memcached.tpl
@@ -148,11 +148,9 @@ spec:
         {{- with $.memcachedConfig.extraContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- if semverCompare ">= 1.19-0" $.ctx.Capabilities.KubeVersion.Version }}
       {{- with $.memcachedConfig.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- tpl . $.ctx | nindent 8 }}
-      {{- end }}
       {{- end }}
       {{- with $.memcachedConfig.affinity }}
       affinity:

--- a/charts/tempo-distributed/templates/memcached/statefulset-memcached.yaml
+++ b/charts/tempo-distributed/templates/memcached/statefulset-memcached.yaml
@@ -132,11 +132,9 @@ spec:
         {{- with .Values.memcached.extraContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- if semverCompare ">= 1.19-0" .Capabilities.KubeVersion.Version }}
       {{- with .Values.memcached.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- tpl . $ | nindent 8 }}
-      {{- end }}
       {{- end }}
       {{- with .Values.memcached.affinity }}
       affinity:

--- a/charts/tempo-distributed/templates/metrics-generator/deployment-metrics-generator.yaml
+++ b/charts/tempo-distributed/templates/metrics-generator/deployment-metrics-generator.yaml
@@ -106,11 +106,9 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
       terminationGracePeriodSeconds: {{ .Values.metricsGenerator.terminationGracePeriodSeconds }}
-      {{- if semverCompare ">= 1.19-0" .Capabilities.KubeVersion.Version }}
       {{- with .Values.metricsGenerator.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- tpl . $ | nindent 8 }}
-      {{- end }}
       {{- end }}
       {{- with .Values.metricsGenerator.affinity }}
       affinity:

--- a/charts/tempo-distributed/templates/metrics-generator/statefulset-metrics-generator.yaml
+++ b/charts/tempo-distributed/templates/metrics-generator/statefulset-metrics-generator.yaml
@@ -116,11 +116,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.metricsGenerator.terminationGracePeriodSeconds }}
-      {{- if semverCompare ">= 1.19-0" .Capabilities.KubeVersion.Version }}
       {{- with .Values.metricsGenerator.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- tpl . $ | nindent 8 }}
-      {{- end }}
       {{- end }}
       {{- with .Values.metricsGenerator.affinity }}
       affinity:

--- a/charts/tempo-distributed/templates/querier/hpa.yaml
+++ b/charts/tempo-distributed/templates/querier/hpa.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.querier.autoscaling.enabled }}
-{{- $apiVersion := include "tempo.hpa.apiVersion" . -}}
-apiVersion: {{ $apiVersion }}
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "tempo.resourceName" (dict "ctx" . "component" "querier") }}
@@ -23,24 +22,16 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if (eq $apiVersion "autoscaling/v2") }}
         target:
           type: Utilization
           averageUtilization: {{ . }}
-        {{- else }}
-        targetAverageUtilization: {{ . }}
-        {{- end }}
   {{- end }}
   {{- with .Values.querier.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
-        {{- if (eq $apiVersion "autoscaling/v2") }}
         target:
           type: Utilization
           averageUtilization: {{ . }}
-        {{- else }}
-        targetAverageUtilization: {{ . }}
-        {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/query-frontend/hpa.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/hpa.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.queryFrontend.autoscaling.enabled }}
-{{- $apiVersion := include "tempo.hpa.apiVersion" . -}}
-apiVersion: {{ $apiVersion }}
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "tempo.resourceName" (dict "ctx" . "component" "query-frontend") }}
@@ -23,24 +22,16 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if (eq $apiVersion "autoscaling/v2") }}
         target:
           type: Utilization
           averageUtilization: {{ . }}
-        {{- else }}
-        targetAverageUtilization: {{ . }}
-        {{- end }}
   {{- end }}
   {{- with .Values.queryFrontend.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
-        {{- if (eq $apiVersion "autoscaling/v2") }}
         target:
           type: Utilization
           averageUtilization: {{ . }}
-        {{- else }}
-        targetAverageUtilization: {{ . }}
-        {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/tests/compactor/hpa_test.yaml
+++ b/charts/tempo-distributed/tests/compactor/hpa_test.yaml
@@ -1,0 +1,93 @@
+# $schema: https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json
+suite: compactor HorizontalPodAutoscaler
+templates:
+  - compactor/hpa.yaml
+
+tests:
+  - it: HPA is not rendered by default (autoscaling disabled)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: HPA is rendered when autoscaling and hpa enabled, with autoscaling/v2 shape
+    set:
+      compactor.autoscaling.enabled: true
+      compactor.autoscaling.hpa.enabled: true
+      compactor.autoscaling.hpa.targetCPUUtilizationPercentage: 60
+      compactor.autoscaling.hpa.targetMemoryUtilizationPercentage: 70
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: apiVersion
+          value: autoscaling/v2
+      - equal:
+          path: kind
+          value: HorizontalPodAutoscaler
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-tempo-compactor
+      - equal:
+          path: spec.scaleTargetRef
+          value:
+            apiVersion: apps/v1
+            kind: Deployment
+            name: RELEASE-NAME-tempo-compactor
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 60
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: memory
+              target:
+                type: Utilization
+                averageUtilization: 70
+      # Regression guard: ensure the legacy v2beta1 field shape is not used
+      - notContains:
+          path: spec.metrics
+          content:
+            targetAverageUtilization: 60
+
+  - it: HPA renders min/max replicas
+    set:
+      compactor.autoscaling.enabled: true
+      compactor.autoscaling.hpa.enabled: true
+      compactor.autoscaling.minReplicas: 2
+      compactor.autoscaling.maxReplicas: 10
+    asserts:
+      - equal:
+          path: spec.minReplicas
+          value: 2
+      - equal:
+          path: spec.maxReplicas
+          value: 10
+
+  - it: HPA renders behavior block when set
+    set:
+      compactor.autoscaling.enabled: true
+      compactor.autoscaling.hpa.enabled: true
+      compactor.autoscaling.hpa.behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 300
+    asserts:
+      - equal:
+          path: spec.behavior.scaleDown.stabilizationWindowSeconds
+          value: 300
+
+  - it: HPA is not rendered when backendScheduler is enabled
+    set:
+      compactor.autoscaling.enabled: true
+      compactor.autoscaling.hpa.enabled: true
+      backendScheduler.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
#### What this PR does / why we need it

Continues #16 (closed) — removing deprecated K8s API guards for `tempo-distributed`.

The chart's `kubeVersion: "^1.25.0-0"` enforces minimum Kubernetes 1.25, yet several templates still gate features behind `semverCompare ">= 1.19-0"` or `>= 1.23-0` checks, and the HPA templates branch between `autoscaling/v2` and `autoscaling/v2beta1`. Both APIs (`topologySpreadConstraints` since 1.19, `autoscaling/v2` since 1.23) are stable in every supported version — the checks and the legacy code paths are dead.

#### What changes

- **Drop `semverCompare ">= 1.19-0"` wrappers** around `topologySpreadConstraints` in:
  - `_pod.tpl` (covers compactor / querier / distributor / query-frontend / backend-scheduler / backend-worker via the shared helper)
  - `ingester/statefulset-ingester.yaml`
  - `metrics-generator/deployment-metrics-generator.yaml`
  - `metrics-generator/statefulset-metrics-generator.yaml`
  - `memcached/statefulset-memcached.yaml` and `memcached/_helpers-memcached.tpl`
  - `enterprise-gateway/gateway-dep.yaml`
  - `gateway/deployment-gateway.yaml`
  - `admin-api/admin-api-dep.yaml`
- **Inline `apiVersion: autoscaling/v2`** directly in all 8 HPA templates (`backend-worker`, `compactor`, `distributor`, `enterprise-federation-frontend`, `gateway`, `ingester`, `querier`, `query-frontend`) and remove the `tempo.hpa.apiVersion` helper from `_helpers.tpl` — it had collapsed to a single static value.
- **Drop `{{- if (eq $apiVersion "autoscaling/v2") }} ... {{- else }} ... {{- end }}` conditionals** in HPA templates that branched between `target.type=Utilization`/`averageUtilization` (v2) and the `targetAverageUtilization` (v2beta1) shape. Always render the v2 form.

Net: 19 files changed, +9/-110 lines.

#### Verification

- `grep -rn 'semverCompare\|tempo.hpa.apiVersion\|\$apiVersion' charts/tempo-distributed/` returns 0 hits after the change
- All 153 chart tests pass: `helm unittest charts/tempo-distributed/ -f 'tests/**/*_test.yaml'`
- `helm template` renders HPAs with `apiVersion: autoscaling/v2` and the correct `target.type=Utilization` shape

#### Which issue this PR fixes

Continues #16 (closed) — same intent, scoped to `tempo-distributed`.

#### Checklist

- [x] DCO signed
- [x] Chart Version bumped (2.17.6 → 2.17.7)
- [x] Title of the PR starts with chart name (e.g. `[tempo-distributed]`)
