### PR TITLE
[grafana-mcp] Add support for custom command

### DIFF
--- a/charts/grafana-mcp/Chart.yaml
+++ b/charts/grafana-mcp/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana-mcp
-version: 0.13.1
+version: 0.14.0
 # renovate: docker=docker.io/grafana/mcp-grafana
 appVersion: 0.13.1
 kubeVersion: "^1.25.0-0"

--- a/charts/grafana-mcp/templates/deployment.yaml
+++ b/charts/grafana-mcp/templates/deployment.yaml
@@ -81,6 +81,10 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.readinessProbe }}
           readinessProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/grafana-mcp/values.yaml
+++ b/charts/grafana-mcp/values.yaml
@@ -47,6 +47,9 @@ disableWrite: false
 # -- Additional command line arguments
 extraArgs: []
 
+# -- Override the container entrypoint command
+command: []
+
 # -- Environment variables
 env: {}
 


### PR DESCRIPTION
#### What this PR does / why we need it

Add support for custom `command` to use with custom built containers.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[grafana]`)
