### PR TITLE
[tempo-distributed] Introduce pod disruption budget template helper

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 2.23.2
+version: 2.23.3
 # renovate: docker=docker.io/grafana/tempo
 appVersion: 2.10.5
 kubeVersion: "^1.25.0-0"

--- a/charts/tempo-distributed/templates/compactor/poddisruptionbudget-compactor.yaml
+++ b/charts/tempo-distributed/templates/compactor/poddisruptionbudget-compactor.yaml
@@ -1,18 +1,3 @@
-{{- if and (not .Values.backendScheduler.enabled) (gt (int .Values.compactor.replicas) 1) .Values.compactor.podDisruptionBudget.enabled }}
-{{ $dict := dict "ctx" . "component" "compactor" "memberlist" true }}
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: {{ include "tempo.resourceName" $dict }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "tempo.labels" $dict | nindent 4 }}
-spec:
-  selector:
-    matchLabels:
-      {{- include "tempo.selectorLabels" $dict | nindent 6 }}
-  maxUnavailable: {{ .Values.compactor.maxUnavailable }}
-  {{- with .Values.compactor.podDisruptionBudget.unhealthyPodEvictionPolicy }}
-  unhealthyPodEvictionPolicy: {{ . }}
-  {{- end }}
+{{- if not .Values.backendScheduler.enabled }}
+{{- include "tempo.lib.pdb" (dict "ctx" $ "component" .Values.compactor "target" "compactor" "memberlist" true) }}
 {{- end }}

