### PR TITLE
[tempo-distributed] Adding toggle for optional component ServiceMonitors

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 2.17.8
+version: 2.17.9
 # renovate: docker=docker.io/grafana/tempo
 appVersion: 2.10.5
 kubeVersion: "^1.25.0-0"

--- a/charts/tempo-distributed/templates/memcached/servicemonitor-memcached-bloom.yaml
+++ b/charts/tempo-distributed/templates/memcached/servicemonitor-memcached-bloom.yaml
@@ -1,1 +1,3 @@
+{{- if and .Values.memcachedBloom.enabled .Values.memcachedExporter.enabled }}
 {{- include "tempo.lib.serviceMonitor" (dict "ctx" $ "component" "memcached-bloom") }}
+{{- end }}

--- a/charts/tempo-distributed/templates/memcached/servicemonitor-memcached-frontend-search.yaml
+++ b/charts/tempo-distributed/templates/memcached/servicemonitor-memcached-frontend-search.yaml
@@ -1,1 +1,3 @@
+{{- if and .Values.memcachedFrontendSearch.enabled .Values.memcachedExporter.enabled }}
 {{- include "tempo.lib.serviceMonitor" (dict "ctx" $ "component" "memcached-frontend-search") }}
+{{- end }}

--- a/charts/tempo-distributed/templates/memcached/servicemonitor-memcached-parquet-footer.yaml
+++ b/charts/tempo-distributed/templates/memcached/servicemonitor-memcached-parquet-footer.yaml
@@ -1,1 +1,3 @@
+{{- if and .Values.memcachedParquetFooter.enabled .Values.memcachedExporter.enabled }}
 {{- include "tempo.lib.serviceMonitor" (dict "ctx" $ "component" "memcached-parquet-footer") }}
+{{- end }}

--- a/charts/tempo-distributed/templates/memcached/servicemonitor-memcached.yaml
+++ b/charts/tempo-distributed/templates/memcached/servicemonitor-memcached.yaml
@@ -1,1 +1,3 @@
+{{- if and .Values.memcached.enabled .Values.memcachedExporter.enabled }}
 {{- include "tempo.lib.serviceMonitor" (dict "ctx" $ "component" "memcached") }}
+{{- end }}

--- a/charts/tempo-distributed/templates/metrics-generator/servicemonitor-metrics-generator.yaml
+++ b/charts/tempo-distributed/templates/metrics-generator/servicemonitor-metrics-generator.yaml
@@ -1,1 +1,3 @@
+{{- if .Values.metricsGenerator.enabled }}
 {{- include "tempo.lib.serviceMonitor" (dict "ctx" $ "component" "metrics-generator" "memberlist" true) }}
+{{- end }}

--- a/charts/tempo-distributed/tests/memcached/per_role_statefulset_test.yaml
+++ b/charts/tempo-distributed/tests/memcached/per_role_statefulset_test.yaml
@@ -67,9 +67,27 @@ tests:
           value: Service
         template: memcached/service-memcached-bloom.yaml
 
+  - it: bloom ServiceMonitor not rendered when bloom not enabled
+    set:
+      metaMonitoring.serviceMonitor.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: memcached/servicemonitor-memcached-bloom.yaml
+
+  - it: bloom ServiceMonitor not rendered when memcached exporter not enabled
+    set:
+      memcachedBloom.enabled: true
+      metaMonitoring.serviceMonitor.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: memcached/servicemonitor-memcached-bloom.yaml
+
   - it: bloom ServiceMonitor rendered with correct name
     set:
       memcachedBloom.enabled: true
+      memcachedExporter.enabled: true
       metaMonitoring.serviceMonitor.enabled: true
     asserts:
       - equal:
@@ -151,9 +169,27 @@ tests:
           value: Service
         template: memcached/service-memcached-parquet-footer.yaml
 
+  - it: parquet-footer ServiceMonitor not rendered when parquet-footer not enabled
+    set:
+      metaMonitoring.serviceMonitor.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: memcached/servicemonitor-memcached-parquet-footer.yaml
+
+  - it: parquet-footer ServiceMonitor not rendered when memcached exporter not enabled
+    set:
+      memcachedBloom.enabled: true
+      metaMonitoring.serviceMonitor.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: memcached/servicemonitor-memcached-parquet-footer.yaml
+
   - it: parquet-footer ServiceMonitor rendered with correct name when enabled
     set:
       memcachedParquetFooter.enabled: true
+      memcachedExporter.enabled: true
       metaMonitoring.serviceMonitor.enabled: true
     asserts:
       - equal:
@@ -178,9 +214,27 @@ tests:
           value: Service
         template: memcached/service-memcached-frontend-search.yaml
 
+  - it: frontend-search ServiceMonitor not rendered when frontend-search not enabled
+    set:
+      metaMonitoring.serviceMonitor.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: memcached/servicemonitor-memcached-frontend-search.yaml
+
+  - it: frontend-search ServiceMonitor not rendered when memcached exporter not enabled
+    set:
+      memcachedBloom.enabled: true
+      metaMonitoring.serviceMonitor.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: memcached/servicemonitor-memcached-frontend-search.yaml
+
   - it: frontend-search ServiceMonitor rendered with correct name when enabled
     set:
       memcachedFrontendSearch.enabled: true
+      memcachedExporter.enabled: true
       metaMonitoring.serviceMonitor.enabled: true
     asserts:
       - equal:
@@ -191,7 +245,6 @@ tests:
           path: kind
           value: ServiceMonitor
         template: memcached/servicemonitor-memcached-frontend-search.yaml
-
 
   - it: parquet-footer PDB not rendered when replicas is 1 (default)
     set:


### PR DESCRIPTION
<!--
Thank you for contributing to grafana-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/grafana-community/helm-charts/blob/main/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them (see CONTRIBUTING.md).
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.  Please check the results.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR adds enabled checks for the metrics-generator and memcached ServiceMonitors so they are only created when the component (and exporter for memcached) is enabled

#### Which issue this PR fixes

- fixes #452 

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
