### PR TITLE
[loki] Accept StorageClass per zone

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.2
-version: 17.1.7
+version: 17.2.0
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/templates/ingester/statefulset-zone.yaml
+++ b/charts/loki/templates/ingester/statefulset-zone.yaml
@@ -52,6 +52,7 @@ spec:
   template:
     {{- include "loki.podTemplate" (dict "target" "ingester" "component" $.Values.ingester "ctx" $ "rolloutZoneName" $zone "args" (list (print "-ingester.availability-zone=" $zone) "-ingester.unregister-on-shutdown=false" "-ingester.tokens-file-path=/var/loki/ring-tokens")) | nindent 4 }}
   {{- if $.Values.ingester.persistence.enabled }}
+  {{- $zoneStorageClass := dig "zoneAwareReplication" (printf "zone%s" (upper (splitList "-" $zone | last))) "persistence" "storageClass" nil $.Values.ingester }}
   volumeClaimTemplates:
   {{- range $.Values.ingester.persistence.claims }}
     - apiVersion: v1
@@ -65,7 +66,8 @@ spec:
       spec:
         accessModes:
           {{- toYaml .accessModes | nindent 10 }}
-        {{- with .storageClass }}
+        {{- $storageClass := default .storageClass $zoneStorageClass }}
+        {{- with $storageClass }}
         storageClassName: {{ if (eq "-" .) }}""{{ else }}{{ . }}{{ end }}
         {{- end }}
         {{- with .volumeAttributesClassName }}

--- a/charts/loki/tests/ingester/zone_test.yaml
+++ b/charts/loki/tests/ingester/zone_test.yaml
@@ -394,6 +394,151 @@ tests:
         documentIndex: 0
         template: ingester/statefulset-zone.yaml
 
+  # ── Per-zone storageClass ────────────────────────────────────────────────────
+
+  - it: should not set storageClassName on any zone when no storageClass is configured
+    set:
+      ingester.persistence.enabled: true
+    asserts:
+      - notExists:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+        documentIndex: 0
+        template: ingester/statefulset-zone.yaml
+      - notExists:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+        documentIndex: 1
+        template: ingester/statefulset-zone.yaml
+      - notExists:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+        documentIndex: 2
+        template: ingester/statefulset-zone.yaml
+
+  - it: should apply claim-level storageClass to every zone when no per-zone override is set
+    set:
+      ingester.persistence.enabled: true
+      ingester.persistence.claims:
+        - name: data
+          accessModes:
+            - ReadWriteOnce
+          size: 10Gi
+          storageClass: shared-class
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: shared-class
+        documentIndex: 0
+        template: ingester/statefulset-zone.yaml
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: shared-class
+        documentIndex: 1
+        template: ingester/statefulset-zone.yaml
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: shared-class
+        documentIndex: 2
+        template: ingester/statefulset-zone.yaml
+
+  - it: should let per-zone storageClass override the claim-level storageClass per zone
+    set:
+      ingester.persistence.enabled: true
+      ingester.persistence.claims:
+        - name: data
+          accessModes:
+            - ReadWriteOnce
+          size: 10Gi
+          storageClass: shared-class
+      ingester.zoneAwareReplication.zoneA.persistence.storageClass: zone-a-sc
+      ingester.zoneAwareReplication.zoneB.persistence.storageClass: zone-b-sc
+      ingester.zoneAwareReplication.zoneC.persistence.storageClass: zone-c-sc
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: zone-a-sc
+        documentIndex: 0
+        template: ingester/statefulset-zone.yaml
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: zone-b-sc
+        documentIndex: 1
+        template: ingester/statefulset-zone.yaml
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: zone-c-sc
+        documentIndex: 2
+        template: ingester/statefulset-zone.yaml
+
+  - it: should override only the zone that sets storageClass and leave others on the claim default
+    set:
+      ingester.persistence.enabled: true
+      ingester.persistence.claims:
+        - name: data
+          accessModes:
+            - ReadWriteOnce
+          size: 10Gi
+          storageClass: shared-class
+      ingester.zoneAwareReplication.zoneB.persistence.storageClass: zone-b-sc
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: shared-class
+        documentIndex: 0
+        template: ingester/statefulset-zone.yaml
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: zone-b-sc
+        documentIndex: 1
+        template: ingester/statefulset-zone.yaml
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: shared-class
+        documentIndex: 2
+        template: ingester/statefulset-zone.yaml
+
+  - it: should set storageClassName to "" when per-zone storageClass is "-" (disable dynamic provisioning)
+    set:
+      ingester.persistence.enabled: true
+      ingester.persistence.claims:
+        - name: data
+          accessModes:
+            - ReadWriteOnce
+          size: 10Gi
+          storageClass: shared-class
+      ingester.zoneAwareReplication.zoneA.persistence.storageClass: "-"
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: ""
+        documentIndex: 0
+        template: ingester/statefulset-zone.yaml
+
+  - it: should apply the per-zone storageClass to every claim in that zone
+    set:
+      ingester.persistence.enabled: true
+      ingester.persistence.claims:
+        - name: data
+          accessModes:
+            - ReadWriteOnce
+          size: 10Gi
+          storageClass: shared-class
+        - name: wal
+          accessModes:
+            - ReadWriteOnce
+          size: 5Gi
+          storageClass: shared-class
+      ingester.zoneAwareReplication.zoneA.persistence.storageClass: zone-a-sc
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: zone-a-sc
+        documentIndex: 0
+        template: ingester/statefulset-zone.yaml
+      - equal:
+          path: spec.volumeClaimTemplates[1].spec.storageClassName
+          value: zone-a-sc
+        documentIndex: 0
+        template: ingester/statefulset-zone.yaml
+
   # ── Migration mode ───────────────────────────────────────────────────────────
 
   - it: should still render zone StatefulSets when migration is enabled

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -2734,6 +2734,14 @@ ingester:
       annotations: {}
       # -- Specific annotations to add to zone A pods
       podAnnotations: {}
