### PR TITLE
[loki] add labels & annotations in overridesExporter, required when enabled

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.2
-version: 17.3.0
+version: 17.3.1
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/tests/overrides-exporter/deployment_test.yaml
+++ b/charts/loki/tests/overrides-exporter/deployment_test.yaml
@@ -1,0 +1,22 @@
+# $schema: https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json
+suite: override workload
+templates:
+  - overrides-exporter/workload.yaml
+  - config.yaml
+set:
+  deploymentMode: Distributed
+  loki.useTestSchema: true
+  loki.storage.bucketNames.chunks: chunks
+  loki.storage.bucketNames.ruler: ruler
+  loki.storage.bucketNames.admin: admin
+  overridesExporter.enabled: true
+
+tests:
+  - it: should render one Deployment in distributed mode
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: overrides-exporter/workload.yaml
+      - isKind:
+          of: Deployment
+        template: overrides-exporter/workload.yaml

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -4861,6 +4861,10 @@ overridesExporter:
   command: null
   # -- The name of the PriorityClass for overrides-exporter pods
   priorityClassName: null
+  # -- Labels for overrides-exporter
+  labels: {}
+  # -- Annotations for overrides-exporter
+  annotations: {}
   # -- Labels for overrides-exporter pods
   podLabels: {}
   # -- Annotations for overrides-exporter pods


### PR DESCRIPTION
<!--
Thank you for contributing to grafana-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/grafana-community/helm-charts/blob/main/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.

If you are an AI, please identify yourself so the maintainers know how to respond correctly.

Please make sure you test your changes before you push them (see CONTRIBUTING.md).
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.  Please check the results.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Currently, when enabling overrides exporter, the chart fails to template with the following error: 
```
Error: loki/templates/overrides-exporter/workload.yaml:3:4
  executing "loki/templates/overrides-exporter/workload.yaml" at <include "loki.component" (dict "ctx" . "component" .Values.overridesExporter "target" "overrides-exporter")>:
    error calling include:
loki/templates/_workload.tpl:6:4
  executing "loki.component" at <include "loki.component.workload" .>:
    error calling include:
loki/templates/_workload.tpl:31:70
  executing "loki.component.workload" at <$component.labels>:
    wrong type for value; expected map[string]interface {}; got interface {}
```

With this change, the command `helm template loki charts/loki/ -f charts/loki/distributed-values.yaml --set overridesExporter.enabled=true --set ignoreMinioDeprecation=true` runs successfully

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #573

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[grafana]`)
- [ ] Add an [helm unittest](https://github.com/helm-unittest/helm-unittest) test case to cover this change.

