### PR TITLE
[loki] feat!: always respect configured registry in image references

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.2
-version: 13.7.1
+version: 14.0.0
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/README.md
+++ b/charts/loki/README.md
@@ -53,6 +53,34 @@ See the [changelog](https://grafana-community.github.io/helm-charts/changelog/?c
 
 ## Upgrading
 
+### From 13.x to 14.0.0 ([#479](https://github.com/grafana-community/helm-charts/pull/479))
+
+The dot-based registry heuristic has been removed. Previously, if the `repository` value contained a dot (`.`) in its first path segment, the chart assumed it already included a registry and silently skipped prepending `global.imageRegistry` or the service-level `registry`. This caused configured registries to be ignored for image references like `mirror.gcr.io/grafana/loki` or `foo.com/loki-fips`.
+
+**This is now the expected behavior**: when a registry is configured (via `global.imageRegistry` or a component's `image.registry`), it is always prepended unconditionally.
+
+Actions required:
+- If you stored a fully-qualified image reference in `repository` (e.g. `repository: private.registry.com/grafana/loki`) and relied on the dot-heuristic to prevent double-prefixing, split the value into separate `registry` and `repository` fields:
+
+Before:
+
+```yaml
+loki:
+  image:
+    repository: private.registry.com/grafana/loki
+```
+
+After:
+
+```yaml
+loki:
+  image:
+    registry: private.registry.com
+    repository: grafana/loki
+```
+
+Users who only set `repository` to a plain path (e.g. `grafana/loki`) or who use `global.imageRegistry` / `image.registry` correctly are unaffected.
+
 ### From 12.x to 13.0.0 ([#258](https://github.com/grafana-community/helm-charts/pull/258))
 
 The persistence configuration for ephemeral volumes has been flattened.

--- a/charts/loki/templates/_helpers.tpl
+++ b/charts/loki/templates/_helpers.tpl
@@ -174,8 +174,7 @@ Input parameters:
 
 {{/*
 Base template for building docker image reference
-Determines the final image name, respecting the global registry if defined, unless the local repository
-already contains a full registry (indicated by a dot '.') for backwards-compatibility.
+Always prepends the registry when one is configured (global or service-level).
 It also respects `.digest` as well as `.sha` (deprecated).
 
 Parameters:
@@ -208,10 +207,8 @@ Parameters:
 {{- $tagRef := printf ":%s" (coalesce $component.tag $default.tag $defaultVersion | toString) -}}
 {{- $ref := ternary $tagRef $digestRef (empty $digestRef) -}}
 
-{{- /* Keep backwards-compatible behavior: do not prefix fully-qualified repositories. */ -}}
 {{- $prefix := "" -}}
-{{- $firstRepositorySegment := (split "/" $repository)._0 -}}
-{{- if and $registry (not (contains "." $firstRepositorySegment)) -}}
+{{- if $registry -}}
 {{- $prefix = printf "%s/" $registry -}}
 {{- end -}}
 

--- a/charts/loki/tests/canary/image_test.yaml
+++ b/charts/loki/tests/canary/image_test.yaml
@@ -50,14 +50,14 @@ tests:
           value: registry.example.com/custom/loki-canary:0.0.0
         template: loki-canary/daemonset.yaml
 
-  - it: should keep fully qualified canary repository without global imageRegistry prefix
+  - it: should always prepend global imageRegistry even when repository contains a registry
     set:
       global.imageRegistry: registry.example.com
       lokiCanary.image.repository: ghcr.io/custom/loki-canary
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/custom/loki-canary:0.0.0
+          value: registry.example.com/ghcr.io/custom/loki-canary:0.0.0
         template: loki-canary/daemonset.yaml
 
   - it: should support deprecated global.image.registry override

--- a/charts/loki/tests/chunks-cache/image_test.yaml
+++ b/charts/loki/tests/chunks-cache/image_test.yaml
@@ -52,14 +52,14 @@ tests:
           value: registry.example.com/custom/memcached:1.6.41-alpine
         template: chunks-cache/statefulset.yaml
 
-  - it: should keep fully qualified memcached repository without global imageRegistry prefix
+  - it: should always prepend global imageRegistry even when repository contains a registry
     set:
       global.imageRegistry: registry.example.com
       memcached.image.repository: ghcr.io/custom/memcached
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/custom/memcached:1.6.41-alpine
+          value: registry.example.com/ghcr.io/custom/memcached:1.6.41-alpine
         template: chunks-cache/statefulset.yaml
 
   - it: should support deprecated global.image.registry override for chunks-cache memcached

--- a/charts/loki/tests/ingester/image_test.yaml
+++ b/charts/loki/tests/ingester/image_test.yaml
@@ -53,14 +53,14 @@ tests:
           value: registry.example.com/custom/loki-write:0.0.0
         template: ingester/statefulset.yaml
 
-  - it: should keep fully qualified write repository without global imageRegistry prefix
+  - it: should always prepend global imageRegistry even when repository contains a registry
     set:
       global.imageRegistry: registry.example.com
       ingester.image.repository: ghcr.io/custom/loki-write
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/custom/loki-write:0.0.0
+          value: registry.example.com/ghcr.io/custom/loki-write:0.0.0
         template: ingester/statefulset.yaml
 
   - it: should support deprecated global.image.registry override

--- a/charts/loki/tests/monolithic/image_test.yaml
+++ b/charts/loki/tests/monolithic/image_test.yaml
@@ -50,14 +50,14 @@ tests:
           value: registry.example.com/custom/loki-singleBinary:0.0.0
         template: monolithic/statefulset.yaml
 
-  - it: should keep fully qualified singleBinary repository without global imageRegistry prefix
+  - it: should always prepend global imageRegistry even when repository contains a registry
     set:
       global.imageRegistry: registry.example.com
       singleBinary.image.repository: ghcr.io/custom/loki-singleBinary
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/custom/loki-singleBinary:0.0.0
+          value: registry.example.com/ghcr.io/custom/loki-singleBinary:0.0.0
         template: monolithic/statefulset.yaml
 
   - it: should support deprecated global.image.registry override

--- a/charts/loki/tests/results-cache/image_test.yaml
+++ b/charts/loki/tests/results-cache/image_test.yaml
@@ -52,14 +52,14 @@ tests:
           value: registry.example.com/custom/memcached:1.6.41-alpine
         template: results-cache/statefulset.yaml
 
-  - it: should keep fully qualified memcached repository without global imageRegistry prefix
+  - it: should always prepend global imageRegistry even when repository contains a registry
     set:
       global.imageRegistry: registry.example.com
       memcached.image.repository: ghcr.io/custom/memcached
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/custom/memcached:1.6.41-alpine
+          value: registry.example.com/ghcr.io/custom/memcached:1.6.41-alpine
         template: results-cache/statefulset.yaml
 
   - it: should support deprecated global.image.registry override for result-cache memcached

--- a/charts/loki/tests/ruler/image_test.yaml
+++ b/charts/loki/tests/ruler/image_test.yaml
@@ -50,14 +50,14 @@ tests:
           value: registry.example.com/custom/loki-ruler:0.0.0
         template: ruler/statefulset.yaml
 
-  - it: should keep fully qualified ruler repository without global imageRegistry prefix
+  - it: should always prepend global imageRegistry even when repository contains a registry
     set:
       global.imageRegistry: registry.example.com
       ruler.image.repository: ghcr.io/custom/loki-ruler
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/custom/loki-ruler:0.0.0
+          value: registry.example.com/ghcr.io/custom/loki-ruler:0.0.0
         template: ruler/statefulset.yaml
 
   - it: should support deprecated global.image.registry override

--- a/charts/loki/tests/write/image_test.yaml
+++ b/charts/loki/tests/write/image_test.yaml
@@ -50,14 +50,14 @@ tests:
           value: registry.example.com/custom/loki-write:0.0.0
         template: write/statefulset.yaml
 
-  - it: should keep fully qualified write repository without global imageRegistry prefix
+  - it: should always prepend global imageRegistry even when repository contains a registry
     set:
       global.imageRegistry: registry.example.com
       write.image.repository: ghcr.io/custom/loki-write
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/custom/loki-write:0.0.0
+          value: registry.example.com/ghcr.io/custom/loki-write:0.0.0
         template: write/statefulset.yaml
 
   - it: should support deprecated global.image.registry override


### PR DESCRIPTION
#### What this PR does / why we need it

The dot-based heuristic introduced previously assumes that a repository containing a `.` already includes a registry (e.g. `private.registry.com/grafana/loki`), and skips prepending any configured registry. However, repositories with dots in their path segments are perfectly valid Docker image names (e.g. `mirror.gcr.io/grafana/loki`, `foo.com/loki-fips`).

This caused both `global.imageRegistry` and service-level `registry` to be silently ignored when the repository happened to contain a dot.

This PR removes the heuristic and restores the pre-heuristic behavior: always prepend the registry when one is configured. Default chart values produce identical image references before and after this change.

This is a port of grafana/loki#21276 to this repository.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

- The change is a single condition removal in `loki.image` (`_helpers.tpl`): the `$firstRepositorySegment` variable and the `not (contains "." ...)` guard are removed, leaving a simple `{{- if $registry -}}`.
- Verified that **all default images are unchanged** — `helm template` output before and after produces identical references:
  ```
  docker.io/grafana/loki:3.7.1
  docker.io/grafana/loki-canary:3.7.1
  docker.io/kiwigrid/k8s-sidecar:...
  docker.io/nginxinc/nginx-unprivileged:...
  memcached:...
  prom/memcached-exporter:...
  ```
- Users who embedded a full registry in the `repository` field (e.g. `repository: private.registry.com/grafana/loki`) and also set `global.imageRegistry` should split those into separate `registry` and `repository` fields:
  ```yaml
  # Before (broken pattern)
  loki:
    image:
      repository: private.registry.com/grafana/loki

  # After
  loki:
    image:
      registry: private.registry.com
      repository: grafana/loki
  ```
- All 384 unit tests pass. The 7 image tests that validated the old (now-removed) heuristic behavior have been updated to document the new behavior.
- Pinging maintainers @TheRealNoob @jkroepke per PR template instructions.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)