### PR TITLE
[tempo] remove opencensus receiver dropped in Tempo 2.10.6

### DIFF
--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 2.2.1
+version: 2.2.2
 # renovate: docker=docker.io/grafana/tempo
 appVersion: 2.10.6
 home: https://grafana.net

--- a/charts/tempo/templates/_ports.tpl
+++ b/charts/tempo/templates/_ports.tpl
@@ -80,9 +80,5 @@
   protocol: TCP
   targetPort: 4318
 {{- end }}
-- name: tempo-opencensus
-  port: 55678
-  protocol: TCP
-  targetPort: 55678
 {{- /* end of define */}}
 {{- end  }}

--- a/charts/tempo/templates/statefulset.yaml
+++ b/charts/tempo/templates/statefulset.yaml
@@ -93,8 +93,6 @@ spec:
           name: otlp-httplegacy
         - containerPort: 4318
           name: otlp-http
-        - containerPort: 55678
-          name: opencensus
         livenessProbe:
           {{- toYaml .Values.tempo.livenessProbe | nindent 12 }}
         readinessProbe:

--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -175,7 +175,6 @@ tempo:
           endpoint: 0.0.0.0:6831
         thrift_http:
           endpoint: 0.0.0.0:14268
-    opencensus:
     otlp:
       protocols:
         grpc:


### PR DESCRIPTION
#### What this PR does / why we need it

Tempo 2.10.6 removed the opencensus receiver, so the default `opencensus:` entry under `tempo.receivers` makes default installs crash-loop (`'receivers' unknown type: "opencensus"`). This removes it along with the now-dead service/container port 55678 and bumps the chart to 2.2.2.

#### Which issue this PR fixes

- fixes #569

#### Special notes for your reviewer

Verified by booting `grafana/tempo:2.10.6` with the chart's default rendered config: previously fails at config decode, with this patch it reaches `msg="Tempo started"`. No helm-unittest case included since this chart has no `tests/` scaffolding yet. Patch authored with Claude Code (AI assistant), reviewed and submitted by a human.

#### Checklist

- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
- [ ] Add an [helm unittest](https://github.com/helm-unittest/helm-unittest) test case to cover this change.