--- a/charts/tempo-distributed/templates/lib/pdb.tpl
+++ b/charts/tempo-distributed/templates/lib/pdb.tpl
@@ -23,3 +23,72 @@ spec:
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+PodDisruptionBudget helper
+
+Emits a PDB only when podDisruptionBudget.enabled is true AND the effective
+minimum replica count is greater than 1 (from static replicas, HPA minReplicas,
+or KEDA minReplicas). This avoids creating a PDB that can never be satisfied
+on single-replica or default deployments.
+
+Legacy $component.maxUnavailable field is honoured for back-compatibility.
+New-style settings live under $component.podDisruptionBudget.{maxUnavailable,minAvailable,...}.
+unhealthyPodEvictionPolicy is handled explicitly to avoid rendering an empty string.
+
+Params:
+  ctx        = root context ($)
+  component  = component values block (e.g. .Values.compactor)
+  target     = component name string (e.g. "compactor")
+  memberlist = bool, default false — add app.kubernetes.io/part-of: memberlist to metadata labels
+*/}}
+{{- define "tempo.lib.pdb" -}}
+{{- $ctx := .ctx -}}
+{{- $component := .component -}}
+{{- $target := .target -}}
+{{- $memberlist := kindIs "bool" .memberlist | ternary .memberlist false -}}
+{{- $hpaEnabled := and (dig "autoscaling" "enabled" false $component) (dig "autoscaling" "hpa" "enabled" false $component) -}}
+{{- $kedaEnabled := and (dig "autoscaling" "enabled" false $component) (dig "autoscaling" "keda" "enabled" false $component) -}}
+{{- $replicas := dig "replicas" 1 $component | int -}}
+{{- $minReplicas := dig "autoscaling" "minReplicas" 1 $component | int -}}
+{{- $pdbEnabled := dig "podDisruptionBudget" "enabled" false $component -}}
+{{- if and $pdbEnabled (or
+  (and (not $hpaEnabled) (not $kedaEnabled) (gt $replicas 1))
+  (and $hpaEnabled (gt $minReplicas 1))
+  (and $kedaEnabled (gt $minReplicas 1))
+) -}}
+{{- with $ctx -}}
+{{- $pdb := dict -}}
+{{- if hasKey $component "maxUnavailable" -}}
+{{- if not (kindIs "invalid" $component.maxUnavailable) -}}
+{{- $_ := set $pdb "maxUnavailable" $component.maxUnavailable -}}
+{{- end -}}
+{{- end -}}
+{{- $_ := mergeOverwrite $pdb (omit ($component.podDisruptionBudget | default dict) "enabled" "labels" "annotations" "unhealthyPodEvictionPolicy") -}}
+{{- if (omit $pdb "selector") }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "tempo.resourceName" (dict "ctx" . "component" $target) }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tempo.labels" (dict "ctx" . "component" $target "memberlist" $memberlist) | nindent 4 }}
+    {{- with $component.podDisruptionBudget.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $component.podDisruptionBudget.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- toYaml (omit $pdb "selector") | nindent 2 }}
+  {{- with $component.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "tempo.selectorLabels" (dict "ctx" . "component" $target) | nindent 6 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/tempo-distributed/tests/compactor/pdb_test.yaml
+++ b/charts/tempo-distributed/tests/compactor/pdb_test.yaml
@@ -1,0 +1,128 @@
+# $schema: https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json
+suite: compactor PodDisruptionBudget
+templates:
+  - lib/pdb.tpl
+  - compactor/poddisruptionbudget-compactor.yaml
+set:
+  compactor.podDisruptionBudget.enabled: true
+
+tests:
+  - it: should not render PDB when replicas is 1 (default)
+    template: compactor/poddisruptionbudget-compactor.yaml
+    set:
+      compactor.replicas: 1
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render PDB when replicas > 1
+    template: compactor/poddisruptionbudget-compactor.yaml
+    set:
+      compactor.replicas: 3
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-tempo-compactor
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+
+  - it: should render PDB when HPA enabled with minReplicas > 1
+    template: compactor/poddisruptionbudget-compactor.yaml
+    set:
+      compactor.replicas: 1
+      compactor.autoscaling.enabled: true
+      compactor.autoscaling.hpa.enabled: true
+      compactor.autoscaling.minReplicas: 2
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+
+  - it: should not render PDB when HPA enabled with minReplicas = 1
+    template: compactor/poddisruptionbudget-compactor.yaml
+    set:
+      compactor.replicas: 1
+      compactor.autoscaling.enabled: true
+      compactor.autoscaling.hpa.enabled: true
+      compactor.autoscaling.minReplicas: 1
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render PDB when KEDA enabled with minReplicas > 1
+    template: compactor/poddisruptionbudget-compactor.yaml
+    set:
+      compactor.replicas: 1
+      compactor.autoscaling.enabled: true
+      compactor.autoscaling.keda.enabled: true
+      compactor.autoscaling.minReplicas: 2
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+
+  - it: should not render PDB when KEDA enabled with minReplicas = 1
+    template: compactor/poddisruptionbudget-compactor.yaml
+    set:
+      compactor.replicas: 1
+      compactor.autoscaling.enabled: true
+      compactor.autoscaling.keda.enabled: true
+      compactor.autoscaling.minReplicas: 1
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render minAvailable when set via podDisruptionBudget
+    template: compactor/poddisruptionbudget-compactor.yaml
+    set:
+      compactor.replicas: 3
+      compactor.podDisruptionBudget.minAvailable: 2
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.minAvailable
+          value: 2
+
+  - it: should not render PDB when backendScheduler is enabled
+    template: compactor/poddisruptionbudget-compactor.yaml
+    set:
+      compactor.replicas: 3
+      backendScheduler.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render PDB when podDisruptionBudget is disabled
+    template: compactor/poddisruptionbudget-compactor.yaml
+    set:
+      compactor.replicas: 3
+      compactor.podDisruptionBudget.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should include memberlist label
+    template: compactor/poddisruptionbudget-compactor.yaml
+    set:
+      compactor.replicas: 3
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/part-of"]
+          value: memberlist
+
+  - it: should include correct selector labels
+    template: compactor/poddisruptionbudget-compactor.yaml
+    set:
+      compactor.replicas: 3
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: compactor


### PR DESCRIPTION
Adds `tempo.lib.pdb` to `templates/lib/pdb.tpl`, a shared named template that emits a `PodDisruptionBudget` only when it can be satisfied:

- `podDisruptionBudget.enabled: true` is set on the component, AND
- effective minimum replica count is greater than 1: static `replicas`, HPA `autoscaling.minReplicas`, or KEDA `autoscaling.minReplicas`

Supports the legacy `$component.maxUnavailable` field for back-compat (compactor, ingester, distributor all set it directly). New-style knobs live under `$component.podDisruptionBudget.{minAvailable,maxUnavailable,...}`. The legacy value is applied first; `podDisruptionBudget.*` fields override it via `mergeOverwrite`.

`tempo.lib.podDisruptionBudget` (the older helper used by `admin-api` and `enterprise-gateway`) is left untouched in the same file.

Migrates `templates/compactor/poddisruptionbudget-compactor.yaml` onto the helper.

**Non-breaking:** `helm template` default output is identical (compactor defaults to `replicas: 1`, which suppresses the PDB both before and after). With `replicas > 1`, spec field order changes (`maxUnavailable` renders before `selector`); map key ordering is semantically insignificant to Kubernetes.

Part of the tempo-distributed shared-template migration series (follows `_service.tpl` and `_serviceaccount.tpl`).