### PR TITLE
[loki] Define memberlist address via CLI

### DIFF
--- a/.agents/agents/test-writer.md
+++ b/.agents/agents/test-writer.md
@@ -85,6 +85,109 @@ tests:
 - `skip`: only for temporary/unreleased behavior; prefer active assertions over skipped tests.
 - `postRenderer`: use only when chart behavior explicitly depends on post-render transforms.
 
+### Testing `lookup` with `kubernetesProvider`
+
+- Use `kubernetesProvider` whenever templates call `lookup`; without it, lookup returns empty and branch coverage is incomplete.
+- Register API kinds in `scheme` using the key format `"<group>/<version>/<Kind>"` or `"v1/<Kind>"` for core APIs.
+- Each scheme entry must define `gvr` (`group` optional for core APIs, plus `version`, `resource`) and `namespaced`.
+- Provide fixture resources in `objects`; test-level `kubernetesProvider.objects` can add scenario-specific fixtures without rewriting suite-wide defaults.
+
+```yaml
+templates:
+  - templates/lookup.yaml
+kubernetesProvider:
+  scheme:
+    "v1/Namespace":
+      gvr:
+        version: "v1"
+        resource: "namespaces"
+      namespaced: false
+    "v1/Pod":
+      gvr:
+        version: "v1"
+        resource: "pods"
+      namespaced: true
+    "networking.k8s.io/v1/Ingress":
+      gvr:
+        group: "networking.k8s.io"
+        version: "v1"
+        resource: "ingresses"
+      namespaced: true
+  objects:
+    - kind: Pod
+      apiVersion: v1
+      metadata:
+        name: exists
+        namespace: default
+    - kind: Ingress
+      apiVersion: networking.k8s.io/v1
+      metadata:
+        name: exists
+        namespace: default
+    - kind: Namespace
+      apiVersion: v1
+      metadata:
+        name: exists
+    - kind: Namespace
+      apiVersion: v1
+      metadata:
+        name: exists2
+tests:
+  - it: manifest should match snapshot
+    asserts:
+      - matchSnapshot: {}
+      - isNotNullOrEmpty:
+          path: pod_exists
+      - isNotNullOrEmpty:
+          path: ingress_exists
+      - isNotNullOrEmpty:
+          path: namespace_exists
+      - isNullOrEmpty:
+          path: pod_not_exists
+      - isNullOrEmpty:
+          path: ingress_not_exists
+      - isNullOrEmpty:
+          path: namespace_not_exists
+      - equal:
+          path: pod_exists.kind
+          value: Pod
+      - equal:
+          path: pod_exists.apiVersion
+          value: v1
+      - equal:
+          path: pod_exists.metadata.name
+          value: exists
+      - equal:
+          path: pod_exists.metadata.namespace
+          value: default
+      - lengthEqual:
+          path: namespaces.items
+          count: 2
+  - it: manifest should validate pod_not_exists due to additional object add in testjob
+    kubernetesProvider:
+      objects:
+        - kind: Pod
+          apiVersion: v1
+          metadata:
+            name: not-exists
+            namespace: default
+    asserts:
+      - isNotNullOrEmpty:
+          path: pod_not_exists
+      - equal:
+          path: pod_not_exists.kind
+          value: Pod
+      - equal:
+          path: pod_not_exists.apiVersion
+          value: v1
+      - equal:
+          path: pod_not_exists.metadata.name
+          value: not-exists
+      - equal:
+          path: pod_not_exists.metadata.namespace
+          value: default
+```
+
 ### Key Assertion Types
 
 | Assertion | Purpose |
@@ -95,6 +198,7 @@ tests:
 | `exists` | Path exists in rendered output |
 | `notExists` / `exists` | Path is absent/present |
 | `isEmpty` / `isNotEmpty` | Path is/isn't empty |
+| `isNullOrEmpty` / `isNotNullOrEmpty` | Path is null/empty or present with content |
 | `isKind` | Kubernetes resource kind check |
 | `isAPIVersion` | API version check |
 | `contains` | Array/map contains entry |
