### PR TITLE
[grafana] Fix `skipTlsVerify` consistent across all sidecars with per-sidecar override support

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 12.4.3
+version: 12.4.4
 # renovate: docker=docker.io/grafana/grafana
 appVersion: 13.0.1-security-01
 kubeVersion: "^1.25.0-0"

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -180,9 +180,10 @@ initContainers:
       - name: NAMESPACE
         value: "{{ tpl (. | join ",") $root }}"
       {{- end }}
-      {{- with .Values.sidecar.alerts.skipTlsVerify }}
+      {{- $skipTlsVerify := ternary .Values.sidecar.alerts.skipTlsVerify .Values.sidecar.skipTlsVerify (kindIs "bool" .Values.sidecar.alerts.skipTlsVerify) }}
+      {{- if $skipTlsVerify }}
       - name: SKIP_TLS_VERIFY
-        value: {{ quote . }}
+        value: "true"
       {{- end }}
       {{- with .Values.sidecar.alerts.script }}
       - name: SCRIPT
@@ -271,9 +272,10 @@ initContainers:
       - name: NAMESPACE
         value: "{{ tpl (. | join ",") $root }}"
       {{- end }}
-      {{- if .Values.sidecar.skipTlsVerify }}
+      {{- $skipTlsVerify := ternary .Values.sidecar.datasources.skipTlsVerify .Values.sidecar.skipTlsVerify (kindIs "bool" .Values.sidecar.datasources.skipTlsVerify) }}
+      {{- if $skipTlsVerify }}
       - name: SKIP_TLS_VERIFY
-        value: "{{ .Values.sidecar.skipTlsVerify }}"
+        value: "true"
       {{- end }}
       {{- with .Values.sidecar.datasources.script }}
       - name: SCRIPT
@@ -412,9 +414,10 @@ initContainers:
       - name: NAMESPACE
         value: "{{ tpl (. | join ",") $root }}"
       {{- end }}
-      {{- with .Values.sidecar.skipTlsVerify }}
+      {{- $skipTlsVerify := ternary .Values.sidecar.notifiers.skipTlsVerify .Values.sidecar.skipTlsVerify (kindIs "bool" .Values.sidecar.notifiers.skipTlsVerify) }}
+      {{- if $skipTlsVerify }}
       - name: SKIP_TLS_VERIFY
-        value: "{{ . }}"
+        value: "true"
       {{- end }}
       {{- with .Values.sidecar.notifiers.script }}
       - name: SCRIPT
@@ -503,9 +506,10 @@ initContainers:
       - name: NAMESPACE
         value: "{{ tpl (. | join ",") $root }}"
       {{- end }}
-      {{- with .Values.sidecar.skipTlsVerify }}
+      {{- $skipTlsVerify := ternary .Values.sidecar.dashboards.skipTlsVerify .Values.sidecar.skipTlsVerify (kindIs "bool" .Values.sidecar.dashboards.skipTlsVerify) }}
+      {{- if $skipTlsVerify }}
       - name: SKIP_TLS_VERIFY
-        value: "{{ . }}"
+        value: "true"
       {{- end }}
       {{- with .Values.sidecar.dashboards.folderAnnotation }}
       - name: FOLDER_ANNOTATION
@@ -650,9 +654,10 @@ containers:
       - name: NAMESPACE
         value: "{{ tpl (. | join ",") $root }}"
       {{- end }}
-      {{- with .Values.sidecar.alerts.skipTlsVerify }}
+      {{- $skipTlsVerify := ternary .Values.sidecar.alerts.skipTlsVerify .Values.sidecar.skipTlsVerify (kindIs "bool" .Values.sidecar.alerts.skipTlsVerify) }}
+      {{- if $skipTlsVerify }}
       - name: SKIP_TLS_VERIFY
-        value: {{ quote . }}
+        value: "true"
       {{- end }}
       {{- with .Values.sidecar.alerts.script }}
       - name: SCRIPT
@@ -778,9 +783,10 @@ containers:
       - name: NAMESPACE
         value: "{{ tpl (. | join ",") $root }}"
       {{- end }}
