### PR TITLE
[grafana-mcp] Add Horizontal Pod Autoscaler (HPA) support to grafana-mcp chart

### DIFF
--- a/charts/grafana-mcp/Chart.yaml
+++ b/charts/grafana-mcp/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: grafana-mcp
-version: 0.13.1
+version: 0.13.2
 # renovate: docker=docker.io/grafana/mcp-grafana
-appVersion: 0.13.1
+appVersion: 0.13.2
 kubeVersion: "^1.25.0-0"
 description: MCP server for Grafana.
 home: https://grafana.com

--- a/charts/grafana-mcp/templates/deployment.yaml
+++ b/charts/grafana-mcp/templates/deployment.yaml
@@ -14,7 +14,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if not .Values.hpa.enabled }}
   replicas: {{ .Values.replicas }}
+  {{- end }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit | default 10 }}
   selector:
     matchLabels:

--- a/charts/grafana-mcp/templates/hpa.yaml
+++ b/charts/grafana-mcp/templates/hpa.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "grafana-mcp.fullname" . }}
+  namespace: {{ include "grafana-mcp.namespace" . }}
+  labels:
+    {{- include "grafana-mcp.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp-server
+    {{- with .Values.hpa.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.hpa.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "grafana-mcp.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+    {{- if .Values.hpa.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetMemoryUtilizationPercentage }}
+    {{- end }}
+    {{- with .Values.hpa.metrics }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.hpa.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/grafana-mcp/values.yaml
+++ b/charts/grafana-mcp/values.yaml
@@ -329,4 +329,3 @@ hpa:
   annotations: {}
   # -- Labels
   labels: {}
-

--- a/charts/grafana-mcp/values.yaml
+++ b/charts/grafana-mcp/values.yaml
@@ -305,3 +305,25 @@ serviceMonitor:
   metricRelabelings: []
   # -- Namespace selector
   namespaceSelector: {}
+
+# -- Horizontal Pod Autoscaler configuration
+hpa:
+  # -- Enable HPA
+  enabled: false
+  # -- Minimum number of replicas
+  minReplicas: 1
+  # -- Maximum number of replicas
+  maxReplicas: 10
+  # -- Target CPU utilization percentage
+  targetCPUUtilizationPercentage: 80
+  # -- Target memory utilization percentage
+  targetMemoryUtilizationPercentage: null
+  # -- Additional metrics
+  metrics: []
+  # -- Behavior configuration
+  behavior: {}
+  # -- Annotations
+  annotations: {}
+  # -- Labels
+  labels: {}
+


### PR DESCRIPTION
<!--
Thank you for contributing to grafana-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/grafana-community/helm-charts/blob/main/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them (see CONTRIBUTING.md).
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.  Please check the results.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
This PR introduces Horizontal Pod Autoscaler (HPA) support for the grafana-mcp Helm chart, enabling automatic scaling of the MCP server based on CPU and memory utilization. This resolves a critical issue where enabling HPA after initial deployment would cause conflicts during helm upgrade operations.

#### Which issue this PR fixes

**Previously, when users attempted to add an HPA resource to the grafana-mcp chart (when using it as a dependency chart):**

- The Deployment template always included a fixed replicas value from values.yaml.
- On initial deployment, this worked fine.
- However, during helm upgrade, Kubernetes would reject the update because the Deployment's static replica count conflicted with the HPA's dynamic scaling control.
- This resulted in failed upgrades and required manual intervention to remove the replicas field from the Deployment.

**Solution**

- The changes implement conditional logic in the Deployment template:
- New HPA Configuration: Added a comprehensive hpa section in values.yaml allowing users to enable/disable HPA, configure min/max replicas, CPU/memory targets, and custom metrics/behavior.
- Conditional Replicas: Modified templates/deployment.yaml to only include the replicas field when hpa.enabled is false. When HPA is enabled, the field is omitted, allowing HPA to manage scaling autonomously.
- HPA Resource Template: Created templates/hpa.yaml that generates a properly configured HorizontalPodAutoscaler resource when enabled.


#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