@@ -104,6 +208,7 @@ tests:
 | `failedTemplate` | Template should fail to render |
 | `notFailedTemplate` | Template should render successfully |
 | `isSubset` | Rendered output is superset of expected |
+| `lengthEqual` | Array/map length equals expected count |
 
 Use antonym assertions (`notEqual`, `notContains`, etc.) instead of relying on `not: true` unless needed for readability.
 

--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.2
-version: 14.2.0
+version: 14.2.2
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/templates/_helpers.tpl
+++ b/charts/loki/templates/_helpers.tpl
@@ -1183,7 +1183,7 @@ env:
   {{- with $envList | uniq }}
   {{- toYaml . | nindent 2 }}
   {{- end }}
-  - name: HASH_RING_INSTANCE_ADDR
+  - name: POD_IP
     valueFrom:
       fieldRef:
         fieldPath: status.podIP

--- a/charts/loki/templates/_pod.tpl
+++ b/charts/loki/templates/_pod.tpl
@@ -210,7 +210,7 @@ spec:
       args:
         {{- if ne $target "canary" }}
         - -config.file=/etc/loki/config/config.yaml
-        - -config.expand-env=true
+        - -memberlist.advertise-addr=$(POD_IP)
         - -target={{ replace "single-binary" "all" $target }}{{- if and .Values.loki.ui.enabled (has $target (list "single-binary" "read" "query-frontend" "querier")) }},ui{{- end }}
         {{- end }}
         {{- with $args }}

--- a/charts/loki/templates/_pod.tpl
+++ b/charts/loki/templates/_pod.tpl
@@ -210,6 +210,7 @@ spec:
       args:
         {{- if ne $target "canary" }}
         - -config.file=/etc/loki/config/config.yaml
+        - -config.expand-env=true
         - -memberlist.advertise-addr=$(POD_IP)
         - -target={{ replace "single-binary" "all" $target }}{{- if and .Values.loki.ui.enabled (has $target (list "single-binary" "read" "query-frontend" "querier")) }},ui{{- end }}
         {{- end }}

--- a/charts/loki/templates/_workload.tpl
+++ b/charts/loki/templates/_workload.tpl
@@ -155,12 +155,12 @@ spec:
     {{- $needsRecreation := false -}}
     {{- $templates := dict -}}
     {{- if and $currentStatefulset (eq $currentStatefulset.metadata.name $newStatefulSet.metadata.name) -}}
-      {{- if ne (len $newStatefulSet.spec.volumeClaimTemplates) (len $currentStatefulset.spec.volumeClaimTemplates) -}}
+      {{- if ne (len ($newStatefulSet.spec.volumeClaimTemplates | default list)) (len ($currentStatefulset.spec.volumeClaimTemplates | default list)) -}}
         {{- $needsRecreation = true -}}
       {{- else -}}
         {{- range $index, $newVolumeClaimTemplate := $newStatefulSet.spec.volumeClaimTemplates -}}
           {{- $currentVolumeClaimTemplateSpec := dict -}}
-            {{- range $oldVolumeClaimTemplate := $currentStatefulset.spec.volumeClaimTemplates -}}
+            {{- range $oldVolumeClaimTemplate := ($currentStatefulset.spec.volumeClaimTemplates | default list) -}}
               {{- if eq $oldVolumeClaimTemplate.metadata.name $newVolumeClaimTemplate.metadata.name -}}
                 {{- $currentVolumeClaimTemplateSpec = $oldVolumeClaimTemplate.spec -}}
               {{- end -}}