+      # -- Persistence overrides applied only to the zone A StatefulSet.
+      persistence:
+        # -- Storage class to use for every PVC in zone A. Overrides the `storageClass` of each entry in
+        # `ingester.persistence.claims` for this zone only. Use this when you have one StorageClass per
+        # availability zone (for example a topology-pinned EBS/PD StorageClass). If null, the
+        # claim-level `storageClass` is used as before, preserving existing behavior.
+        # If set to "-", `storageClassName: ""` is rendered, which disables dynamic provisioning.
+        storageClass: null
     zoneB:
       # -- optionally define a node selector for this zone
       nodeSelector: null
@@ -2744,6 +2752,12 @@ ingester:
       annotations: {}
       # -- Specific annotations to add to zone B pods
       podAnnotations: {}
+      # -- Persistence overrides applied only to the zone B StatefulSet.
+      persistence:
+        # -- Storage class to use for every PVC in zone B. See
+        # `ingester.zoneAwareReplication.zoneA.persistence.storageClass` for details. If null, the
+        # claim-level `storageClass` is used as before.
+        storageClass: null
     zoneC:
       # -- optionally define a node selector for this zone
       nodeSelector: null
@@ -2754,6 +2768,12 @@ ingester:
       annotations: {}
       # -- Specific annotations to add to zone C pods
       podAnnotations: {}
+      # -- Persistence overrides applied only to the zone C StatefulSet.
+      persistence:
+        # -- Storage class to use for every PVC in zone C. See
+        # `ingester.zoneAwareReplication.zoneA.persistence.storageClass` for details. If null, the
+        # claim-level `storageClass` is used as before.
+        storageClass: null
     # -- The migration block allows migrating non zone aware ingesters to zone aware ingesters.
     migration:
       enabled: false


### PR DESCRIPTION
#### What this PR does / why we need it

Currently the Loki helm chart accepts a single StorageClass for all Ingester StatefulSet, even with zone-awareness enabled, therefore PVCs backing Loki must be replicated to all three zones.

This PR permits providing a different StorageClass per Ingester StatefulSet.

We have a StorageClass per zone, where volumes created using a zone-specific storage class are not replicated to other zones. We would like Loki to use these storage classes (Ingesters in zone-a should use storage in zone-a).

Tested:

```yaml
# content of values.yaml:
deploymentMode: Distributed
backend:
  replicas: 0
read:
  replicas: 0
write:
  replicas: 0
singleBinary:
  replicas: 0
loki:
  useTestSchema: true
  storage:
    bucketNames:
      chunks: chunks
      ruler: ruler
      admin: admin
ingester:
  replicas: 3
  persistence:
    enabled: true
    claims:
      - name: data
        accessModes: [ReadWriteOnce]
        size: 10Gi
        storageClass: shared-default
  zoneAwareReplication:
    enabled: true
    zoneA: {storageClass: zone-a-storage}
    zoneB: {storageClass: zone-b-storage}
    zoneC: {storageClass: "-"}     # → storageClassName: ""
```

Test
```shell
helm template demo helm-charts/charts/loki -f values.yaml | grep storageClass
        storageClassName: zone-a-storage
        storageClassName: zone-b-storage
        storageClassName: ""
```

#### Which issue this PR fixes

n/a

#### Special notes for your reviewer

This is already possible with the Mimir Helm Chart: https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed

#### Checklist

- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)

Requesting review from as per contribution guidelines: @TheRealNoob, @jkroepke, @QuentinBisson