### PR TITLE
[grafana] Make sidecar container args configurable

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 12.4.4
+version: 12.5.0
 # renovate: docker=docker.io/grafana/grafana
 appVersion: 13.0.1-security-01
 kubeVersion: "^1.25.0-0"

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -124,6 +124,12 @@ initContainers:
     image: "{{ $registry }}/{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}"
     {{- end }}
     imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
+    {{- if .Values.sidecar.alerts.args }}
+    args:
+    {{- range .Values.sidecar.alerts.args }}
+      - {{ . | quote }}
+    {{- end }}
+    {{- end }}
     {{- if .Values.sidecar.alerts.restartPolicy }}
     restartPolicy: {{ .Values.sidecar.alerts.restartPolicy }}
     {{- with .Values.sidecar.alerts.startupProbe }}
@@ -221,6 +227,12 @@ initContainers:
     image: "{{ $registry }}/{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}"
     {{- end }}
     imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
+    {{- if .Values.sidecar.datasources.args }}
+    args:
+    {{- range .Values.sidecar.datasources.args }}
+      - {{ . | quote }}
+    {{- end }}
+    {{- end }}
     {{- if .Values.sidecar.datasources.restartPolicy }}
     restartPolicy: {{ .Values.sidecar.datasources.restartPolicy }}
     {{- with .Values.sidecar.datasources.startupProbe }}
@@ -363,6 +375,12 @@ initContainers:
     image: "{{ $registry }}/{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}"
     {{- end }}
     imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
+    {{- if .Values.sidecar.notifiers.args }}
+    args:
+    {{- range .Values.sidecar.notifiers.args }}
+      - {{ . | quote }}
+    {{- end }}
+    {{- end }}
     {{- if .Values.sidecar.notifiers.restartPolicy }}
     restartPolicy: {{ .Values.sidecar.notifiers.restartPolicy }}
     {{- with .Values.sidecar.notifiers.startupProbe }}
@@ -455,6 +473,12 @@ initContainers:
     image: "{{ $registry }}/{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}"
     {{- end }}
     imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
+    {{- if .Values.sidecar.dashboards.args }}
+    args:
+    {{- range .Values.sidecar.dashboards.args }}
+      - {{ . | quote }}
+    {{- end }}
+    {{- end }}
     {{- if .Values.sidecar.dashboards.restartPolicy }}
     restartPolicy: {{ .Values.sidecar.dashboards.restartPolicy }}
     {{- with .Values.sidecar.dashboards.startupProbe }}
@@ -612,6 +636,12 @@ containers:
     image: "{{ $registry }}/{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}"
     {{- end }}
     imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
+    {{- if .Values.sidecar.alerts.args }}
+    args:
+    {{- range .Values.sidecar.alerts.args }}
+      - {{ . | quote }}
+    {{- end }}
+    {{- end }}
     env:
       {{- range $key, $value := .Values.sidecar.alerts.env }}
       - name: "{{ $key }}"
@@ -741,6 +771,12 @@ containers:
     image: "{{ $registry }}/{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}"
     {{- end }}
     imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
+    {{- if .Values.sidecar.dashboards.args }}
+    args:
+    {{- range .Values.sidecar.dashboards.args }}
+      - {{ . | quote }}
+    {{- end }}
+    {{- end }}
     env:
       {{- range $key, $value := .Values.sidecar.dashboards.env }}
       - name: "{{ $key }}"
@@ -874,6 +910,12 @@ containers:
     image: "{{ $registry }}/{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}"
     {{- end }}
     imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
+    {{- if .Values.sidecar.datasources.args }}
+    args:
+    {{- range .Values.sidecar.datasources.args }}
+      - {{ . | quote }}
+    {{- end }}
+    {{- end }}
     env:
       {{- range $key, $value := .Values.sidecar.datasources.env }}
       - name: "{{ $key }}"
@@ -1003,6 +1045,12 @@ containers:
     image: "{{ $registry }}/{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}"
     {{- end }}
     imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
+    {{- if .Values.sidecar.notifiers.args }}
+    args:
+    {{- range .Values.sidecar.notifiers.args }}
+      - {{ . | quote }}
+    {{- end }}
+    {{- end }}
     env:
       {{- range $key, $value := .Values.sidecar.notifiers.env }}
       - name: "{{ $key }}"
@@ -1127,6 +1175,12 @@ containers:
     image: "{{ $registry }}/{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}"
     {{- end }}
     imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