-      {{- with .Values.sidecar.skipTlsVerify }}
+      {{- $skipTlsVerify := ternary .Values.sidecar.dashboards.skipTlsVerify .Values.sidecar.skipTlsVerify (kindIs "bool" .Values.sidecar.dashboards.skipTlsVerify) }}
+      {{- if $skipTlsVerify }}
       - name: SKIP_TLS_VERIFY
-        value: "{{ . }}"
+        value: "true"
       {{- end }}
       {{- with .Values.sidecar.dashboards.folderAnnotation }}
       - name: FOLDER_ANNOTATION
@@ -910,9 +916,10 @@ containers:
       - name: NAMESPACE
         value: "{{ tpl (. | join ",") $root }}"
       {{- end }}
-      {{- if .Values.sidecar.skipTlsVerify }}
+      {{- $skipTlsVerify := ternary .Values.sidecar.datasources.skipTlsVerify .Values.sidecar.skipTlsVerify (kindIs "bool" .Values.sidecar.datasources.skipTlsVerify) }}
+      {{- if $skipTlsVerify }}
       - name: SKIP_TLS_VERIFY
-        value: "{{ .Values.sidecar.skipTlsVerify }}"
+        value: "true"
       {{- end }}
       {{- with .Values.sidecar.datasources.script }}
       - name: SCRIPT
@@ -1033,9 +1040,10 @@ containers:
       - name: NAMESPACE
         value: "{{ tpl (. | join ",") $root }}"
       {{- end }}
-      {{- with .Values.sidecar.skipTlsVerify }}
+      {{- $skipTlsVerify := ternary .Values.sidecar.notifiers.skipTlsVerify .Values.sidecar.skipTlsVerify (kindIs "bool" .Values.sidecar.notifiers.skipTlsVerify) }}
+      {{- if $skipTlsVerify }}
       - name: SKIP_TLS_VERIFY
-        value: "{{ . }}"
+        value: "true"
       {{- end }}
       {{- with .Values.sidecar.notifiers.script }}
       - name: SCRIPT
@@ -1160,9 +1168,10 @@ containers:
       - name: SCRIPT
         value: {{ quote . }}
       {{- end }}
-      {{- with .Values.sidecar.skipTlsVerify }}
+      {{- $skipTlsVerify := ternary .Values.sidecar.plugins.skipTlsVerify .Values.sidecar.skipTlsVerify (kindIs "bool" .Values.sidecar.plugins.skipTlsVerify) }}
+      {{- if $skipTlsVerify }}
       - name: SKIP_TLS_VERIFY
