### PR TITLE
[tempo-distributed] Introduce workload template helper

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 2.23.0
+version: 2.23.1
 # renovate: docker=docker.io/grafana/tempo
 appVersion: 2.10.5
 kubeVersion: "^1.25.0-0"

--- a/charts/tempo-distributed/templates/compactor/deployment-compactor.yaml
+++ b/charts/tempo-distributed/templates/compactor/deployment-compactor.yaml
@@ -1,29 +1,3 @@
-{{- if and (not .Values.backendScheduler.enabled) }}
-{{ $dict := dict "ctx" . "component" "compactor" "memberlist" true }}
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: {{ template "tempo.resourceName" $dict }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "tempo.labels" $dict | nindent 4 }}
-  {{- with .Values.compactor.annotations }}
-  annotations:
-  {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  minReadySeconds: {{ .Values.compactor.minReadySeconds }}
-{{- if not .Values.compactor.autoscaling.enabled }}
-  replicas: {{ .Values.compactor.replicas }}
-{{- end }}
-  revisionHistoryLimit: {{ .Values.tempo.revisionHistoryLimit }}
-  selector:
-    matchLabels:
-      {{- include "tempo.selectorLabels" $dict | nindent 6 }}
-{{- with .Values.compactor.strategy }}
-  strategy:
-{{- toYaml . | nindent 4 }}
-{{- end }}
-  template:
-    {{- include "tempo.podTemplate" (dict "ctx" $ "component" .Values.compactor "target" "compactor") | nindent 4 }}
+{{- if not .Values.backendScheduler.enabled }}
+{{- include "tempo.lib.workload" (dict "ctx" $ "component" .Values.compactor "target" "compactor" "memberlist" true) }}
 {{- end }}

--- a/charts/tempo-distributed/templates/lib/workload.tpl
+++ b/charts/tempo-distributed/templates/lib/workload.tpl
@@ -1,0 +1,68 @@
+{{/*
+Workload helper
+
+Emits a Deployment or StatefulSet for a standard Tempo component. The pod
+template is delegated to tempo.podTemplate.
+
+For Deployments: renders minReadySeconds and the rolling-update strategy from
+$component.strategy. Replicas are suppressed when autoscaling.enabled is true.
+
+For StatefulSets: renders serviceName ($target), podManagementPolicy: Parallel,
+and updateStrategy from $component.statefulStrategy.
+
+Params:
+  ctx        = root context ($)
+  component  = component values block (e.g. .Values.compactor)
+  target     = component name string (e.g. "compactor")
+  kind       = "Deployment" (default) or "StatefulSet"
+  memberlist = bool, default false — add app.kubernetes.io/part-of: memberlist
+*/}}
+{{- define "tempo.lib.workload" -}}
+{{- $ctx := .ctx -}}
+{{- $component := .component -}}
+{{- $target := .target -}}
+{{- $kind := .kind | default "Deployment" -}}
+{{- $memberlist := kindIs "bool" .memberlist | ternary .memberlist false -}}
+{{- with $ctx -}}
+apiVersion: apps/v1
+kind: {{ $kind }}
+metadata:
+  name: {{ include "tempo.resourceName" (dict "ctx" . "component" $target) }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tempo.labels" (dict "ctx" . "component" $target "memberlist" $memberlist) | nindent 4 }}
+    {{- with $component.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $component.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if eq $kind "Deployment" }}
+  minReadySeconds: {{ $component.minReadySeconds }}
+  {{- end }}
+  {{- if not (dig "autoscaling" "enabled" false $component) }}
+  replicas: {{ $component.replicas }}
+  {{- end }}
+  revisionHistoryLimit: {{ .Values.tempo.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "tempo.selectorLabels" (dict "ctx" . "component" $target) | nindent 6 }}
+  {{- if eq $kind "StatefulSet" }}
+  podManagementPolicy: Parallel
+  serviceName: {{ $target }}
+  {{- with $component.statefulStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- else }}
+  {{- with $component.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
+  template:
+    {{- include "tempo.podTemplate" (dict "ctx" . "component" $component "target" $target) | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/tempo-distributed/tests/compactor/deployment_test.yaml
+++ b/charts/tempo-distributed/tests/compactor/deployment_test.yaml
@@ -1,6 +1,7 @@
 # $schema: https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json
 suite: compactor Deployment
 templates:
+  - lib/workload.tpl
   - compactor/deployment-compactor.yaml
   - configmap-tempo.yaml
 
@@ -329,3 +330,61 @@ tests:
     asserts:
       - notExists:
           path: spec.template.spec.dnsConfig
+
+  - it: should not render when backendScheduler is enabled
+    template: compactor/deployment-compactor.yaml
+    set:
+      backendScheduler.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders memberlist label on Deployment metadata
+    template: compactor/deployment-compactor.yaml
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/part-of"]
+          value: memberlist
+
+  - it: renders minReadySeconds from compactor.minReadySeconds
+    template: compactor/deployment-compactor.yaml
+    set:
+      compactor.minReadySeconds: 20
+    asserts:
+      - equal:
+          path: spec.minReadySeconds
+          value: 20
+
+  - it: renders revisionHistoryLimit from tempo.revisionHistoryLimit
+    template: compactor/deployment-compactor.yaml
+    set:
+      tempo.revisionHistoryLimit: 5
+    asserts:
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 5
+
+  - it: renders strategy from compactor.strategy
+    template: compactor/deployment-compactor.yaml
+    set:
+      compactor.strategy:
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 0
+    asserts:
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 1
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 0
+
+  - it: renders Deployment annotations from compactor.annotations
+    template: compactor/deployment-compactor.yaml
+    set:
+      compactor.annotations:
+        custom-annotation: value
+    asserts:
+      - equal:
+          path: metadata.annotations["custom-annotation"]
+          value: value


### PR DESCRIPTION
Adds `tempo.lib.workload` at `templates/lib/workload.tpl`, a shared named template that emits a `Deployment` or `StatefulSet` for a standard Tempo component. The pod template is delegated to the existing `tempo.podTemplate` helper.

**Deployment path:** renders `minReadySeconds`, `revisionHistoryLimit`, selector, rolling `strategy` from `$component.strategy`. `replicas` is suppressed when `autoscaling.enabled` is true.

**StatefulSet path:** renders `serviceName` (`$target`), `podManagementPolicy: Parallel`, `updateStrategy` from `$component.statefulStrategy`.

Both paths forward optional `$component.labels` and `$component.annotations` to the metadata block. The `memberlist` param adds `app.kubernetes.io/part-of: memberlist` to metadata labels.

Migrates `templates/compactor/deployment-compactor.yaml` onto the helper. The `backendScheduler.enabled` gate is preserved in the caller file. Adds six workload-level test cases to the existing compactor deployment suite: `minReadySeconds`, `strategy`, `revisionHistoryLimit`, memberlist label, annotations, `backendScheduler` gate.

**Non-breaking:** `helm template` before/after diff is empty.

This completes the compactor migration — every compactor template now delegates to a shared named helper.

Part of the tempo-distributed shared-template migration series (follows service, serviceaccount, pdb, and hpa helpers).