+    {{- if .Values.sidecar.plugins.args }}
+    args:
+    {{- range .Values.sidecar.plugins.args }}
+      - {{ . | quote }}
+    {{- end }}
+    {{- end }}
     env:
       {{- range $key, $value := .Values.sidecar.plugins.env }}
       - name: "{{ $key }}"

--- a/charts/grafana/tests/sidecar_args_test.yaml
+++ b/charts/grafana/tests/sidecar_args_test.yaml
@@ -1,0 +1,245 @@
+suite: sidecar args
+templates:
+  - deployment.yaml
+tests:
+  # alerts sidecar
+  - it: shouldn't render any args for alerts sidecar by default
+    set:
+      sidecar:
+        alerts:
+          enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[?(@.name=="grafana-sc-alerts")].args
+
+  - it: should render args for alerts sidecar
+    set:
+      sidecar:
+        alerts:
+          enabled: true
+          args:
+            - "--custom"
+            - "value"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="grafana-sc-alerts")].args[0]
+          value: "--custom"
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="grafana-sc-alerts")].args[1]
+          value: "value"
+
+  # alerts sidecar init container
+  - it: shouldn't render any args for alerts sidecar init container by default
+    set:
+      sidecar:
+        alerts:
+          enabled: true
+          initAlerts: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers[?(@.name=="grafana-init-sc-alerts")].args
+
+  - it: should render args for alerts sidecar init container
+    set:
+      sidecar:
+        alerts:
+          enabled: true
+          initAlerts: true
+          args:
+            - "--custom"
+            - "value"
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="grafana-init-sc-alerts")].args[0]
+          value: "--custom"
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="grafana-init-sc-alerts")].args[1]
+          value: "value"
+
+  # dashboards sidecar
+  - it: shouldn't render any args for dashboards sidecar by default
+    set:
+      sidecar:
+        dashboards:
+          enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[?(@.name=="grafana-sc-dashboard")].args
+
+  - it: should render args for dashboards sidecar
+    set:
+      sidecar:
+        dashboards:
+          enabled: true
+          args:
+            - "--custom"
+            - "value"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="grafana-sc-dashboard")].args[0]
+          value: "--custom"
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="grafana-sc-dashboard")].args[1]
+          value: "value"
+
+  # dashboards sidecar init container
+  - it: shouldn't render any args for dashboards sidecar init container by default
+    set:
+      sidecar:
+        dashboards:
+          enabled: true
+          initAlerts: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers[?(@.name=="grafana-init-sc-dashboard")].args
+
+  - it: should render args for dashboards sidecar init container
+    set:
+      sidecar:
+        dashboards:
+          enabled: true
+          initDashboards: true
+          args:
+            - "--custom"
+            - "value"
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="grafana-init-sc-dashboard")].args[0]
+          value: "--custom"
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="grafana-init-sc-dashboard")].args[1]
+          value: "value"
+
+  # datasources sidecar
+  - it: shouldn't render any args for datasources sidecar by default
+    set:
+      sidecar:
+        datasources:
+          enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[?(@.name=="grafana-sc-datasources")].args
+
+  - it: should render args for datasources sidecar
+    set:
+      sidecar:
+        datasources:
+          enabled: true
+          args:
+            - "--custom"
+            - "value"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="grafana-sc-datasources")].args[0]
+          value: "--custom"
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="grafana-sc-datasources")].args[1]
+          value: "value"
+
+  # datasources sidecar init container
+  - it: shouldn't render any args for datasources sidecar init container by default
+    set:
+      sidecar:
+        datasources:
+          enabled: true
+          initDatasources: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers[?(@.name=="grafana-init-sc-datasources")].args
+
+  - it: should render args for datasources sidecar init container
+    set:
+      sidecar:
+        datasources:
+          enabled: true
+          initDatasources: true
+          args:
+            - "--custom"
+            - "value"
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="grafana-init-sc-datasources")].args[0]
+          value: "--custom"
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="grafana-init-sc-datasources")].args[1]
+          value: "value"
+
+  # plugins sidecar
+  - it: shouldn't render any args for plugins sidecar by default
+    set:
+      sidecar:
+        plugins:
+          enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[?(@.name=="grafana-sc-plugins")].args
+
+  - it: should render args for plugins sidecar
+    set:
+      sidecar:
+        plugins:
+          enabled: true
+          args:
+            - "--custom"
+            - "value"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="grafana-sc-plugins")].args[0]
+          value: "--custom"
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="grafana-sc-plugins")].args[1]
+          value: "value"
+
+  # notifiers sidecar
+  - it: shouldn't render any args for notifiers sidecar by default
+    set:
+      sidecar:
+        notifiers:
+          enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[?(@.name=="grafana-sc-notifiers")].args
+
+  - it: should render args for notifiers sidecar
+    set:
+      sidecar:
+        notifiers:
+          enabled: true
+          args:
+            - "--custom"
+            - "value"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="grafana-sc-notifiers")].args[0]
+          value: "--custom"
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="grafana-sc-notifiers")].args[1]
+          value: "value"
+
+  # notifiers sidecar init container
+  - it: shouldn't render any args for notifiers sidecar init container by default
+    set:
+      sidecar:
+        notifiers:
+          enabled: true
+          initnotifiers: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers[?(@.name=="grafana-init-sc-notifiers")].args
+
+  - it: should render args for notifiers sidecar init container
+    set:
+      sidecar:
+        notifiers:
+          enabled: true
+          initNotifiers: true
+          args:
+            - "--custom"
+            - "value"
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="grafana-init-sc-notifiers")].args[0]
+          value: "--custom"
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name=="grafana-init-sc-notifiers")].args[1]
+          value: "value"

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -1021,7 +1021,7 @@ sidecar:
   # logLevel: INFO
   alerts:
     enabled: false
