### PR TITLE
[loki] disable rendering replicas when replicas is set to null

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.2
-version: 17.0.1
+version: 17.0.2
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/templates/ingester/_helpers.tpl
+++ b/charts/loki/templates/ingester/_helpers.tpl
@@ -76,7 +76,7 @@ expects a dict
 }
 */}}
 {{- define "loki.ingester.maxUnavailable" -}}
-{{- ceil (mulf .replicas (divf (int .ctx.Values.ingester.zoneAwareReplication.maxUnavailablePct) 100)) -}}
+{{- max 1 (ceil (mulf .replicas (divf (int .ctx.Values.ingester.zoneAwareReplication.maxUnavailablePct) 100))) -}}
 {{- end -}}
 
 {{/*

--- a/charts/loki/templates/ingester/statefulset-zone.yaml
+++ b/charts/loki/templates/ingester/statefulset-zone.yaml
@@ -25,7 +25,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-{{- if and (not $.Values.ingester.autoscaling.enabled) (not $.Values.ingester.kedaAutoscaling.enabled) (not $.Values.ingester.externalReplicaManagement) }}
+{{- if and (not $.Values.ingester.autoscaling.enabled) (not $.Values.ingester.kedaAutoscaling.enabled) (not (kindIs "invalid" $.Values.ingester.replicas)) }}
   replicas: {{ $replicas }}
 {{- end }}
   podManagementPolicy: Parallel

--- a/charts/loki/templates/ingester/statefulset-zone.yaml
+++ b/charts/loki/templates/ingester/statefulset-zone.yaml
@@ -25,7 +25,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-{{- if and (not $.Values.ingester.autoscaling.enabled) (not $.Values.ingester.kedaAutoscaling.enabled) }}
+{{- if and (not $.Values.ingester.autoscaling.enabled) (not $.Values.ingester.kedaAutoscaling.enabled) (not $.Values.ingester.externalReplicaManagement) }}
   replicas: {{ $replicas }}
 {{- end }}
   podManagementPolicy: Parallel

--- a/charts/loki/templates/ingester/statefulset.yaml
+++ b/charts/loki/templates/ingester/statefulset.yaml
@@ -16,7 +16,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if and (not .Values.ingester.autoscaling.enabled) (not .Values.ingester.kedaAutoscaling.enabled) }}
+{{- if and (not .Values.ingester.autoscaling.enabled) (not .Values.ingester.kedaAutoscaling.enabled) (not .Values.ingester.externalReplicaManagement) }}
   replicas: {{ .Values.ingester.replicas }}
 {{- end }}
   podManagementPolicy: Parallel

--- a/charts/loki/templates/ingester/statefulset.yaml
+++ b/charts/loki/templates/ingester/statefulset.yaml
@@ -16,7 +16,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if and (not .Values.ingester.autoscaling.enabled) (not .Values.ingester.kedaAutoscaling.enabled) (not .Values.ingester.externalReplicaManagement) }}
+{{- if and (not .Values.ingester.autoscaling.enabled) (not .Values.ingester.kedaAutoscaling.enabled) (not (kindIs "invalid" .Values.ingester.replicas)) }}
   replicas: {{ .Values.ingester.replicas }}
 {{- end }}
   podManagementPolicy: Parallel

--- a/charts/loki/tests/ingester/statefulset_replicas_test.yaml
+++ b/charts/loki/tests/ingester/statefulset_replicas_test.yaml
@@ -1,0 +1,139 @@
+# $schema: https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json
+suite: ingester replicas and rollout-max-unavailable
+templates:
+  - ingester/statefulset-zone.yaml
+  - ingester/statefulset.yaml
+  - config.yaml
+set:
+  deploymentMode: Distributed
+  loki.useTestSchema: true
+  loki.storage.bucketNames.chunks: chunks
+  loki.storage.bucketNames.ruler: ruler
+  loki.storage.bucketNames.admin: admin
+
+tests:
+  - it: should omit spec.replicas from zone StatefulSets when ingester.replicas is null
+    set:
+      ingester.zoneAwareReplication.enabled: true
+      ingester.autoscaling.enabled: false
+      ingester.replicas: null
+    asserts:
+      - notExists:
+          path: spec.replicas
+        template: ingester/statefulset-zone.yaml
+
+  - it: should set rollout-max-unavailable to 1 on zone StatefulSets when ingester.replicas is null
+    set:
+      ingester.zoneAwareReplication.enabled: true
+      ingester.autoscaling.enabled: false
+      ingester.replicas: null
+    asserts:
+      - equal:
+          path: metadata.annotations["rollout-max-unavailable"]
+          value: "1"
+        template: ingester/statefulset-zone.yaml
+
+  - it: should set spec.replicas to 1 per zone when ingester.replicas is 3
+    set:
+      ingester.zoneAwareReplication.enabled: true
+      ingester.autoscaling.enabled: false
+      ingester.replicas: 3
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1
+        template: ingester/statefulset-zone.yaml
+
+  - it: should set rollout-max-unavailable to 1 when ingester.replicas is 3
+    set:
+      ingester.zoneAwareReplication.enabled: true
+      ingester.autoscaling.enabled: false
+      ingester.replicas: 3
+    asserts:
+      - equal:
+          path: metadata.annotations["rollout-max-unavailable"]
+          value: "1"
+        template: ingester/statefulset-zone.yaml
+
+  - it: should set spec.replicas to 7 per zone when ingester.replicas is 21
+    set:
+      ingester.zoneAwareReplication.enabled: true
+      ingester.autoscaling.enabled: false
+      ingester.replicas: 21
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 7
+        template: ingester/statefulset-zone.yaml
+
+  - it: should set rollout-max-unavailable to 3 when ingester.replicas is 21
+    set:
+      ingester.zoneAwareReplication.enabled: true
+      ingester.autoscaling.enabled: false
+      ingester.replicas: 21
+    asserts:
+      - equal:
+          path: metadata.annotations["rollout-max-unavailable"]
+          value: "3"
+        template: ingester/statefulset-zone.yaml
+
+  - it: should omit spec.replicas from zone StatefulSets when autoscaling is enabled
+    set:
+      ingester.zoneAwareReplication.enabled: true
+      ingester.replicas: 9
+      ingester.autoscaling.enabled: true
+    asserts:
+      - notExists:
+          path: spec.replicas
+        template: ingester/statefulset-zone.yaml
+
+  - it: should omit spec.replicas from zone StatefulSets when kedaAutoscaling is enabled
+    set:
+      ingester.zoneAwareReplication.enabled: true
+      ingester.replicas: 9
+      ingester.kedaAutoscaling.enabled: true
+    asserts:
+      - notExists:
+          path: spec.replicas
+        template: ingester/statefulset-zone.yaml
+
+  - it: should omit spec.replicas from non-zone StatefulSet when ingester.replicas is null
+    set:
+      ingester.zoneAwareReplication.enabled: false
+      ingester.autoscaling.enabled: false
+      ingester.replicas: null
+    asserts:
+      - notExists:
+          path: spec.replicas
+        template: ingester/statefulset.yaml
+
+  - it: should render spec.replicas on non-zone StatefulSet when ingester.replicas is set
+    set:
+      ingester.zoneAwareReplication.enabled: false
+      ingester.autoscaling.enabled: false
+      ingester.replicas: 5
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 5
+        template: ingester/statefulset.yaml
+
+  - it: should omit spec.replicas from non-zone StatefulSet when autoscaling is enabled
+    set:
+      ingester.zoneAwareReplication.enabled: false
+      ingester.replicas: 5
+      ingester.autoscaling.enabled: true
+    asserts:
+      - notExists:
+          path: spec.replicas
+        template: ingester/statefulset.yaml
+
+  - it: should omit spec.replicas from non-zone StatefulSet when kedaAutoscaling is enabled
+    set:
+      ingester.zoneAwareReplication.enabled: false
+      ingester.replicas: 5
+      ingester.kedaAutoscaling.enabled: true
+    asserts:
+      - notExists:
+          path: spec.replicas
+        template: ingester/statefulset.yaml

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -2429,11 +2429,9 @@ ingester:
   enabled: true
   # -- Number of replicas for the ingester, when zoneAwareReplication.enabled is true, the total
   # number of replicas will match this value with each zone having 1/3rd of the total replicas.
+  # Set to null to omit spec.replicas from the StatefulSet, allowing an external controller
+  # (e.g. HPA, KEDA, rollout-operator) to manage replica counts without Helm resetting them.
   replicas: 0
-  # -- When true, omit spec.replicas from the StatefulSet(s) entirely.
-  # Use when an external controller (e.g. HPA, KEDA, rollout-operator) manages replica counts,
-  # to prevent Helm or ArgoCD from resetting replicas on every sync.
-  externalReplicaManagement: false
   # -- DNSConfig for ingester pods
   dnsConfig: {}
   # -- hostAliases to add

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -2430,6 +2430,10 @@ ingester:
   # -- Number of replicas for the ingester, when zoneAwareReplication.enabled is true, the total
   # number of replicas will match this value with each zone having 1/3rd of the total replicas.
   replicas: 0
+  # -- When true, omit spec.replicas from the StatefulSet(s) entirely.
+  # Use when an external controller (e.g. HPA, KEDA, rollout-operator) manages replica counts,
+  # to prevent Helm or ArgoCD from resetting replicas on every sync.
+  externalReplicaManagement: false
   # -- DNSConfig for ingester pods
   dnsConfig: {}
   # -- hostAliases to add


### PR DESCRIPTION
<!--
Thank you for contributing to grafana-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/grafana-community/helm-charts/blob/main/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them (see CONTRIBUTING.md).
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.  Please check the results.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR attempts to fix #409, in an alternative way to #421.

If users manage the number of replicas of the loki ingester `StatefulSets` through other means than the built-in `HorizontalPodAutoscaler`/`ScaledObject`, the `externalReplicaManagement` option omits rendering the `replicas` field in the `StatefulSets`.

#### Which issue this PR fixes

- fixes #409

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
