### PR TITLE
[loki] fix: use headless service for query-scheduler address

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.1
-version: 13.6.0
+version: 13.6.1
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/templates/_helpers.tpl
+++ b/charts/loki/templates/_helpers.tpl
@@ -1018,7 +1018,7 @@ enableServiceLinks: {{ $ctx.Values.loki.enableServiceLinks }}
 {{- $querySchedulerAddress := ""}}
 {{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
 {{- if $isDistributed -}}
-{{- $querySchedulerAddress = printf "%s.%s.svc.%s:%s" (include "loki.resourceName" (dict "ctx" . "component" "query-scheduler")) (include "loki.namespace" .) .Values.global.clusterDomain (.Values.loki.server.grpc_listen_port | toString) -}}
+{{- $querySchedulerAddress = printf "%s-headless.%s.svc.%s:%s" (include "loki.resourceName" (dict "ctx" . "component" "query-scheduler")) (include "loki.namespace" .) .Values.global.clusterDomain (.Values.loki.server.grpc_listen_port | toString) -}}
 {{- end -}}
 {{- printf "%s" $querySchedulerAddress }}
 {{- end }}


### PR DESCRIPTION
## What this PR does

Changes the `loki.querySchedulerAddress` helper to use the headless service (`-headless` suffix), so that DNS returns all scheduler pod IPs and gRPC clients connect to every replica.

## Problem

With 2+ query-scheduler replicas in Distributed mode, the `querySchedulerAddress` helper generates:

```
<release>-loki-query-scheduler.<ns>.svc.cluster.local:9095
```

This resolves to a single ClusterIP virtual IP. gRPC multiplexes over one long-lived TCP connection, so all frontends and queriers pin to whichever pod kube-proxy initially routes them to. This causes a split-brain:

- **Scheduler Pod A**: frontend clients connected, 0 querier workers
- **Scheduler Pod B**: querier workers connected, 0 frontend clients

Queries dispatched to Pod A hang indefinitely.

## Fix

Use the headless service (already created by the chart's `_service.tpl`) so DNS returns all pod IPs:

```diff
-{{- $querySchedulerAddress = printf "%s.%s.svc.%s:%s" ...
+{{- $querySchedulerAddress = printf "%s-headless.%s.svc.%s:%s" ...
```

The `scheduler_address` field uses a direct gRPC dial that natively resolves multi-A DNS records — no `dns+` prefix is needed (unlike `index_gateway_client` which uses the dskit multi-resolver).

## Verified locally

After the fix, both scheduler pods show balanced connections:

| Pod | Frontend clients | Querier clients |
|---|---|---|
| Scheduler 1 | 10 | 2 |
| Scheduler 2 | 10 | 2 |

Repeated queries via the gateway succeed consistently (previously only the first query would succeed, then all subsequent queries hung).

## How to reproduce (before fix)

1. Deploy Loki in Distributed mode with `queryScheduler.replicas: 2`
2. Restart all pods simultaneously (e.g., Docker Desktop restart on kind, or node failure)
3. Check `loki_query_scheduler_connected_frontend_clients` and `loki_query_scheduler_connected_querier_clients` on each scheduler pod
4. One pod will have 0 querier clients → queries routed there hang

## Checklist

- [x] Tests updated / not needed
- [x] Documentation updated / not needed