### PR TITLE
[loki] Bind component service accounts to OpenShift SCC

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.2
-version: 17.1.3
+version: 17.1.4
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/templates/_helpers.tpl
+++ b/charts/loki/templates/_helpers.tpl
@@ -185,6 +185,53 @@ Input parameters:
 {{- end -}}
 
 {{/*
+Create the list of ServiceAccount subjects that should be allowed to use the Loki OpenShift SCC.
+
+Input parameters:
+  . = root context
+*/}}
+{{- define "loki.sccServiceAccountSubjects" -}}
+{{- $ctx := . -}}
+{{- $isScalable := eq (include "loki.deployment.isScalable" $ctx) "true" -}}
+{{- $isDistributed := eq (include "loki.deployment.isDistributed" $ctx) "true" -}}
+{{- $seen := dict -}}
+{{- $subjects := list -}}
+{{- $serviceAccounts := list
+  (dict "target" "" "component" .Values "enabled" true)
+  (dict "target" "gateway" "component" .Values.gateway "enabled" .Values.gateway.enabled)
+  (dict "target" "memcached" "component" .Values.memcached "enabled" (or .Values.memcached.enabled .Values.chunksCache.enabled))
+  (dict "target" "canary" "component" .Values.lokiCanary "enabled" .Values.lokiCanary.enabled)
+  (dict "target" "write" "component" .Values.write "enabled" (and $isScalable .Values.write.enabled))
+  (dict "target" "read" "component" .Values.read "enabled" (and $isScalable .Values.read.enabled))
+  (dict "target" "backend" "component" .Values.backend "enabled" (and $isScalable .Values.backend.enabled))
+  (dict "target" "ingester" "component" .Values.ingester "enabled" (and $isDistributed .Values.ingester.enabled))
+  (dict "target" "distributor" "component" .Values.distributor "enabled" (and $isDistributed .Values.distributor.enabled))
+  (dict "target" "querier" "component" .Values.querier "enabled" (and $isDistributed .Values.querier.enabled))
+  (dict "target" "query-frontend" "component" .Values.queryFrontend "enabled" (and $isDistributed .Values.queryFrontend.enabled))
+  (dict "target" "query-scheduler" "component" .Values.queryScheduler "enabled" (and $isDistributed .Values.queryScheduler.enabled))
+  (dict "target" "index-gateway" "component" .Values.indexGateway "enabled" (and $isDistributed .Values.indexGateway.enabled))
+  (dict "target" "compactor" "component" .Values.compactor "enabled" (and $isDistributed .Values.compactor.enabled))
+  (dict "target" "ruler" "component" .Values.ruler "enabled" (and $isDistributed .Values.ruler.enabled))
+  (dict "target" "overrides-exporter" "component" .Values.overridesExporter "enabled" (and $isDistributed .Values.overridesExporter.enabled))
+  (dict "target" "pattern-ingester" "component" .Values.patternIngester "enabled" (and $isDistributed .Values.patternIngester.enabled))
+  (dict "target" "bloom-planner" "component" .Values.bloomPlanner "enabled" (and $isDistributed .Values.bloomPlanner.enabled))
+  (dict "target" "bloom-builder" "component" .Values.bloomBuilder "enabled" (and $isDistributed .Values.bloomBuilder.enabled))
+  (dict "target" "bloom-gateway" "component" .Values.bloomGateway "enabled" (and $isDistributed .Values.bloomGateway.enabled))
+  (dict "target" "table-manager" "component" .Values.tableManager "enabled" .Values.tableManager.enabled)
+-}}
+{{- range $serviceAccounts -}}
+{{- if .enabled -}}
+{{- $name := include "loki.serviceAccountName" (dict "ctx" $ctx "component" .component "target" .target) -}}
+{{- if not (hasKey $seen $name) -}}
+{{- $_ := set $seen $name true -}}
+{{- $subjects = append $subjects (dict "kind" "ServiceAccount" "name" $name "namespace" (include "loki.namespace" $ctx)) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- toYaml $subjects -}}
+{{- end -}}
+
+{{/*
 Base template for building docker image reference
 Always prepends the registry when one is configured (global or service-level).
 It also respects `.digest` as well as `.sha` (deprecated).

--- a/charts/loki/templates/rolebinding.yaml
+++ b/charts/loki/templates/rolebinding.yaml
@@ -11,7 +11,11 @@ roleRef:
   kind: Role
   name: {{ include "loki.name" . }}
 subjects:
+{{- if .Values.rbac.sccEnabled }}
+  {{- include "loki.sccServiceAccountSubjects" . | nindent 2 }}
+{{- else }}
   - kind: ServiceAccount
     name: {{ include "loki.serviceAccountName" (dict "ctx" . "component" .Values "target" "") }}
     namespace: {{ include "loki.namespace" $ }}
+{{- end }}
 {{- end }}

--- a/charts/loki/tests/rolebinding_test.yaml
+++ b/charts/loki/tests/rolebinding_test.yaml
@@ -66,6 +66,53 @@ tests:
           path: subjects[0].name
           value: my-custom-sa
 
+  - it: includes component service accounts when sccEnabled=true
+    set:
+      rbac.sccEnabled: true
+    asserts:
+      - contains:
+          path: subjects
+          content:
+            kind: ServiceAccount
+            name: RELEASE-NAME-loki
+            namespace: NAMESPACE
+          any: true
+      - contains:
+          path: subjects
+          content:
+            kind: ServiceAccount
+            name: RELEASE-NAME-loki-gateway
+            namespace: NAMESPACE
+          any: true
+      - contains:
+          path: subjects
+          content:
+            kind: ServiceAccount
+            name: RELEASE-NAME-loki-memcached
+            namespace: NAMESPACE
+          any: true
+
+  - it: includes custom component service account names when sccEnabled=true
+    set:
+      rbac.sccEnabled: true
+      gateway.serviceAccount.name: custom-gateway-sa
+      memcached.serviceAccount.name: custom-memcached-sa
+    asserts:
+      - contains:
+          path: subjects
+          content:
+            kind: ServiceAccount
+            name: custom-gateway-sa
+            namespace: NAMESPACE
+          any: true
+      - contains:
+          path: subjects
+          content:
+            kind: ServiceAccount
+            name: custom-memcached-sa
+            namespace: NAMESPACE
+          any: true
+
   - it: roleRef references the loki role by name
     set:
       rbac.namespaced: true


### PR DESCRIPTION
<!--
Thank you for contributing to grafana-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/grafana-community/helm-charts/blob/main/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them (see CONTRIBUTING.md).
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.  Please check the results.
-->

<!-- markdownlint-disable-next-line first-line-heading -->

Fix Loki OpenShift SCC RoleBinding subjects for component ServiceAccounts.

Loki component workloads can now render dedicated ServiceAccounts such as gateway and memcached, but the OpenShift SCC RoleBinding only granted SCC usage to the primary Loki ServiceAccount. This caused component pods to fall back to OpenShift restricted-v2 and fail admission when their configured security contexts used fixed UIDs.

This change adds a reusable SCC ServiceAccount subject helper, resolves component ServiceAccount names through the existing chart helper, de-duplicates fallback/global names, and updates the SCC RoleBinding to include all enabled component ServiceAccounts. Focused unit coverage was added for default component SAs and custom component SA names.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
