### PR TITLE
[grafana-mcp] Support disabling the write features for grafana-mcp server

### DIFF
--- a/charts/grafana-mcp/Chart.yaml
+++ b/charts/grafana-mcp/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana-mcp
-version: 0.12.0
+version: 0.13.0
 # renovate: docker=docker.io/grafana/mcp-grafana
 appVersion: 0.13.0
 kubeVersion: "^1.25.0-0"

--- a/charts/grafana-mcp/templates/deployment.yaml
+++ b/charts/grafana-mcp/templates/deployment.yaml
@@ -137,6 +137,9 @@ spec:
             {{- if .Values.metrics.enabled }}
             - --metrics
             {{- end }}
+            {{- if .Values.disableWrite }}
+            - --disable-write
+            {{- end }}
             {{- range .Values.disabledCategories }}
             - --disable-{{ . }}
             {{- end }}

--- a/charts/grafana-mcp/values.yaml
+++ b/charts/grafana-mcp/values.yaml
@@ -41,6 +41,9 @@ debug: false
 # -- Categories to disable (e.g., oncall, incident, sift)
 disabledCategories: []
 
+# -- Disable write operations to Grafana
+disableWrite: false
+
 # -- Additional command line arguments
 extraArgs: []
 


### PR DESCRIPTION
#### What this PR does / why we need it

Support deploying the grafana-mcp server in a read only mode
https://github.com/grafana/mcp-grafana#read-only-mode

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[grafana]`)