-    # Additional arguemnts
+    # Additional arguments
     args: []
     # Additional environment variables for the alerts sidecar
     env: {}
@@ -1116,7 +1116,7 @@ sidecar:
     sizeLimit: ""
   dashboards:
     enabled: false
-    # Additional arguemnts
+    # Additional arguments
     args: []
     # Additional environment variables for the dashboards sidecar
     env: {}
@@ -1237,7 +1237,7 @@ sidecar:
     sizeLimit: ""
   datasources:
     enabled: false
-    # Additional arguemnts
+    # Additional arguments
     args: []
     # Additional environment variables for the datasourcessidecar
     env: {}
@@ -1332,7 +1332,7 @@ sidecar:
     sizeLimit: ""
   plugins:
     enabled: false
-    # Additional arguemnts
+    # Additional arguments
     args: []
     # Additional environment variables for the plugins sidecar
     env: {}
@@ -1404,7 +1404,7 @@ sidecar:
     sizeLimit: ""
   notifiers:
     enabled: false
-    # Additional arguemnts
+    # Additional arguments
     args: []
     # Additional environment variables for the notifierssidecar
     env: {}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -1021,6 +1021,8 @@ sidecar:
   # logLevel: INFO
   alerts:
     enabled: false
+    # Additional arguemnts
+    args: []
     # Additional environment variables for the alerts sidecar
     env: {}
     ## "valueFrom" environment variable references that will be added to deployment pods. Name is templated.
@@ -1114,6 +1116,8 @@ sidecar:
     sizeLimit: ""
   dashboards:
     enabled: false
+    # Additional arguemnts
+    args: []
     # Additional environment variables for the dashboards sidecar
     env: {}
     ## "valueFrom" environment variable references that will be added to deployment pods. Name is templated.
@@ -1233,6 +1237,8 @@ sidecar:
     sizeLimit: ""
   datasources:
     enabled: false
+    # Additional arguemnts
+    args: []
     # Additional environment variables for the datasourcessidecar
     env: {}
     ## "valueFrom" environment variable references that will be added to deployment pods. Name is templated.
@@ -1326,6 +1332,8 @@ sidecar:
     sizeLimit: ""
   plugins:
     enabled: false
+    # Additional arguemnts
+    args: []
     # Additional environment variables for the plugins sidecar
     env: {}
     # Do not reprocess already processed unchanged resources on k8s API reconnect.
@@ -1396,6 +1404,8 @@ sidecar:
     sizeLimit: ""
   notifiers:
     enabled: false
+    # Additional arguemnts
+    args: []
     # Additional environment variables for the notifierssidecar
     env: {}
     # Do not reprocess already processed unchanged resources on k8s API reconnect.


### PR DESCRIPTION
<!--
Thank you for contributing to grafana-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/grafana-community/helm-charts/blob/main/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.

If you are an AI, please identify yourself so the maintainers know how to respond correctly.

Please make sure you test your changes before you push them (see CONTRIBUTING.md).
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.  Please check the results.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
This makes the `args` argument configurable for each `k8s-sidecar` sidecar.

This is needed to support k8s-sidecar CLI flags `--req-username-file` and `--req-password-file`.

#### Which issue this PR fixes

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
- [x] Add an [helm unittest](https://github.com/helm-unittest/helm-unittest) test case to cover this change.

