### PR TITLE
[tempo-distributed] Introduce HPA template helper

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 2.23.1
+version: 2.23.2
 # renovate: docker=docker.io/grafana/tempo
 appVersion: 2.10.5
 kubeVersion: "^1.25.0-0"

--- a/charts/tempo-distributed/templates/compactor/hpa.yaml
+++ b/charts/tempo-distributed/templates/compactor/hpa.yaml
@@ -1,37 +1,3 @@
-{{- if and (not .Values.backendScheduler.enabled) .Values.compactor.autoscaling.enabled .Values.compactor.autoscaling.hpa.enabled }}
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: {{ include "tempo.resourceName" (dict "ctx" . "component" "compactor") }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "tempo.labels" (dict "ctx" . "component" "compactor") | nindent 4 }}
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: {{ include "tempo.resourceName" (dict "ctx" . "component" "compactor") }}
-  minReplicas: {{ .Values.compactor.autoscaling.minReplicas }}
-  maxReplicas: {{ .Values.compactor.autoscaling.maxReplicas }}
-  {{- with .Values.compactor.autoscaling.hpa.behavior }}
-  behavior:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-  metrics:
-  {{- with .Values.compactor.autoscaling.hpa.targetMemoryUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: {{ . }}
-  {{- end }}
-  {{- with .Values.compactor.autoscaling.hpa.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: {{ . }}
-  {{- end }}
+{{- if not .Values.backendScheduler.enabled }}
+{{- include "tempo.lib.hpa" (dict "ctx" $ "component" .Values.compactor "target" "compactor") }}
 {{- end }}

--- a/charts/tempo-distributed/templates/lib/hpa.tpl
+++ b/charts/tempo-distributed/templates/lib/hpa.tpl
@@ -1,0 +1,62 @@
+{{/*
+HPA helper
+
+Emits an HorizontalPodAutoscaler (autoscaling/v2) when autoscaling.enabled and
+autoscaling.hpa.enabled are both true on the component.
+
+Metrics are read from $component.autoscaling.hpa.targetCPUUtilizationPercentage
+and $component.autoscaling.hpa.targetMemoryUtilizationPercentage. Neither is
+emitted when its value is null/zero.
+
+Params:
+  ctx       = root context ($)
+  component = component values block (e.g. .Values.compactor)
+  target    = component name string (e.g. "compactor")
+  kind      = scaleTargetRef kind, default "Deployment"
+*/}}
+{{- define "tempo.lib.hpa" -}}
+{{- $ctx := .ctx -}}
+{{- $component := .component -}}
+{{- $target := .target -}}
+{{- $kind := .kind | default "Deployment" -}}
+{{- $hpaEnabled := and (dig "autoscaling" "enabled" false $component) (dig "autoscaling" "hpa" "enabled" false $component) -}}
+{{- if $hpaEnabled -}}
+{{- with $ctx -}}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "tempo.resourceName" (dict "ctx" . "component" $target) }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tempo.labels" (dict "ctx" . "component" $target) | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: {{ $kind }}
+    name: {{ include "tempo.resourceName" (dict "ctx" . "component" $target) }}
+  minReplicas: {{ $component.autoscaling.minReplicas }}
+  maxReplicas: {{ $component.autoscaling.maxReplicas }}
+  {{- with $component.autoscaling.hpa.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  metrics:
+  {{- with $component.autoscaling.hpa.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+  {{- end }}
+  {{- with $component.autoscaling.hpa.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/tempo-distributed/tests/compactor/hpa_test.yaml
+++ b/charts/tempo-distributed/tests/compactor/hpa_test.yaml
@@ -1,15 +1,27 @@
 # $schema: https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json
 suite: compactor HorizontalPodAutoscaler
 templates:
+  - lib/hpa.tpl
   - compactor/hpa.yaml
 
 tests:
   - it: HPA is not rendered by default (autoscaling disabled)
+    template: compactor/hpa.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: HPA is not rendered when autoscaling.enabled but hpa.enabled is false
+    template: compactor/hpa.yaml
+    set:
+      compactor.autoscaling.enabled: true
+      compactor.autoscaling.hpa.enabled: false
     asserts:
       - hasDocuments:
           count: 0
 
   - it: HPA is rendered when autoscaling and hpa enabled, with autoscaling/v2 shape
+    template: compactor/hpa.yaml
     set:
       compactor.autoscaling.enabled: true
       compactor.autoscaling.hpa.enabled: true
@@ -51,13 +63,60 @@ tests:
               target:
                 type: Utilization
                 averageUtilization: 70
-      # Regression guard: ensure the legacy v2beta1 field shape is not used
       - notContains:
           path: spec.metrics
           content:
             targetAverageUtilization: 60
 
+  - it: HPA renders CPU metric from hpa.targetCPUUtilizationPercentage
+    template: compactor/hpa.yaml
+    set:
+      compactor.autoscaling.enabled: true
+      compactor.autoscaling.hpa.enabled: true
+      compactor.autoscaling.hpa.targetCPUUtilizationPercentage: 80
+    asserts:
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 80
+
+  - it: HPA renders memory metric from hpa.targetMemoryUtilizationPercentage
+    template: compactor/hpa.yaml
+    set:
+      compactor.autoscaling.enabled: true
+      compactor.autoscaling.hpa.enabled: true
+      compactor.autoscaling.hpa.targetCPUUtilizationPercentage: null
+      compactor.autoscaling.hpa.targetMemoryUtilizationPercentage: 75
+    asserts:
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: memory
+              target:
+                type: Utilization
+                averageUtilization: 75
+
+  - it: HPA renders both CPU and memory metrics
+    template: compactor/hpa.yaml
+    set:
+      compactor.autoscaling.enabled: true
+      compactor.autoscaling.hpa.enabled: true
+      compactor.autoscaling.hpa.targetCPUUtilizationPercentage: 80
+      compactor.autoscaling.hpa.targetMemoryUtilizationPercentage: 75
+    asserts:
+      - lengthEqual:
+          path: spec.metrics
+          count: 2
+
   - it: HPA renders min/max replicas
+    template: compactor/hpa.yaml
     set:
       compactor.autoscaling.enabled: true
       compactor.autoscaling.hpa.enabled: true
@@ -72,6 +131,7 @@ tests:
           value: 10
 
   - it: HPA renders behavior block when set
+    template: compactor/hpa.yaml
     set:
       compactor.autoscaling.enabled: true
       compactor.autoscaling.hpa.enabled: true
@@ -83,7 +143,18 @@ tests:
           path: spec.behavior.scaleDown.stabilizationWindowSeconds
           value: 300
 
+  - it: HPA does not render behavior block when empty
+    template: compactor/hpa.yaml
+    set:
+      compactor.autoscaling.enabled: true
+      compactor.autoscaling.hpa.enabled: true
+      compactor.autoscaling.hpa.behavior: {}
+    asserts:
+      - notExists:
+          path: spec.behavior
+
   - it: HPA is not rendered when backendScheduler is enabled
+    template: compactor/hpa.yaml
     set:
       compactor.autoscaling.enabled: true
       compactor.autoscaling.hpa.enabled: true


### PR DESCRIPTION
Adds `tempo.lib.hpa` at `templates/lib/hpa.tpl`, a shared named template that emits an `autoscaling/v2` `HorizontalPodAutoscaler` when `autoscaling.enabled` and `autoscaling.hpa.enabled` are both true on the component.

Metrics are read from `autoscaling.hpa.targetCPUUtilizationPercentage` and `autoscaling.hpa.targetMemoryUtilizationPercentage`; neither field is emitted when null. The `behavior` block is rendered when non-empty. The `kind` parameter (default `Deployment`) lets StatefulSet consumers reuse the same helper.

This targets the compactor/backend-scheduler-era autoscaling structure (`autoscaling.hpa.*`) rather than the older flat structure used by distributor (`autoscaling.*`). Those components will be migrated in a follow-up with values restructuring.

Migrates `templates/compactor/hpa.yaml` onto the helper. The `backendScheduler.enabled` gate is preserved in the caller file.

**Non-breaking:** `helm template` default output is identical (`autoscaling.enabled: false` by default).

Part of the tempo-distributed shared-template migration series (follows service, serviceaccount, and pdb helpers).