### PR TITLE
[loki] fix: Use correct access_key_id mapping in alibabacloud storage helper template

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.1
-version: 13.7.0
+version: 13.7.1
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/templates/_helpers.tpl
+++ b/charts/loki/templates/_helpers.tpl
@@ -286,7 +286,7 @@ alibabacloud:
   {{- toYaml (mergeOverwrite dict
     (dict
       "bucket" $bucketName
-      "access_key_id" .secretAccessKey
+      "access_key_id" .accessKeyId
       "secret_access_key" .secretAccessKey
     )
     (omit . "bucket" "accessKeyId" "secretAccessKey")


### PR DESCRIPTION

<!--
Thank you for contributing to grafana-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/grafana-community/helm-charts/blob/main/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them (see CONTRIBUTING.md).
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.  Please check the results.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

- Fix a one-character bug in `grafana-loki/chart/templates/_helpers.tpl` where the alibabacloud storage block had `"access_key_id" .secretAccessKey` instead of `.accessKeyId`.
- As a result, `loki.storage.alibabacloud.accessKeyId` was previously unusable — the rendered `access_key_id` always took `secretAccessKey`'s value.

#### Which issue this PR fixes

Same as https://github.com/grafana/loki/pull/21827

#### Special notes for your reviewer

- [x] `helm template` against a sample values file with `loki.storage.type=alibabacloud` and distinct `accessKeyId` / `secretAccessKey` values, and confirm the rendered Loki config has them mapped correctly.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
