### PR TITLE
[grafana] remove invalid hostPath from extraVolumeMounts example

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 12.4.6
+version: 12.4.7
 # renovate: docker=docker.io/grafana/grafana
 appVersion: 13.0.2
 kubeVersion: "^1.25.0-0"

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -117,7 +117,6 @@ extraVolumeMounts:
     readOnly: false
   - name: dashboards
     mountPath: /var/lib/grafana/dashboards
-    hostPath: /usr/shared/grafana/dashboards
     readOnly: false
 
 extraVolumes:


### PR DESCRIPTION
## Description

The grafana chart README's "Example of extraVolumeMounts and extraVolumes" showed a `dashboards` **volume mount** with a `hostPath` key:

```yaml
extraVolumeMounts:
  - name: dashboards
    mountPath: /var/lib/grafana/dashboards
    hostPath: /usr/shared/grafana/dashboards   # <- invalid on a volumeMount
    readOnly: false
```

A Kubernetes `volumeMount` has no `hostPath` field, and the chart template (`templates/_pod.tpl`) only renders `name`/`mountPath`/`subPath`/`readOnly` for each `extraVolumeMounts` entry — so the key was silently ignored and misled readers into thinking it did something. The `hostPath` belongs on the corresponding `extraVolumes` entry, which the example already has.

This removes the stray `hostPath` line from the volume mount. The `extraVolumes` part is unchanged.

Resolves grafana/helm-charts#4007 (filed against the now-migrated repo).

Chart version bumped 12.4.6 → 12.4.7 per the repo's immutability policy; `helm lint` passes.
