### PR TITLE
[tempo-distributed] Add block-builder, live-store and Kafka ingest support (opt-in)

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 2.23.4
+version: 2.24.0
 # renovate: docker=docker.io/grafana/tempo
 appVersion: 2.10.5
 kubeVersion: "^1.25.0-0"

--- a/charts/tempo-distributed/templates/block-builder/service-block-builder.yaml
+++ b/charts/tempo-distributed/templates/block-builder/service-block-builder.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.blockBuilder.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "tempo.resourceName" (dict "ctx" . "component" "block-builder") }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tempo.labels" (dict "ctx" . "component" "block-builder") | nindent 4 }}
+  {{- with .Values.blockBuilder.service.annotations }}
+  annotations:
+    {{- tpl (toYaml . | nindent 4) $ }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http-metrics
+      port: 3200
+      targetPort: http-metrics
+      protocol: TCP
+  selector:
+    {{- include "tempo.selectorLabels" (dict "ctx" . "component" "block-builder") | nindent 4 }}
+  ipFamilies: {{ .Values.tempo.service.ipFamilies }}
+  ipFamilyPolicy: {{ .Values.tempo.service.ipFamilyPolicy }}
+{{- end }}

--- a/charts/tempo-distributed/templates/block-builder/servicemonitor-block-builder.yaml
+++ b/charts/tempo-distributed/templates/block-builder/servicemonitor-block-builder.yaml
@@ -1,0 +1,3 @@
+{{- if .Values.blockBuilder.enabled }}
+{{- include "tempo.lib.serviceMonitor" (dict "ctx" $ "component" "block-builder" "memberlist" true) }}
+{{- end }}

--- a/charts/tempo-distributed/templates/block-builder/statefulset-block-builder.yaml
+++ b/charts/tempo-distributed/templates/block-builder/statefulset-block-builder.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.blockBuilder.enabled }}
+{{- $dict := dict "ctx" . "component" "block-builder" "memberlist" true -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "tempo.resourceName" $dict }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- with .Values.blockBuilder.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.blockBuilder.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.blockBuilder.replicas }}
+  revisionHistoryLimit: {{ .Values.tempo.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "tempo.selectorLabels" $dict | nindent 6 }}
+  serviceName: block-builder
+  podManagementPolicy: Parallel
+  updateStrategy:
+    {{- toYaml .Values.blockBuilder.statefulStrategy | nindent 4 }}
+  template:
+    {{- include "tempo.podTemplate" (dict "ctx" $ "component" .Values.blockBuilder "target" "block-builder") | nindent 4 }}
+{{- end }}

--- a/charts/tempo-distributed/templates/ingester/hpa.yaml
+++ b/charts/tempo-distributed/templates/ingester/hpa.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingester.enabled }}
 {{- if .Values.ingester.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
@@ -34,4 +35,5 @@ spec:
           type: Utilization
           averageUtilization: {{ . }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/ingester/poddisruptionbudget-ingester.yaml
+++ b/charts/tempo-distributed/templates/ingester/poddisruptionbudget-ingester.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingester.enabled }}
 {{- if and (gt (int .Values.ingester.replicas) 1) .Values.ingester.podDisruptionBudget.enabled }}
 {{ $dict := dict "ctx" . "component" "ingester" "memberlist" true }}
 apiVersion: policy/v1
@@ -15,4 +16,5 @@ spec:
   {{- with .Values.ingester.podDisruptionBudget.unhealthyPodEvictionPolicy }}
   unhealthyPodEvictionPolicy: {{ . }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/ingester/service-ingester-discovery.yaml
+++ b/charts/tempo-distributed/templates/ingester/service-ingester-discovery.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingester.enabled }}
 {{- $dict := dict "ctx" . "component" "ingester" true }}
 apiVersion: v1
 kind: Service
@@ -28,3 +29,4 @@ spec:
       {{- end }}
   selector:
     {{- include "tempo.selectorLabels" $dict | nindent 4 }}
+{{- end }}

