### PR TITLE
[tempo-distributed] Fix: hpa template for backend-worker has targetetRef set to Deployment instead of StatefulSet

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 2.21.1
+version: 2.21.3
 # renovate: docker=docker.io/grafana/tempo
 appVersion: 2.10.5
 kubeVersion: "^1.25.0-0"

--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 2.21.3
+version: 2.21.2
 # renovate: docker=docker.io/grafana/tempo
 appVersion: 2.10.5
 kubeVersion: "^1.25.0-0"

--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 2.21.2
+version: 2.21.3
 # renovate: docker=docker.io/grafana/tempo
 appVersion: 2.10.5
 kubeVersion: "^1.25.0-0"

--- a/charts/tempo-distributed/templates/backend-worker/hpa.yaml
+++ b/charts/tempo-distributed/templates/backend-worker/hpa.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
-    kind: Deployment
+    kind: StatefulSet
     name: {{ include "tempo.resourceName" (dict "ctx" . "component" "backend-worker") }}
   minReplicas: {{ .Values.backendWorker.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.backendWorker.autoscaling.maxReplicas }}

--- a/charts/tempo-distributed/tests/backend-worker/hpa_test.yaml
+++ b/charts/tempo-distributed/tests/backend-worker/hpa_test.yaml
@@ -1,0 +1,96 @@
+# $schema: https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json
+suite: backend-worker HorizontalPodAutoscaler
+templates:
+  - backend-worker/hpa.yaml
+
+tests:
+  - it: HPA is not rendered by default (autoscaling disabled)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: HPA is rendered when autoscaling and hpa enabled, with autoscaling/v2 shape
+    set:
+      backendScheduler.enabled: true
+      backendWorker.autoscaling.enabled: true
+      backendWorker.autoscaling.hpa.enabled: true
+      backendWorker.autoscaling.hpa.targetCPUUtilizationPercentage: 60
+      backendWorker.autoscaling.hpa.targetMemoryUtilizationPercentage: 70
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: apiVersion
+          value: autoscaling/v2
+      - equal:
+          path: kind
+          value: HorizontalPodAutoscaler
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-tempo-backend-worker
+      - equal:
+          path: spec.scaleTargetRef
+          value:
+            apiVersion: apps/v1
+            kind: StatefulSet
+            name: RELEASE-NAME-tempo-backend-worker
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 60
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: memory
+              target:
+                type: Utilization
+                averageUtilization: 70
+      # Regression guard: ensure the legacy v2beta1 field shape is not used
+      - notContains:
+          path: spec.metrics
+          content:
+            targetAverageUtilization: 60
+
+  - it: HPA renders min/max replicas
+    set:
+      backendScheduler.enabled: true
+      backendWorker.autoscaling.enabled: true
+      backendWorker.autoscaling.hpa.enabled: true
+      backendWorker.autoscaling.minReplicas: 2
+      backendWorker.autoscaling.maxReplicas: 10
+    asserts:
+      - equal:
+          path: spec.minReplicas
+          value: 2
+      - equal:
+          path: spec.maxReplicas
+          value: 10
+
+  - it: HPA renders behavior block when set
+    set:
+      backendScheduler.enabled: true
+      backendWorker.autoscaling.enabled: true
+      backendWorker.autoscaling.hpa.enabled: true
+      backendWorker.autoscaling.hpa.behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 300
+    asserts:
+      - equal:
+          path: spec.behavior.scaleDown.stabilizationWindowSeconds
+          value: 300
+
+  - it: HPA is not rendered when backendScheduler is disabled
+    set:
+      backendWorker.autoscaling.enabled: true
+      backendWorker.autoscaling.hpa.enabled: true
+      backendScheduler.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
<!--
Thank you for contributing to grafana-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/grafana-community/helm-charts/blob/main/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them (see CONTRIBUTING.md).
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.  Please check the results.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Fix: hpa template for backend-worker has targetetRef set to Deployment instead of StatefulSet

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