-        value: "{{ . }}"
+        value: "true"
       {{- end }}
       {{- if and (not .Values.env.GF_SECURITY_ADMIN_USER) (not .Values.env.GF_SECURITY_ADMIN_USER__FILE) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
       - name: REQ_USERNAME

--- a/charts/grafana/tests/skip_tls_verify_sidecar_test.yaml
+++ b/charts/grafana/tests/skip_tls_verify_sidecar_test.yaml
@@ -1,0 +1,232 @@
+# $schema: https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json
+suite: grafana sidecar skipTlsVerify
+templates:
+  - deployment.yaml
+
+tests:
+  - it: should set SKIP_TLS_VERIFY when alert-specific skipTlsVerify is enabled
+    set:
+      sidecar.alerts.enabled: true
+      sidecar.alerts.initAlerts: true
+      sidecar.alerts.skipTlsVerify: true
+    asserts:
+      - template: deployment.yaml
+        hasDocuments:
+          count: 1
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: SKIP_TLS_VERIFY
+            value: "true"
+
+  - it: should fallback to global sidecar.skipTlsVerify for alerts when alert-specific value is unset
+    set:
+      sidecar.alerts.enabled: true
+      sidecar.alerts.initAlerts: true
+      sidecar.skipTlsVerify: true
+    asserts:
+      - template: deployment.yaml
+        hasDocuments:
+          count: 1
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: SKIP_TLS_VERIFY
+            value: "true"
+
+  - it: should not render SKIP_TLS_VERIFY for alerts when neither global nor per-sidecar skipTlsVerify is set
+    set:
+      sidecar.alerts.enabled: true
+      sidecar.alerts.initAlerts: true
+    asserts:
+      - template: deployment.yaml
+        hasDocuments:
+          count: 1
+      - template: deployment.yaml
+        notContains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: SKIP_TLS_VERIFY
+
+  - it: should set SKIP_TLS_VERIFY for datasources when datasources.skipTlsVerify is enabled
+    set:
+      sidecar.datasources.enabled: true
+      sidecar.datasources.initDatasources: true
+      sidecar.datasources.skipTlsVerify: true
+    asserts:
+      - template: deployment.yaml
+        hasDocuments:
+          count: 1
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: SKIP_TLS_VERIFY
+            value: "true"
+
+  - it: should fallback to global sidecar.skipTlsVerify for datasources when per-sidecar value is unset
+    set:
+      sidecar.datasources.enabled: true
+      sidecar.datasources.initDatasources: true
+      sidecar.skipTlsVerify: true
+    asserts:
+      - template: deployment.yaml
+        hasDocuments:
+          count: 1
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: SKIP_TLS_VERIFY
+            value: "true"
+
+  - it: should not render SKIP_TLS_VERIFY for datasources when neither global nor per-sidecar skipTlsVerify is set
+    set:
+      sidecar.datasources.enabled: true
+      sidecar.datasources.initDatasources: true
+    asserts:
+      - template: deployment.yaml
+        hasDocuments:
+          count: 1
+      - template: deployment.yaml
+        notContains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: SKIP_TLS_VERIFY
+
+  - it: should set SKIP_TLS_VERIFY for notifiers when notifiers.skipTlsVerify is enabled
+    set:
+      sidecar.notifiers.enabled: true
+      sidecar.notifiers.initNotifiers: true
+      sidecar.notifiers.skipTlsVerify: true
+    asserts:
+      - template: deployment.yaml
+        hasDocuments:
+          count: 1
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: SKIP_TLS_VERIFY
+            value: "true"
+
+  - it: should fallback to global sidecar.skipTlsVerify for notifiers when per-sidecar value is unset
+    set:
+      sidecar.notifiers.enabled: true
+      sidecar.notifiers.initNotifiers: true
+      sidecar.skipTlsVerify: true
+    asserts:
+      - template: deployment.yaml
+        hasDocuments:
+          count: 1
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: SKIP_TLS_VERIFY
+            value: "true"
+
+  - it: should not render SKIP_TLS_VERIFY for notifiers when neither global nor per-sidecar skipTlsVerify is set
+    set:
+      sidecar.notifiers.enabled: true
+      sidecar.notifiers.initNotifiers: true
+    asserts:
+      - template: deployment.yaml
+        hasDocuments:
+          count: 1
+      - template: deployment.yaml
+        notContains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: SKIP_TLS_VERIFY
+
+  - it: should set SKIP_TLS_VERIFY for dashboards when dashboards.skipTlsVerify is enabled
+    set:
+      sidecar.dashboards.enabled: true
+      sidecar.dashboards.initDashboards: true
+      sidecar.dashboards.skipTlsVerify: true
+    asserts:
+      - template: deployment.yaml
+        hasDocuments:
+          count: 1
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: SKIP_TLS_VERIFY
+            value: "true"
+
+  - it: should fallback to global sidecar.skipTlsVerify for dashboards when per-sidecar value is unset
+    set:
+      sidecar.dashboards.enabled: true
+      sidecar.dashboards.initDashboards: true
+      sidecar.skipTlsVerify: true
+    asserts:
+      - template: deployment.yaml
+        hasDocuments:
+          count: 1
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: SKIP_TLS_VERIFY
+            value: "true"
+
+  - it: should not render SKIP_TLS_VERIFY for dashboards when neither global nor per-sidecar skipTlsVerify is set
+    set:
+      sidecar.dashboards.enabled: true
+      sidecar.dashboards.initDashboards: true
+    asserts:
+      - template: deployment.yaml
+        hasDocuments:
+          count: 1
+      - template: deployment.yaml
+        notContains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: SKIP_TLS_VERIFY
+
+  - it: should set SKIP_TLS_VERIFY for plugins when plugins.skipTlsVerify is enabled
+    set:
+      sidecar.plugins.enabled: true
+      sidecar.plugins.skipTlsVerify: true
+    asserts:
+      - template: deployment.yaml
+        hasDocuments:
+          count: 1
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SKIP_TLS_VERIFY
+            value: "true"
+
+  - it: should fallback to global sidecar.skipTlsVerify for plugins when per-sidecar value is unset
+    set:
+      sidecar.plugins.enabled: true
+      sidecar.skipTlsVerify: true
+    asserts:
+      - template: deployment.yaml
+        hasDocuments:
+          count: 1
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SKIP_TLS_VERIFY
+            value: "true"
+
+  - it: should not render SKIP_TLS_VERIFY for plugins when neither global nor per-sidecar skipTlsVerify is set
+    set:
+      sidecar.plugins.enabled: true
+    asserts:
+      - template: deployment.yaml
+        hasDocuments:
+          count: 1
+      - template: deployment.yaml
+        notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SKIP_TLS_VERIFY

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -1012,7 +1012,7 @@ sidecar:
       - ALL
     seccompProfile:
       type: RuntimeDefault
-  # skipTlsVerify Set to true to skip tls verification for kube api calls
+  # Set to true to skip tls verification for kube api calls. Can be overridden per sidecar
   # skipTlsVerify: true
   enableUniqueFilenames: false
   readinessProbe: {}
@@ -1038,6 +1038,8 @@ sidecar:
     #      key: value_key
     # Do not reprocess already processed unchanged resources on k8s API reconnect.
     # ignoreAlreadyProcessed: true
+    # Set to true to skip tls verification for kube api calls. Overrides sidecar.skipTlsVerify
+    # skipTlsVerify: true
     # label that the configmaps with alert are marked with (can be templated)
     label: grafana_alert
     # value of label that the configmaps with alert are set to (can be templated)
@@ -1129,6 +1131,8 @@ sidecar:
     #      key: value_key
     # Do not reprocess already processed unchanged resources on k8s API reconnect.
     # ignoreAlreadyProcessed: true
+    # Set to true to skip tls verification for kube api calls. Overrides sidecar.skipTlsVerify
+    # skipTlsVerify: true
     SCProvider: true
     # label that the configmaps with dashboards are marked with (can be templated)
     label: grafana_dashboard
@@ -1246,6 +1250,8 @@ sidecar:
     #      key: value_key
     # Do not reprocess already processed unchanged resources on k8s API reconnect.
     # ignoreAlreadyProcessed: true
+    # Set to true to skip tls verification for kube api calls. Overrides sidecar.skipTlsVerify
+    # skipTlsVerify: true
     # label that the configmaps with datasources are marked with (can be templated)
     label: grafana_datasource
     # value of label that the configmaps with datasources are set to (can be templated)
@@ -1324,6 +1330,8 @@ sidecar:
     env: {}
     # Do not reprocess already processed unchanged resources on k8s API reconnect.
     # ignoreAlreadyProcessed: true
+    # Set to true to skip tls verification for kube api calls. Overrides sidecar.skipTlsVerify
+    # skipTlsVerify: true
     # label that the configmaps with plugins are marked with (can be templated)
     label: grafana_plugin
     # value of label that the configmaps with plugins are set to (can be templated)
@@ -1392,6 +1400,8 @@ sidecar:
     env: {}
     # Do not reprocess already processed unchanged resources on k8s API reconnect.
     # ignoreAlreadyProcessed: true
+    # Set to true to skip tls verification for kube api calls. Overrides sidecar.skipTlsVerify
+    # skipTlsVerify: true
     # label that the configmaps with notifiers are marked with (can be templated)
     label: grafana_notifier
     # value of label that the configmaps with notifiers are set to (can be templated)


### PR DESCRIPTION
<!--
Thank you for contributing to grafana-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/grafana-community/helm-charts/blob/main/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them (see CONTRIBUTING.md).
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.  Please check the results.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
The `skipTlsVerify` setting was inconsistently handled across sidecars:
- **Alerts sidecar** used only `sidecar.alerts.skipTlsVerify` (per-sidecar), ignoring the global `sidecar.skipTlsVerify` entirely
- **All other sidecars** (dashboards, datasources, notifiers, plugins) used only the global `sidecar.skipTlsVerify`, with no way to override per-sidecar

This change is **fully backward compatible**:
- If only `sidecar.skipTlsVerify` is set -> behavior is the same for dashboards, datasources, notifiers, plugins. **alerts now also respects it** (previously ignored)
- If only `sidecar.alerts.skipTlsVerify` is set -> behavior is unchanged for alerts
- If neither is set -> no change (SKIP_TLS_VERIFY env var is not rendered)

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