--- a/charts/tempo-distributed/templates/ingester/service-ingester.yaml
+++ b/charts/tempo-distributed/templates/ingester/service-ingester.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingester.enabled }}
 {{- $dict := dict "ctx" . "component" "ingester" true }}
 {{- $zonesMap := include "ingester.zoneAwareReplicationMap" $dict | fromYaml -}}
 {{- range $zoneName, $rolloutZone := $zonesMap -}}
@@ -36,3 +37,4 @@ spec:
 ---
 {{ end }}
 {{ end }}
+{{- end }}

--- a/charts/tempo-distributed/templates/ingester/servicemonitor-ingester.yaml
+++ b/charts/tempo-distributed/templates/ingester/servicemonitor-ingester.yaml
@@ -1,1 +1,3 @@
+{{- if .Values.ingester.enabled }}
 {{- include "tempo.lib.serviceMonitor" (dict "ctx" $ "component" "ingester" "memberlist" true) }}
+{{- end }}

--- a/charts/tempo-distributed/templates/ingester/statefulset-ingester.yaml
+++ b/charts/tempo-distributed/templates/ingester/statefulset-ingester.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingester.enabled }}
 {{- $dict := dict "ctx" . "component" "ingester" "memberlist" true -}}
 {{- $zonesMap := include "ingester.zoneAwareReplicationMap" $dict | fromYaml -}}
 {{- range $zoneName, $rolloutZone := $zonesMap -}}
@@ -225,3 +226,4 @@ spec:
 ---
 {{ end }}
 {{ end }}
+{{- end }}

