### PR TITLE
[grafana] Update docker.io/grafana/grafana Docker tag to v13.0.1-security-01

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: grafana
-version: 12.3.1
+version: 12.3.2
 # renovate: docker=docker.io/grafana/grafana
-appVersion: 13.0.1
+appVersion: 13.0.1-security-01
 kubeVersion: "^1.25.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.com


### PR DESCRIPTION
<!--
Thank you for contributing to grafana-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/grafana-community/helm-charts/blob/main/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them (see CONTRIBUTING.md).
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.  Please check the results.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Bumps the Grafana chart `appVersion` from `13.0.1` to `13.0.1-security-01` to pick up the upstream Grafana security patch release.

- Upstream release: https://github.com/grafana/grafana/releases/tag/v13.0.1%2Bsecurity-01
- Docker tag: [`grafana/grafana:13.0.1-security-01`](https://hub.docker.com/r/grafana/grafana/tags?name=13.0.1-security-01) (the `+security-01` build-metadata suffix in the GitHub release name is normalized to `-security-01` on Docker Hub since `+` is not a valid OCI tag character)
- Chart `version` bumped `12.3.1` → `12.3.2` (patch SemVer bump, no breaking changes)

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

- This is a tag-only update; no template or values changes were required.
- Renovate's docker versioning treats `13.0.1` and `13.0.1-security-01` as separate streams and will not auto-bump across the suffix change, so this manual PR is needed.
- `make helm-unittest HELM_UNITTEST_CHART=grafana` passes locally.

cc @jkroepke @QuentinBisson

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
