### PR TITLE
[tempo-distributed] Tempo Memcached Headless Services

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 2.17.9
+version: 2.17.10
 # renovate: docker=docker.io/grafana/tempo
 appVersion: 2.10.5
 kubeVersion: "^1.25.0-0"

--- a/charts/tempo-distributed/templates/memcached/_helpers-memcached.tpl
+++ b/charts/tempo-distributed/templates/memcached/_helpers-memcached.tpl
@@ -26,7 +26,7 @@ spec:
   selector:
     matchLabels:
       {{- include "tempo.selectorLabels" $dict | nindent 6 }}
-  serviceName: {{ $.component }}
+  serviceName: {{ include "tempo.resourceName" $dict }}
   template:
     metadata:
       {{- if or $.ctx.Values.tempo.podAnnotations $.memcachedConfig.podAnnotations }}
@@ -195,6 +195,8 @@ metadata:
     {{- tpl (toYaml . | nindent 4) $.ctx }}
   {{- end }}
 spec:
+  type: ClusterIP
+  clusterIP: None
   ipFamilies: {{ $.ctx.Values.tempo.service.ipFamilies }}
   ipFamilyPolicy: {{ $.ctx.Values.tempo.service.ipFamilyPolicy }}
   ports:

--- a/charts/tempo-distributed/templates/memcached/service-memcached.yaml
+++ b/charts/tempo-distributed/templates/memcached/service-memcached.yaml
@@ -11,6 +11,8 @@ metadata:
     {{- tpl (toYaml . | nindent 4) $ }}
   {{- end }}
 spec:
+  type: ClusterIP
+  clusterIP: None
   ipFamilies: {{ .Values.tempo.service.ipFamilies }}
   ipFamilyPolicy: {{ .Values.tempo.service.ipFamilyPolicy }}
   ports:

--- a/charts/tempo-distributed/templates/memcached/statefulset-memcached.yaml
+++ b/charts/tempo-distributed/templates/memcached/statefulset-memcached.yaml
@@ -17,7 +17,7 @@ spec:
   selector:
     matchLabels:
       {{- include "tempo.selectorLabels" $dict | nindent 6 }}
-  serviceName: memcached
+  serviceName: {{ include "tempo.resourceName" $dict }}
   template:
     metadata:
       {{- if or .Values.tempo.podAnnotations .Values.memcached.podAnnotations }}

--- a/charts/tempo-distributed/tests/memcached/per_role_statefulset_test.yaml
+++ b/charts/tempo-distributed/tests/memcached/per_role_statefulset_test.yaml
@@ -34,6 +34,15 @@ tests:
           value: StatefulSet
         template: memcached/statefulset-memcached-bloom.yaml
 
+  - it: bloom StatefulSet rendered with correct serviceName when enabled
+    set:
+      memcachedBloom.enabled: true
+    asserts:
+      - equal:
+          path: spec.serviceName
+          value: RELEASE-NAME-tempo-memcached-bloom
+        template: memcached/statefulset-memcached-bloom.yaml
+
   - it: bloom StatefulSet uses memcached.image
     set:
       memcachedBloom.enabled: true
@@ -65,6 +74,19 @@ tests:
       - equal:
           path: kind
           value: Service
+        template: memcached/service-memcached-bloom.yaml
+
+  - it: bloom Service rendered as headless when enabled
+    set:
+      memcachedBloom.enabled: true
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+        template: memcached/service-memcached-bloom.yaml
+      - equal:
+          path: spec.clusterIP
+          value: None
         template: memcached/service-memcached-bloom.yaml
 
   - it: bloom ServiceMonitor not rendered when bloom not enabled
@@ -131,12 +153,30 @@ tests:
           value: RELEASE-NAME-tempo-memcached-parquet-footer
         template: memcached/statefulset-memcached-parquet-footer.yaml
 
+  - it: parquet-footer StatefulSet rendered with correct serviceName when enabled
+    set:
+      memcachedParquetFooter.enabled: true
+    asserts:
+      - equal:
+          path: spec.serviceName
+          value: RELEASE-NAME-tempo-memcached-parquet-footer
+        template: memcached/statefulset-memcached-parquet-footer.yaml
+
   - it: frontend-search StatefulSet rendered with correct name when enabled
     set:
       memcachedFrontendSearch.enabled: true
     asserts:
       - equal:
           path: metadata.name
+          value: RELEASE-NAME-tempo-memcached-frontend-search
+        template: memcached/statefulset-memcached-frontend-search.yaml
+
+  - it: frontend-search StatefulSet rendered with correct serviceName when enabled
+    set:
+      memcachedFrontendSearch.enabled: true
+    asserts:
+      - equal:
+          path: spec.serviceName
           value: RELEASE-NAME-tempo-memcached-frontend-search
         template: memcached/statefulset-memcached-frontend-search.yaml
 
@@ -167,6 +207,19 @@ tests:
       - equal:
           path: kind
           value: Service
+        template: memcached/service-memcached-parquet-footer.yaml
+
+  - it: parquet-footer Service rendered as headless when enabled
+    set:
+      memcachedParquetFooter.enabled: true
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+        template: memcached/service-memcached-parquet-footer.yaml
+      - equal:
+          path: spec.clusterIP
+          value: None
         template: memcached/service-memcached-parquet-footer.yaml
 
   - it: parquet-footer ServiceMonitor not rendered when parquet-footer not enabled
@@ -212,6 +265,19 @@ tests:
       - equal:
           path: kind
           value: Service
+        template: memcached/service-memcached-frontend-search.yaml
+
+  - it: frontend-search Service rendered as headless when enabled
+    set:
+      memcachedFrontendSearch.enabled: true
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+        template: memcached/service-memcached-frontend-search.yaml
+      - equal:
+          path: spec.clusterIP
+          value: None
         template: memcached/service-memcached-frontend-search.yaml
 
   - it: frontend-search ServiceMonitor not rendered when frontend-search not enabled


### PR DESCRIPTION
<!--
Thank you for contributing to grafana-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/grafana-community/helm-charts/blob/main/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them (see CONTRIBUTING.md).
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.  Please check the results.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

The memcached Services should be headless since Memcached is deployed as a StatefulSet.

The Memcached StatefulSet serviceNames should also be updated to reflect these Services. They are currently pointing to nonexistent Services.

This PR updates the StatefulSet serviceNames and sets `type: ClusterIP` and `clusterIP: None` in all memcached Services 

#### Which issue this PR fixes

fixes #455 

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