--- a/charts/tempo-distributed/templates/live-store/service-live-store.yaml
+++ b/charts/tempo-distributed/templates/live-store/service-live-store.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.liveStore.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "tempo.resourceName" (dict "ctx" . "component" "live-store") }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tempo.labels" (dict "ctx" . "component" "live-store") | nindent 4 }}
+  {{- with .Values.liveStore.service.annotations }}
+  annotations:
+    {{- tpl (toYaml . | nindent 4) $ }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http-metrics
+      port: 3200
+      targetPort: http-metrics
+      protocol: TCP
+  selector:
+    {{- include "tempo.selectorLabels" (dict "ctx" . "component" "live-store") | nindent 4 }}
+  ipFamilies: {{ .Values.tempo.service.ipFamilies }}
+  ipFamilyPolicy: {{ .Values.tempo.service.ipFamilyPolicy }}
+{{- end }}

--- a/charts/tempo-distributed/templates/live-store/servicemonitor-live-store.yaml
+++ b/charts/tempo-distributed/templates/live-store/servicemonitor-live-store.yaml
@@ -1,0 +1,3 @@
+{{- if .Values.liveStore.enabled }}
+{{- include "tempo.lib.serviceMonitor" (dict "ctx" $ "component" "live-store" "memberlist" true) }}
+{{- end }}

--- a/charts/tempo-distributed/templates/live-store/statefulset-live-store.yaml
+++ b/charts/tempo-distributed/templates/live-store/statefulset-live-store.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.liveStore.enabled }}
+{{- $dict := dict "ctx" . "component" "live-store" "memberlist" true -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "tempo.resourceName" $dict }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tempo.labels" $dict | nindent 4 }}
+    {{- with .Values.liveStore.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.liveStore.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.liveStore.replicas }}
+  revisionHistoryLimit: {{ .Values.tempo.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "tempo.selectorLabels" $dict | nindent 6 }}
+  serviceName: live-store
+  podManagementPolicy: Parallel
+  updateStrategy:
+    {{- toYaml .Values.liveStore.statefulStrategy | nindent 4 }}
+  template:
+    {{- include "tempo.podTemplate" (dict "ctx" $ "component" .Values.liveStore "target" "live-store") | nindent 4 }}
+{{- end }}

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -2208,6 +2208,9 @@ config: |
           max_compaction_objects: {{ .Values.backendScheduler.config.provider.compaction.compaction.max_compaction_objects }}
           max_time_per_tenant: {{ .Values.backendScheduler.config.provider.compaction.compaction.max_time_per_tenant }}
           retention_concurrency: {{ .Values.backendScheduler.config.provider.compaction.compaction.retention_concurrency }}
+          v2_in_buffer_bytes: {{ .Values.backendScheduler.config.provider.compaction.compaction.v2_in_buffer_bytes }}
+          v2_out_buffer_bytes: {{ .Values.backendScheduler.config.provider.compaction.compaction.v2_out_buffer_bytes }}
+          v2_prefetch_traces_count: {{ .Values.backendScheduler.config.provider.compaction.compaction.v2_prefetch_traces_count }}
         max_jobs_per_tenant: {{ .Values.backendScheduler.config.provider.compaction.max_jobs_per_tenant }}
         min_input_blocks: {{ .Values.backendScheduler.config.provider.compaction.min_input_blocks }}
         max_input_blocks: {{ .Values.backendScheduler.config.provider.compaction.max_input_blocks }}
@@ -2259,6 +2262,9 @@ config: |
       retention_concurrency: {{ .Values.compactor.config.compaction.retention_concurrency }}
       max_time_per_tenant: {{ .Values.compactor.config.compaction.max_time_per_tenant }}
       compaction_cycle: {{ .Values.compactor.config.compaction.compaction_cycle }}
+      v2_in_buffer_bytes: {{ .Values.compactor.config.compaction.v2_in_buffer_bytes }}
+      v2_out_buffer_bytes: {{ .Values.compactor.config.compaction.v2_out_buffer_bytes }}
+      v2_prefetch_traces_count: {{ .Values.compactor.config.compaction.v2_prefetch_traces_count }}
     ring:
       kvstore:
         store: memberlist

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -188,6 +188,9 @@ rbac:
 
 # Configuration for the ingester
 ingester:
+  # -- Enable the ingester. Set to false when using the Tempo 3.0 block-builder/live-store
+  # write path. Ingesters are not part of the Tempo 3.0 microservices architecture.
+  enabled: true
   # -- Annotations for the ingester StatefulSet
   annotations: {}
   # -- Labels for the ingester StatefulSet
@@ -1323,6 +1326,198 @@ compactor:
         - name: ndots
           value: "3"    # This is required for Azure Kubernetes Service (AKS) https://github.com/grafana/tempo/issues/1462
 
+# -- Ingest configuration. Sets the top-level `ingest:` block in tempo.yaml.
+# Required for Tempo 3.0 microservices mode. Distributors write spans to Kafka;
+# block-builders and live-stores consume from it.
+# The number of block-builder and live-store replicas must equal the Kafka partition count.
+ingest:
+  kafka:
+    # -- Kafka broker address (e.g. "kafka.kafka-namespace.svc.cluster.local:9092")
+    address: ""
+    # -- Kafka topic name for trace data
+    topic: tempo-traces
+    # -- Automatically create the topic if it does not exist
+    auto_create_topic_enabled: true
+    # -- Number of partitions for the auto-created topic.
+    # Block-builder and live-store replica count must match this value.
+    auto_create_topic_default_partitions: 3
+
+# Configuration for the block-builder (Tempo 3.0+)
+# Consumes spans from Kafka and writes blocks to object storage.
+# One replica per Kafka partition — replica count must equal ingest.kafka.auto_create_topic_default_partitions.
+blockBuilder:
+  # -- Enable the block-builder. Requires ingest.kafka.address to be set.
+  enabled: false
+  # -- Number of replicas. Must equal the Kafka partition count.
+  replicas: 3
+  # -- Annotations for the block-builder StatefulSet
+  annotations: {}
+  # -- Labels for the block-builder StatefulSet
+  labels: {}
+  # -- hostAliases to add
+  hostAliases: []
+  # -- Init containers to add to the block-builder pod
+  initContainers: []
+  image:
+    # -- The Docker registry for the block-builder image. Overrides `tempo.image.registry`
+    registry: null
+    # -- Optional list of imagePullSecrets. Overrides `tempo.image.pullSecrets`
+    pullSecrets: []
+    # -- Docker image repository for the block-builder image. Overrides `tempo.image.repository`
+    repository: null
+    # -- Docker image tag for the block-builder image. Overrides `tempo.image.tag`
+    tag: null
+  # -- The name of the PriorityClass for block-builder pods
+  priorityClassName: null
+  # -- Labels for block-builder pods
+  podLabels: {}
+  # -- Annotations for block-builder pods
+  podAnnotations: {}
+  # -- Additional CLI args for the block-builder
+  extraArgs: []
+  # -- Environment variables to add to the block-builder pods
+  extraEnv: []
+  # -- Environment variables from secrets or configmaps to add to the block-builder pods
+  extraEnvFrom: []
+  # -- Additional ports to expose on the block-builder container
+  extraPorts: []
+  # -- Liveness probe for block-builder pods. Uses `tempo.livenessProbe` as default if not set.
+  livenessProbe: {}
+  # -- Readiness probe for block-builder pods. Uses `tempo.readinessProbe` as default if not set.
+  readinessProbe: {}
+  # -- Resource requests and limits for the block-builder
+  resources: {}
+  # -- Grace period to allow the block-builder to flush its WAL before being killed
+  terminationGracePeriodSeconds: 300
+  # -- topologySpread for block-builder pods. Passed through `tpl`.
+  topologySpreadConstraints: |
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          {{- include "tempo.selectorLabels" (dict "ctx" . "component" "block-builder") | nindent 6 }}
+  # -- Affinity for block-builder pods. Passed through `tpl`.
+  affinity: |
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                {{- include "tempo.selectorLabels" (dict "ctx" . "component" "block-builder") | nindent 12 }}
+            topologyKey: kubernetes.io/hostname
+  # -- Node selector for block-builder pods
+  nodeSelector: {}
+  # -- Tolerations for block-builder pods
+  tolerations: []
+  # -- Extra volumes for block-builder pods
+  extraVolumeMounts: []
+  # -- Extra volumes for block-builder StatefulSet
+  extraVolumes: []
+  # -- Containers to add to the block-builder pods
+  extraContainers: []
+  # -- updateStrategy of the block-builder StatefulSet
+  statefulStrategy:
+    rollingUpdate:
+      partition: 0
+  service:
+    # -- Annotations for block-builder service
+    annotations: {}
+  config:
+    # -- Number of Kafka partitions each block-builder instance consumes.
+    # Each pod consumes this many partitions starting from its ordinal * partitions_per_instance.
+    partitions_per_instance: 1
+
+# Configuration for the live-store (Tempo 3.0+)
+# Consumes spans from Kafka and serves recent-data queries (last ~30 minutes).
+# One replica per Kafka partition — replica count must equal ingest.kafka.auto_create_topic_default_partitions.
+liveStore:
+  # -- Enable the live-store. Requires ingest.kafka.address to be set.
+  enabled: false
+  # -- Number of replicas. Must equal the Kafka partition count.
+  replicas: 3
+  # -- Annotations for the live-store StatefulSet
+  annotations: {}
+  # -- Labels for the live-store StatefulSet
+  labels: {}
+  # -- hostAliases to add
+  hostAliases: []
+  # -- Init containers to add to the live-store pod
+  initContainers: []
+  image:
+    # -- The Docker registry for the live-store image. Overrides `tempo.image.registry`
+    registry: null
+    # -- Optional list of imagePullSecrets. Overrides `tempo.image.pullSecrets`
+    pullSecrets: []
+    # -- Docker image repository for the live-store image. Overrides `tempo.image.repository`
+    repository: null
+    # -- Docker image tag for the live-store image. Overrides `tempo.image.tag`
+    tag: null
+  # -- The name of the PriorityClass for live-store pods
+  priorityClassName: null
+  # -- Labels for live-store pods
+  podLabels: {}
+  # -- Annotations for live-store pods
+  podAnnotations: {}
+  # -- Additional CLI args for the live-store
+  extraArgs: []
+  # -- Environment variables to add to the live-store pods
+  extraEnv: []
+  # -- Environment variables from secrets or configmaps to add to the live-store pods
+  extraEnvFrom: []
+  # -- Additional ports to expose on the live-store container
+  extraPorts: []
+  # -- Liveness probe for live-store pods. Uses `tempo.livenessProbe` as default if not set.
+  livenessProbe: {}
+  # -- Readiness probe for live-store pods. Uses `tempo.readinessProbe` as default if not set.
+  readinessProbe: {}
+  # -- Resource requests and limits for the live-store
+  resources: {}
+  # -- Grace period to allow the live-store to shut down before being killed
+  terminationGracePeriodSeconds: 60
+  # -- topologySpread for live-store pods. Passed through `tpl`.
+  topologySpreadConstraints: |
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          {{- include "tempo.selectorLabels" (dict "ctx" . "component" "live-store") | nindent 6 }}
+  # -- Affinity for live-store pods. Passed through `tpl`.
+  affinity: |
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                {{- include "tempo.selectorLabels" (dict "ctx" . "component" "live-store") | nindent 12 }}
+            topologyKey: kubernetes.io/hostname
+  # -- Node selector for live-store pods
+  nodeSelector: {}
+  # -- Tolerations for live-store pods
+  tolerations: []
+  # -- Extra volumes for live-store pods
+  extraVolumeMounts: []
+  # -- Extra volumes for live-store StatefulSet
+  extraVolumes: []
+  # -- Containers to add to the live-store pods
+  extraContainers: []
+  # -- updateStrategy of the live-store StatefulSet
+  statefulStrategy:
+    rollingUpdate:
+      partition: 0
+  service:
+    # -- Annotations for live-store service
+    annotations: {}
+  # -- Extra live-store configuration. Merged verbatim into the `live_store:` config block.
+  # See https://grafana.com/docs/tempo/latest/configuration/#live-store for available fields.
+  config:
+    ring:
+      kvstore:
+        store: memberlist
+
 # Configuration for the querier
 querier:
   # -- Number of replicas for the querier
@@ -2013,9 +2208,6 @@ config: |
           max_compaction_objects: {{ .Values.backendScheduler.config.provider.compaction.compaction.max_compaction_objects }}
           max_time_per_tenant: {{ .Values.backendScheduler.config.provider.compaction.compaction.max_time_per_tenant }}
           retention_concurrency: {{ .Values.backendScheduler.config.provider.compaction.compaction.retention_concurrency }}
-          v2_in_buffer_bytes: {{ .Values.backendScheduler.config.provider.compaction.compaction.v2_in_buffer_bytes }}
-          v2_out_buffer_bytes: {{ .Values.backendScheduler.config.provider.compaction.compaction.v2_out_buffer_bytes }}
-          v2_prefetch_traces_count: {{ .Values.backendScheduler.config.provider.compaction.compaction.v2_prefetch_traces_count }}
         max_jobs_per_tenant: {{ .Values.backendScheduler.config.provider.compaction.max_jobs_per_tenant }}
         min_input_blocks: {{ .Values.backendScheduler.config.provider.compaction.min_input_blocks }}
         max_input_blocks: {{ .Values.backendScheduler.config.provider.compaction.max_input_blocks }}
@@ -2045,18 +2237,26 @@ config: |
     ring:
       kvstore:
         store: memberlist
-  {{- else }}
+  {{- end }}
+  {{- if .Values.blockBuilder.enabled }}
+  block_builder:
+    partitions_per_instance: {{ .Values.blockBuilder.config.partitions_per_instance }}
+  {{- end }}
+  {{- if .Values.liveStore.enabled }}
+  live_store:
+    {{- with .Values.liveStore.config }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  {{- if not .Values.backendScheduler.enabled }}
   compactor:
     compaction:
       block_retention: {{ .Values.compactor.config.compaction.block_retention }}
       compacted_block_retention: {{ .Values.compactor.config.compaction.compacted_block_retention }}
       compaction_window: {{ .Values.compactor.config.compaction.compaction_window }}
-      v2_in_buffer_bytes: {{ .Values.compactor.config.compaction.v2_in_buffer_bytes }}
-      v2_out_buffer_bytes: {{ .Values.compactor.config.compaction.v2_out_buffer_bytes }}
       max_compaction_objects: {{ .Values.compactor.config.compaction.max_compaction_objects }}
       max_block_bytes: {{ .Values.compactor.config.compaction.max_block_bytes }}
       retention_concurrency: {{ .Values.compactor.config.compaction.retention_concurrency }}
-      v2_prefetch_traces_count: {{ .Values.compactor.config.compaction.v2_prefetch_traces_count }}
       max_time_per_tenant: {{ .Values.compactor.config.compaction.max_time_per_tenant }}
       compaction_cycle: {{ .Values.compactor.config.compaction.compaction_cycle }}
     ring:
@@ -2201,6 +2401,15 @@ config: |
       interval: {{ .Values.queryFrontend.config.metrics.interval }}
       duration_slo: {{ .Values.queryFrontend.config.metrics.duration_slo }}
       throughput_bytes_slo: {{ .Values.queryFrontend.config.metrics.throughput_bytes_slo }}
+  {{- with .Values.ingest.kafka.address }}
+  ingest:
+    kafka:
+      address: {{ . }}
+      topic: {{ $.Values.ingest.kafka.topic }}
+      auto_create_topic_enabled: {{ $.Values.ingest.kafka.auto_create_topic_enabled }}
+      auto_create_topic_default_partitions: {{ $.Values.ingest.kafka.auto_create_topic_default_partitions }}
+  {{- end }}
+  {{- if .Values.ingester.enabled }}
   ingester:
     lifecycler:
       ring:
@@ -2229,6 +2438,7 @@ config: |
     {{- if .Values.ingester.config.flush_all_on_shutdown }}
     flush_all_on_shutdown: {{ .Values.ingester.config.flush_all_on_shutdown }}
     {{- end }}
+  {{- end }}
   memberlist:
     {{- with .Values.memberlist }}
       {{- toYaml . | nindent 2 }}


### PR DESCRIPTION
## What this does

Adds the Tempo block-builder and live-store components (introduced experimentally in Tempo 2.9) as **opt-in**. All new values default to disabled. Existing deployments are unaffected.

## New components

- **block-builder**: StatefulSet, one replica per Kafka partition, consumes from Kafka and writes Parquet blocks to object storage. Gated on \`blockBuilder.enabled: false\`.
- **live-store**: StatefulSet, one replica per Kafka partition, consumes from Kafka and serves recent-data queries. Gated on \`liveStore.enabled: false\`.

Both use the existing \`tempo.podTemplate\`, \`tempo.lib.serviceMonitor\`, and resource naming helpers same pattern as backend-scheduler/worker.

## New values

```yaml
# Kafka connectivity ingest: block only emitted when address is set
ingest:
  kafka:
    address: ""
    topic: tempo-traces
    auto_create_topic_default_partitions: 3

blockBuilder:
  enabled: false   # opt-in
  replicas: 3      # must equal partition count

liveStore:
  enabled: false   # opt-in
  replicas: 3      # must equal partition count

# New flag default true, no behavior change for existing deployments
ingester:
  enabled: true
```

## Other changes

- Removed deprecated \`v2_in_buffer_bytes\`, \`v2_out_buffer_bytes\`, \`v2_prefetch_traces_count\` from backend-scheduler and compactor config
- \`ingester:\` config block gated on \`ingester.enabled\`

## Tested

Validated on kind with Tempo 2.10.5: block-builder and live-store start and pass readiness with 0 restarts alongside the existing components.

## Part of

PR series for Tempo 3.0 — merge order: #548 → this PR → #553 → #551