--- a/charts/loki/tests/compactor/recreate_test.yaml
+++ b/charts/loki/tests/compactor/recreate_test.yaml
@@ -1,0 +1,384 @@
+# $schema: https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json
+suite: compactor StatefulSet recreate job
+templates:
+  - templates/compactor/workload.yaml
+  - templates/config.yaml
+
+# Common base values for all tests in this suite
+set:
+  deploymentMode: Distributed
+  loki.storage.bucketNames.chunks: chunks
+  loki.storage.bucketNames.ruler: ruler
+  compactor.enabled: true
+  compactor.kind: StatefulSet
+  compactor.replicas: 1
+  compactor.statefulSetRecreateJob.enabled: true
+
+tests:
+  - it: should render only StatefulSet when upgrade=true but no existing StatefulSet is found (lookup returns empty)
+    release:
+      upgrade: true
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: templates/compactor/workload.yaml
+      - isKind:
+          of: StatefulSet
+        template: templates/compactor/workload.yaml
+
+    # Regression test for: "len of nil pointer" when the existing StatefulSet has no spec.volumeClaimTemplates
+  # and the new deployment adds PVCs (statefulSetRecreateJob.enabled=true).
+  # Error: loki/templates/_workload.tpl:158: executing "loki.component.workload.recreate"
+  #        at <len $currentStatefulset.spec.volumeClaimTemplates>: error calling len: len of nil pointer
+  - it: should render StatefulSet and recreate Job when existing StatefulSet has no volumeClaimTemplates but new one does
+    release:
+      upgrade: true
+    set:
+      compactor.persistence.enabled: true
+      compactor.persistence.type: pvc
+      compactor.persistence.claims:
+        - name: data
+          size: 10Gi
+          accessModes:
+            - ReadWriteOnce
+    kubernetesProvider:
+      scheme:
+        apps/v1/StatefulSet:
+          gvr:
+            group: apps
+            version: v1
+            resource: statefulsets
+          namespaced: true
+      objects:
+        - apiVersion: apps/v1
+          kind: StatefulSet
+          metadata:
+            name: RELEASE-NAME-loki-compactor
+            namespace: NAMESPACE
+          spec:
+            # spec.volumeClaimTemplates intentionally absent (nil) — the bug scenario
+            podManagementPolicy: Parallel
+    asserts:
+      - hasDocuments:
+          count: 5
+        template: templates/compactor/workload.yaml
+      - isKind:
+          of: StatefulSet
+        template: templates/compactor/workload.yaml
+        documentIndex: 0
+      - isKind:
+          of: Job
+        template: templates/compactor/workload.yaml
+        documentIndex: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-loki-compactor-recreate
+        template: templates/compactor/workload.yaml
+        documentIndex: 1
+
+  - it: should render only StatefulSet when upgrade has no VCT changes (no recreation needed)
+    release:
+      upgrade: true
+    set:
+      compactor.persistence.enabled: true
+      compactor.persistence.type: pvc
+      compactor.persistence.claims:
+        - name: data
+          size: 10Gi
+          accessModes:
+            - ReadWriteOnce
+    kubernetesProvider:
+      scheme:
+        apps/v1/StatefulSet:
+          gvr:
+            group: apps
+            version: v1
+            resource: statefulsets
+          namespaced: true
+      objects:
+        - apiVersion: apps/v1
+          kind: StatefulSet
+          metadata:
+            name: RELEASE-NAME-loki-compactor
+            namespace: NAMESPACE
+          spec:
+            podManagementPolicy: Parallel
+            volumeClaimTemplates:
+              - metadata:
+                  name: data
+                spec:
+                  resources:
+                    requests:
+                      storage: "10Gi"
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: templates/compactor/workload.yaml
+      - isKind:
+          of: StatefulSet
+        template: templates/compactor/workload.yaml
+
+  - it: should render StatefulSet and recreate Job when existing VCT storage size changed
+    release:
+      upgrade: true
+    set:
+      compactor.persistence.enabled: true
+      compactor.persistence.type: pvc
+      compactor.persistence.claims:
+        - name: data
+          size: 20Gi
+          accessModes:
+            - ReadWriteOnce
+    kubernetesProvider:
+      scheme:
+        apps/v1/StatefulSet:
+          gvr:
+            group: apps
+            version: v1
+            resource: statefulsets
+          namespaced: true
+      objects:
+        - apiVersion: apps/v1
+          kind: StatefulSet
+          metadata:
+            name: RELEASE-NAME-loki-compactor
+            namespace: NAMESPACE
+          spec:
+            podManagementPolicy: Parallel
+            volumeClaimTemplates:
+              - metadata:
+                  name: data
+                spec:
+                  resources:
+                    requests:
+                      storage: "10Gi"
+    asserts:
+      - hasDocuments:
+          count: 5
+        template: templates/compactor/workload.yaml
+      - isKind:
+          of: Job
+        template: templates/compactor/workload.yaml
+        documentIndex: 1
+
+  - it: should not render recreate Job when statefulSetRecreateJob is disabled even if upgrade=true
+    release:
+      upgrade: true
+    set:
+      compactor.statefulSetRecreateJob.enabled: false
+      compactor.persistence.enabled: true
+      compactor.persistence.type: pvc
+      compactor.persistence.claims:
+        - name: data
+          size: 10Gi
+          accessModes:
+            - ReadWriteOnce
+    kubernetesProvider:
+      scheme:
+        apps/v1/StatefulSet:
+          gvr:
+            group: apps
+            version: v1
+            resource: statefulsets
+          namespaced: true
+      objects:
+        - apiVersion: apps/v1
+          kind: StatefulSet
+          metadata:
+            name: RELEASE-NAME-loki-compactor
+            namespace: NAMESPACE
+          spec:
+            # statefulSetRecreateJob is disabled so lookup is not called;
+            # mock included to confirm no Job is emitted even when a StatefulSet exists
+            podManagementPolicy: Parallel
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: templates/compactor/workload.yaml
+      - isKind:
+          of: StatefulSet
+        template: templates/compactor/workload.yaml
+
+  - it: should not render recreate resources on install even if PVC size changed
+    set:
+      compactor.persistence.enabled: true
+      compactor.persistence.type: pvc
+      compactor.persistence.claims:
+        - name: data
+          size: 20Gi
+          accessModes:
+            - ReadWriteOnce
+    kubernetesProvider:
+      scheme:
+        apps/v1/StatefulSet:
+          gvr:
+            group: apps
+            version: v1
+            resource: statefulsets
+          namespaced: true
+      objects:
+        - apiVersion: apps/v1
+          kind: StatefulSet
+          metadata:
+            name: RELEASE-NAME-loki-compactor
+            namespace: NAMESPACE
+          spec:
+            podManagementPolicy: Parallel
+            volumeClaimTemplates:
+              - metadata:
+                  name: data
+                spec:
+                  resources:
+                    requests:
+                      storage: "10Gi"
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: templates/compactor/workload.yaml
+      - isKind:
+          of: StatefulSet
+        template: templates/compactor/workload.yaml
+
+  - it: should not render recreate resources when kind is Deployment
+    release:
+      upgrade: true
+    set:
+      compactor.kind: Deployment
+      compactor.persistence.enabled: true
+      compactor.persistence.type: pvc
+      compactor.persistence.claims:
+        - name: data
+          size: 20Gi
+          accessModes:
+            - ReadWriteOnce
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: templates/compactor/workload.yaml
+      - isKind:
+          of: Deployment
+        template: templates/compactor/workload.yaml
+
+  - it: should render recreate hook resources and patch PVC initContainers for each replica
+    release:
+      upgrade: true
+    set:
+      compactor.replicas: 2
+      compactor.persistence.enabled: true
+      compactor.persistence.type: pvc
+      compactor.persistence.claims:
+        - name: data
+          size: 20Gi
+          accessModes:
+            - ReadWriteOnce
+    kubernetesProvider:
+      scheme:
+        apps/v1/StatefulSet:
+          gvr:
+            group: apps
+            version: v1
+            resource: statefulsets
+          namespaced: true
+      objects:
+        - apiVersion: apps/v1
+          kind: StatefulSet
+          metadata:
+            name: RELEASE-NAME-loki-compactor
+            namespace: NAMESPACE
+          spec:
+            replicas: "2"
+            podManagementPolicy: Parallel
+            volumeClaimTemplates:
+              - metadata:
+                  name: data
+                spec:
+                  resources:
+                    requests:
+                      storage: "10Gi"
+    asserts:
+      - hasDocuments:
+          count: 5
+        template: templates/compactor/workload.yaml
+      - isKind:
+          of: Job
+        template: templates/compactor/workload.yaml
+        documentIndex: 1
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-upgrade
+        template: templates/compactor/workload.yaml
+        documentIndex: 1
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: patch-pvc-data-0
+        template: templates/compactor/workload.yaml
+        documentIndex: 1
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: patch-pvc-data-1
+        template: templates/compactor/workload.yaml
+        documentIndex: 1
+      - equal:
+          path: rules[1].resources[0]
+          value: persistentvolumeclaims
+        template: templates/compactor/workload.yaml
+        documentIndex: 3
+      - equal:
+          path: rules[1].resourceNames[0]
+          value: data-RELEASE-NAME-loki-compactor-0
+        template: templates/compactor/workload.yaml
+        documentIndex: 3
+      - equal:
+          path: rules[1].resourceNames[1]
+          value: data-RELEASE-NAME-loki-compactor-1
+        template: templates/compactor/workload.yaml
+        documentIndex: 3
+
+  - it: should not render patch initContainers when defaults.statefulSetRecreateJob.patchPVC is false
+    release:
+      upgrade: true
+    set:
+      defaults.statefulSetRecreateJob.patchPVC: false
+      compactor.persistence.enabled: true
+      compactor.persistence.type: pvc
+      compactor.persistence.claims:
+        - name: data
+          size: 20Gi
+          accessModes:
+            - ReadWriteOnce
+    kubernetesProvider:
+      scheme:
+        apps/v1/StatefulSet:
+          gvr:
+            group: apps
+            version: v1
+            resource: statefulsets
+          namespaced: true
+      objects:
+        - apiVersion: apps/v1
+          kind: StatefulSet
+          metadata:
+            name: RELEASE-NAME-loki-compactor
+            namespace: NAMESPACE
+          spec:
+            replicas: "1"
+            podManagementPolicy: Parallel
+            volumeClaimTemplates:
+              - metadata:
+                  name: data
+                spec:
+                  resources:
+                    requests:
+                      storage: "10Gi"
+    asserts:
+      - hasDocuments:
+          count: 5
+        template: templates/compactor/workload.yaml
+      - isKind:
+          of: Job
+        template: templates/compactor/workload.yaml
+        documentIndex: 1
+      - notExists:
+          path: spec.template.spec.initContainers[0]
+        template: templates/compactor/workload.yaml
+        documentIndex: 1

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -509,7 +509,6 @@ loki:
   # -- Extra memberlist configuration
   extraMemberlistConfig:
     abort_if_cluster_join_fails: true
-    advertise_addr: ${HASH_RING_INSTANCE_ADDR}
     advertise_port: 7946
     bind_port: 7946
     max_join_backoff: 1m
@@ -5236,6 +5235,14 @@ rollout_operator:
     runAsNonRoot: true
     seccompProfile:
       type: RuntimeDefault
+  webhooks:
+    # -- Enable the rollout-operator webhooks. See https://github.com/grafana/rollout-operator/#webhooks.
+    # Note that the webhooks require custom resource definitions. If upgrading, manually apply the files in the `crds` directory.
+    enabled: true
+    # -- Timeout in seconds for the prepare-downscale mutating webhook. Must be between 1 and 30.
+    timeoutSeconds: 10
+    # -- Validating and mutating webhook failure policy. `Ignore` or `Fail`.
+    failurePolicy: "Ignore"
 # -- Configuration for the minio subchart
 minio:
   enabled: false


### PR DESCRIPTION
<!--
Thank you for contributing to grafana-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/grafana-community/helm-charts/blob/main/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them (see CONTRIBUTING.md).
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.  Please check the results.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #449 

#### Special notes for your reviewer

Added some additional unit test for the statefulset recreation job
Set rollout operator Webhooks to ignore by default to prevent deadlock conditions.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[grafana]`)
