### PR TITLE
[grafana] Fix VPA namespace to respect namespaceOverride

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 12.4.2
+version: 12.4.3
 # renovate: docker=docker.io/grafana/grafana
 appVersion: 13.0.1-security-01
 kubeVersion: "^1.25.0-0"

--- a/charts/grafana/templates/vpa.yaml
+++ b/charts/grafana/templates/vpa.yaml
@@ -23,7 +23,7 @@ apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: {{ include "grafana.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "grafana.namespace" . }}
   labels:
     {{- include "grafana.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
<!--
Thank you for contributing to grafana-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/grafana-community/helm-charts/blob/main/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them (see CONTRIBUTING.md).
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.  Please check the results.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
The VPA template (vpa.yaml) was using `.Release.Namespace` directly :
https://github.com/grafana-community/helm-charts/blob/2baea13854a52861b95a74a26184b9841ba58193/charts/grafana/templates/vpa.yaml#L22-L26

Instead of the `grafana.namespace` helper template :
https://github.com/grafana-community/helm-charts/blob/2baea13854a52861b95a74a26184b9841ba58193/charts/grafana/templates/_helpers.tpl#L53-L62

This means when a user sets `namespaceOverride`, the VPA resource would be created in the wrong namespace (the release namespace instead of the overridden one). All other templates use `include "grafana.namespace" .` but VPA uses `.Release.Namespace`, ignoring `namespaceOverride`.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
