### PR TITLE
[loki] add gateway.metrics.service.annotations and gateway.metrics.service.labels

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.1
-version: 13.3.3
+version: 13.4.0
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/templates/gateway/service-exporter.yaml
+++ b/charts/loki/templates/gateway/service-exporter.yaml
@@ -9,14 +9,14 @@ metadata:
     {{- with .Values.loki.serviceLabels }}
     {{- toYaml . | nindent 4}}
     {{- end }}
-    {{- with .Values.gateway.service.labels }}
+    {{- with .Values.gateway.metrics.service.labels }}
     {{- toYaml . | nindent 4}}
     {{- end }}
   annotations:
     {{- with .Values.loki.serviceAnnotations }}
     {{- toYaml . | nindent 4}}
     {{- end }}
-    {{- with .Values.gateway.service.annotations }}
+    {{- with .Values.gateway.metrics.service.annotations }}
     {{- toYaml . | nindent 4}}
     {{- end }}
 spec:

--- a/charts/loki/values.schema.json
+++ b/charts/loki/values.schema.json
@@ -284,6 +284,7 @@
         },
         "metrics": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "service": {
               "type": "object",

--- a/charts/loki/values.schema.json
+++ b/charts/loki/values.schema.json
@@ -284,10 +284,10 @@
         },
         "metrics": {
           "type": "object",
-          "additionalProperties": false,
           "properties": {
             "service": {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "annotations": {
                   "type": "object",

--- a/charts/loki/values.schema.json
+++ b/charts/loki/values.schema.json
@@ -281,6 +281,28 @@
           "additionalProperties": {
             "$ref": "#/definitions/gatewayRouteEntry"
           }
+        },
+        "metrics": {
+          "type": "object",
+          "properties": {
+            "service": {
+              "type": "object",
+              "properties": {
+                "annotations": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "labels": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -1399,6 +1399,13 @@ gateway:
       failureThreshold: 3
     # -- Startup probe for memcached exporter
     startupProbe: {}
+    service:
+      # -- Annotations for the gateway metrics exporter service.
+      # Use this instead of gateway.service.annotations to avoid propagating
+      # annotations (e.g. external-dns) to the exporter ClusterIP service.
+      annotations: {}
+      # -- Labels for the gateway metrics exporter service.
+      labels: {}
 
 # -- Ingress configuration Use either this ingress or the gateway, but not both at once.
 # If you enable this, make sure to disable the gateway.


### PR DESCRIPTION
#### What this PR does / why we need it
The `service-exporter.yaml` template for the gateway metrics exporter service was inheriting `gateway.service.annotations` and `gateway.service.labels`, which are intended for the main gateway service only, for example.

This caused unintended side effects, for example, `external-dns` annotations set on `gateway.service.annotations` would be picked up by the exporter ClusterIP service, registering its ClusterIP in DNS alongside the ILB VIP and causing client
connections to time out.

This PR introduces two new dedicated keys for the exporter service:
- `gateway.metrics.service.annotations` (replaces `gateway.service.annotations` in `service-exporter.yaml`)
- `gateway.metrics.service.labels` (replaces `gateway.service.labels` in `service-exporter.yaml`)

Both default to `{}` and are documented in `values.yaml` and `values.schema.json`.

#### Which issue this PR fixes
- fixes #

#### Special notes for your reviewer

Users relying on `gateway.service.annotations` or `gateway.service.labels` to set values on the exporter service will need to migrate those to the new `gateway.metrics.service.annotations` / `gateway.metrics.service.labels` keys.

#### Checklist
- [X] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped (`13.3.3` → `13.4.0`)
- [x] Title of the PR starts with chart name (e.g. `[loki]`)