### PR TITLE
[tempo-distributed]  removed incorrect config options from the backend-worker

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 2.21.1
+version: 2.21.2
 # renovate: docker=docker.io/grafana/tempo
 appVersion: 2.10.5
 kubeVersion: "^1.25.0-0"

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -1105,16 +1105,6 @@ backendWorker:
     compaction: {}
     # -- Timeout for finishing the current job before shutting down the worker
     finish_on_shutdown_timeout: 30s
-    # -- Maximum number of compaction jobs to create per tenant
-    max_jobs_per_tenant: 1000
-    # -- Minimum number of blocks required for compaction
-    min_input_blocks: 2
-    # -- Maximum number of blocks to compact together
-    max_input_blocks: 4
-    # -- Maximum compaction level (0 means no limit)
-    max_compaction_level: 0
-    # -- Minimum time between compaction cycles for a tenant
-    min_cycle_interval: 30s
   service:
     # -- Annotations for backend-worker service
     annotations: {}


### PR DESCRIPTION

<!--
Thank you for contributing to grafana-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/grafana-community/helm-charts/blob/main/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them (see CONTRIBUTING.md).
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.  Please check the results.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
Removes incorrect configuration values that were added to the backend-worker in https://github.com/grafana-community/helm-charts/pull/381. This configuration only applies to the backend-scheduler and not the backend-worker.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
