### PR TITLE
[tempo-distributed] Expand KEDA ScaledObject test coverage

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 2.23.3
+version: 2.23.4
 # renovate: docker=docker.io/grafana/tempo
 appVersion: 2.10.5
 kubeVersion: "^1.25.0-0"

--- a/charts/tempo-distributed/tests/compactor/scaledobject_test.yaml
+++ b/charts/tempo-distributed/tests/compactor/scaledobject_test.yaml
@@ -11,6 +11,15 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: ScaledObject is not rendered when autoscaling.enabled but keda.enabled is false
+    template: compactor/keda-scaledObject.yaml
+    set:
+      compactor.autoscaling.enabled: true
+      compactor.autoscaling.keda.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: ScaledObject is rendered when autoscaling and keda are enabled and has triggers
     template: compactor/keda-scaledObject.yaml
     set:
@@ -73,6 +82,40 @@ tests:
           path: spec.maxReplicaCount
           value: 10
 
+  - it: ScaledObject renders pollingInterval when set
+    template: compactor/keda-scaledObject.yaml
+    set:
+      compactor.autoscaling.enabled: true
+      compactor.autoscaling.keda.enabled: true
+      compactor.autoscaling.keda.pollingInterval: 30
+      compactor.autoscaling.keda.triggers:
+        - type: prometheus
+          metadata:
+            serverAddress: http://prometheus:9090
+            threshold: "250"
+            query: sum(rate(http_requests_total[1m]))
+    asserts:
+      - equal:
+          path: spec.pollingInterval
+          value: 30
+
+  - it: ScaledObject renders cooldownPeriod when set
+    template: compactor/keda-scaledObject.yaml
+    set:
+      compactor.autoscaling.enabled: true
+      compactor.autoscaling.keda.enabled: true
+      compactor.autoscaling.keda.cooldownPeriod: 300
+      compactor.autoscaling.keda.triggers:
+        - type: prometheus
+          metadata:
+            serverAddress: http://prometheus:9090
+            threshold: "250"
+            query: sum(rate(http_requests_total[1m]))
+    asserts:
+      - equal:
+          path: spec.cooldownPeriod
+          value: 300
+
   - it: ScaledObject renders behavior block when set
     template: compactor/keda-scaledObject.yaml
     set:
@@ -120,11 +163,27 @@ tests:
           path: spec.fallback.behavior
           value: currentReplicasIfHigher
 
-  - it: ScaledObject is not rendered when backendScheduler is enabled
+  - it: ScaledObject fails when both HPA and KEDA are enabled
     template: compactor/keda-scaledObject.yaml
     set:
       compactor.autoscaling.enabled: true
       compactor.autoscaling.hpa.enabled: true
+      compactor.autoscaling.keda.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: Cannot enable both HPA and Keda based autoscaling for compactor at the same time.
+
+  - it: ScaledObject is not rendered when backendScheduler is enabled
+    template: compactor/keda-scaledObject.yaml
+    set:
+      compactor.autoscaling.enabled: true
+      compactor.autoscaling.keda.enabled: true
+      compactor.autoscaling.keda.triggers:
+        - type: prometheus
+          metadata:
+            serverAddress: http://prometheus:9090
+            threshold: "250"
+            query: sum(rate(http_requests_total[1m]))
       backendScheduler.enabled: true
     asserts:
       - hasDocuments:


### PR DESCRIPTION
Expands the unit-test suite for the existing `tempo.lib.keda` and `tempo.lib.validateAutoscaling` helpers in `templates/lib/keda.tpl`.

`tests/compactor/scaledobject_test.yaml` grows from 6 tests to 10, adding:

- `keda.enabled=false` with `autoscaling.enabled=true` renders 0 documents
- `pollingInterval` renders on the ScaledObject spec
- `cooldownPeriod` renders on the ScaledObject spec
- both HPA and KEDA enabled triggers `tempo.lib.validateAutoscaling` failure with the expected error message

No template files changed. Non-breaking.

Part of the tempo-distributed shared-template migration series (follows service, serviceaccount, pdb, and hpa helpers).