### PR TITLE
[tempo-distributed] add unhealthyPodEvictionPolicy support to PodDisruptionBudget

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 2.22.1
+version: 2.23.0
 # renovate: docker=docker.io/grafana/tempo
 appVersion: 2.10.5
 kubeVersion: "^1.25.0-0"

--- a/charts/tempo-distributed/templates/compactor/poddisruptionbudget-compactor.yaml
+++ b/charts/tempo-distributed/templates/compactor/poddisruptionbudget-compactor.yaml
@@ -12,4 +12,7 @@ spec:
     matchLabels:
       {{- include "tempo.selectorLabels" $dict | nindent 6 }}
   maxUnavailable: {{ .Values.compactor.maxUnavailable }}
+  {{- with .Values.compactor.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/distributor/poddisruptionbudget-distributor.yaml
+++ b/charts/tempo-distributed/templates/distributor/poddisruptionbudget-distributor.yaml
@@ -12,4 +12,7 @@ spec:
     matchLabels:
       {{- include "tempo.selectorLabels" $dict | nindent 6 }}
   maxUnavailable: {{ .Values.distributor.maxUnavailable }}
+  {{- with .Values.distributor.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/gateway/poddisruptionbudget-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/poddisruptionbudget-gateway.yaml
@@ -12,4 +12,7 @@ spec:
     matchLabels:
       {{- include "tempo.selectorLabels" $dict | nindent 6 }}
   maxUnavailable: {{ .Values.gateway.maxUnavailable }}
+  {{- with .Values.gateway.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/ingester/poddisruptionbudget-ingester.yaml
+++ b/charts/tempo-distributed/templates/ingester/poddisruptionbudget-ingester.yaml
@@ -12,4 +12,7 @@ spec:
     matchLabels:
       {{- include "tempo.selectorLabels" $dict | nindent 6 }}
   maxUnavailable: {{ default (sub (.Values.ingester.replicas) (add (div .Values.ingester.config.replication_factor 2) 1)) .Values.ingester.maxUnavailable }}
+  {{- with .Values.ingester.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/memcached/poddisruptionbudget-memcached.yaml
+++ b/charts/tempo-distributed/templates/memcached/poddisruptionbudget-memcached.yaml
@@ -12,4 +12,7 @@ spec:
     matchLabels:
       {{- include "tempo.selectorLabels" $dict | nindent 6 }}
   maxUnavailable: {{ .Values.memcached.maxUnavailable }}
+  {{- with .Values.memcached.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/metrics-generator/poddisruptionbudget-metrics-generator.yaml
+++ b/charts/tempo-distributed/templates/metrics-generator/poddisruptionbudget-metrics-generator.yaml
@@ -13,5 +13,8 @@ spec:
     matchLabels:
       {{- include "tempo.selectorLabels" $dict | nindent 6 }}
   maxUnavailable: {{ .Values.metricsGenerator.maxUnavailable }}
+  {{- with .Values.metricsGenerator.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/querier/poddisruptionbudget-querier.yaml
+++ b/charts/tempo-distributed/templates/querier/poddisruptionbudget-querier.yaml
@@ -12,4 +12,7 @@ spec:
     matchLabels:
       {{- include "tempo.selectorLabels" $dict | nindent 6 }}
   maxUnavailable: {{ .Values.querier.maxUnavailable }}
+  {{- with .Values.querier.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/query-frontend/poddisruptionbudget-query-frontend.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/poddisruptionbudget-query-frontend.yaml
@@ -12,4 +12,7 @@ spec:
     matchLabels:
       {{- include "tempo.selectorLabels" $dict | nindent 6 }}
   maxUnavailable: {{ .Values.queryFrontend.maxUnavailable }}
+  {{- with .Values.queryFrontend.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -274,6 +274,8 @@ ingester:
   podDisruptionBudget:
     # -- Enable PodDisruptionBudget for ingester
     enabled: true
+    # -- Set unhealthyPodEvictionPolicy for the ingester PodDisruptionBudget. Requires policy/v1.
+    unhealthyPodEvictionPolicy: ""
   # -- Override Pod Disruption Budget maxUnavailable with a static value
   # maxUnavailable: 1
   # -- Node selector for ingester pods
@@ -483,6 +485,8 @@ metricsGenerator:
   podDisruptionBudget:
     # -- Enable PodDisruptionBudget for metrics-generator
     enabled: true
+    # -- Set unhealthyPodEvictionPolicy for the metrics-generator PodDisruptionBudget. Requires policy/v1.
+    unhealthyPodEvictionPolicy: ""
   # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: 1
   # -- Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing/terminating
@@ -701,6 +705,8 @@ distributor:
   podDisruptionBudget:
     # -- Enable PodDisruptionBudget for distributor
     enabled: true
+    # -- Set unhealthyPodEvictionPolicy for the distributor PodDisruptionBudget. Requires policy/v1.
+    unhealthyPodEvictionPolicy: ""
   # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: 1
   # -- Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing/terminating
@@ -1269,6 +1275,8 @@ compactor:
   podDisruptionBudget:
     # -- Enable PodDisruptionBudget for compactor
     enabled: true
+    # -- Set unhealthyPodEvictionPolicy for the compactor PodDisruptionBudget. Requires policy/v1.
+    unhealthyPodEvictionPolicy: ""
   # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: 1
   # -- Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing/terminating
@@ -1397,6 +1405,8 @@ querier:
   podDisruptionBudget:
     # -- Enable PodDisruptionBudget for querier
     enabled: true
+    # -- Set unhealthyPodEvictionPolicy for the querier PodDisruptionBudget. Requires policy/v1.
+    unhealthyPodEvictionPolicy: ""
   # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: 1
   # -- Max Surge for querier pods
@@ -1665,6 +1675,8 @@ queryFrontend:
   podDisruptionBudget:
     # -- Enable PodDisruptionBudget for query-frontend
     enabled: true
+    # -- Set unhealthyPodEvictionPolicy for the query-frontend PodDisruptionBudget. Requires policy/v1.
+    unhealthyPodEvictionPolicy: ""
   # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: 1
   # -- Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing/terminating
@@ -2457,6 +2469,8 @@ memcached:
   podDisruptionBudget:
     # -- Enable PodDisruptionBudget for memcached
     enabled: true
+    # -- Set unhealthyPodEvictionPolicy for the memcached PodDisruptionBudget. Requires policy/v1.
+    unhealthyPodEvictionPolicy: ""
   # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: 1
   # -- Init containers for the memcached pod
@@ -3019,6 +3033,8 @@ gateway:
   podDisruptionBudget:
     # -- Enable PodDisruptionBudget for gateway
     enabled: true
+    # -- Set unhealthyPodEvictionPolicy for the gateway PodDisruptionBudget. Requires policy/v1.
+    unhealthyPodEvictionPolicy: ""
   # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: 1
   # -- Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing/terminating


### PR DESCRIPTION
## What

Adds optional `unhealthyPodEvictionPolicy` support to the `PodDisruptionBudget` resources for all components in `tempo-distributed`: ingester, distributor, compactor, querier, query-frontend, metrics-generator, memcached, and gateway.

The field is controlled via `<component>.podDisruptionBudget.unhealthyPodEvictionPolicy` in `values.yaml`. It defaults to `""` (empty string), which causes the `{{- with }}` block to be skipped entirely, preserving existing behavior for anyone not setting the field.

```yaml
ingester:
  podDisruptionBudget:
    enabled: true
    unhealthyPodEvictionPolicy: "AlwaysAllow"  # or "IfHealthyBudget"
```

## Why

`unhealthyPodEvictionPolicy` on `policy/v1` PodDisruptionBudgets (GA in Kubernetes 1.26) is required by certain linters (e.g. kube-linter `pdb-unhealthy-pod-eviction-policy` check) and is a useful safety knob when running Tempo components in production clusters with strict eviction policies.

Without this field being configurable via values, users cannot satisfy the check or tune eviction behavior without patching the templates themselves.

## Scope

- 8 PDB templates updated (one per component)
- `values.yaml`: `unhealthyPodEvictionPolicy: ""` added inside each existing `podDisruptionBudget:` block
- Chart version bumped: `2.22.1` → `2.23.0`

Signed-off-by: QuentinBisson <quentin@giantswarm.io>