### PR TITLE
[loki] Allow percentages in PDB schemas

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.2
-version: 17.4.4
+version: 17.4.5
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/tests/ingester/pdb_test.yaml
+++ b/charts/loki/tests/ingester/pdb_test.yaml
@@ -85,6 +85,35 @@ tests:
           path: spec.maxUnavailable
           value: 2
 
+  - it: should accept percentage string for podDisruptionBudget.maxUnavailable
+    set:
+      ingester.maxUnavailable: null
+      ingester.podDisruptionBudget.maxUnavailable: 20%
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 20%
+
+  - it: should accept percentage string for deprecated maxUnavailable field
+    set:
+      ingester.maxUnavailable: 20%
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 20%
+
+  - it: should accept percentage string for podDisruptionBudget.minAvailable
+    set:
+      ingester.maxUnavailable: null
+      ingester.podDisruptionBudget.maxUnavailable: null
+      ingester.podDisruptionBudget.minAvailable: 50%
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 50%
+      - notExists:
+          path: spec.maxUnavailable
+
   - it: should use podDisruptionBudget.minAvailable when set to 0
     set:
       ingester.maxUnavailable: null

--- a/charts/loki/values.schema.json
+++ b/charts/loki/values.schema.json
@@ -201,6 +201,7 @@
                     "description": "Pod Disruption Budget maxUnavailable",
                     "deprecated": true,
                     "type": [
+                        "string",
                         "number",
                         "null"
                     ]
@@ -317,6 +318,7 @@
                         "maxUnavailable": {
                             "description": "Pod Disruption Budget maxUnavailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -324,6 +326,7 @@
                         "minAvailable": {
                             "description": "Pod Disruption Budget minAvailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -729,6 +732,7 @@
                     "description": "Pod Disruption Budget maxUnavailable",
                     "deprecated": true,
                     "type": [
+                        "string",
                         "number",
                         "null"
                     ]
@@ -828,6 +832,7 @@
                         "maxUnavailable": {
                             "description": "Pod Disruption Budget maxUnavailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -835,6 +840,7 @@
                         "minAvailable": {
                             "description": "Pod Disruption Budget minAvailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -1238,6 +1244,7 @@
                         "maxUnavailable": {
                             "description": "Pod Disruption Budget maxUnavailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -1245,6 +1252,7 @@
                         "minAvailable": {
                             "description": "Pod Disruption Budget minAvailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -1641,6 +1649,7 @@
                         "maxUnavailable": {
                             "description": "Pod Disruption Budget maxUnavailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -1648,6 +1657,7 @@
                         "minAvailable": {
                             "description": "Pod Disruption Budget minAvailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -2001,6 +2011,7 @@
                             "description": "Pod Disruption Budget maxUnavailable",
                             "deprecated": true,
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -2185,6 +2196,7 @@
                     "description": "Pod Disruption Budget maxUnavailable",
                     "deprecated": true,
                     "type": [
+                        "string",
                         "number",
                         "null"
                     ]
@@ -2267,6 +2279,7 @@
                         "maxUnavailable": {
                             "description": "Pod Disruption Budget maxUnavailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -2274,6 +2287,7 @@
                         "minAvailable": {
                             "description": "Pod Disruption Budget minAvailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -3313,6 +3327,7 @@
                     "description": "Pod Disruption Budget maxUnavailable",
                     "deprecated": true,
                     "type": [
+                        "string",
                         "number",
                         "null"
                     ]
@@ -3353,6 +3368,7 @@
                         "maxUnavailable": {
                             "description": "Pod Disruption Budget maxUnavailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -3360,6 +3376,7 @@
                         "minAvailable": {
                             "description": "Pod Disruption Budget minAvailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -4047,6 +4064,7 @@
                         "maxUnavailable": {
                             "description": "Pod Disruption Budget maxUnavailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -4054,6 +4072,7 @@
                         "minAvailable": {
                             "description": "Pod Disruption Budget minAvailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -4531,6 +4550,7 @@
                     "description": "Pod Disruption Budget maxUnavailable",
                     "deprecated": true,
                     "type": [
+                        "string",
                         "number",
                         "null"
                     ]
@@ -4634,6 +4654,7 @@
                         "maxUnavailable": {
                             "description": "Pod Disruption Budget maxUnavailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -4641,6 +4662,7 @@
                         "minAvailable": {
                             "description": "Pod Disruption Budget minAvailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -5069,6 +5091,7 @@
                     "description": "Pod Disruption Budget maxUnavailable",
                     "deprecated": true,
                     "type": [
+                        "string",
                         "number",
                         "null"
                     ]
@@ -5168,6 +5191,7 @@
                         "maxUnavailable": {
                             "description": "Pod Disruption Budget maxUnavailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -5175,6 +5199,7 @@
                         "minAvailable": {
                             "description": "Pod Disruption Budget minAvailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -6119,6 +6144,7 @@
                         "maxUnavailable": {
                             "description": "Pod Disruption Budget maxUnavailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -6126,6 +6152,7 @@
                         "minAvailable": {
                             "description": "Pod Disruption Budget minAvailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -6970,6 +6997,7 @@
                     "description": "Pod Disruption Budget maxUnavailable",
                     "deprecated": true,
                     "type": [
+                        "string",
                         "number",
                         "null"
                     ]
@@ -7010,6 +7038,7 @@
                         "maxUnavailable": {
                             "description": "Pod Disruption Budget maxUnavailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -7017,6 +7046,7 @@
                         "minAvailable": {
                             "description": "Pod Disruption Budget minAvailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -7326,6 +7356,7 @@
                     "description": "Pod Disruption Budget maxUnavailable",
                     "deprecated": true,
                     "type": [
+                        "string",
                         "number",
                         "null"
                     ]
@@ -7446,6 +7477,7 @@
                         "maxUnavailable": {
                             "description": "Pod Disruption Budget maxUnavailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -7453,6 +7485,7 @@
                         "minAvailable": {
                             "description": "Pod Disruption Budget minAvailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -7850,6 +7883,7 @@
                     "description": "Pod Disruption Budget maxUnavailable",
                     "deprecated": true,
                     "type": [
+                        "string",
                         "number",
                         "null"
                     ]
@@ -7890,6 +7924,7 @@
                         "maxUnavailable": {
                             "description": "Pod Disruption Budget maxUnavailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -7897,6 +7932,7 @@
                         "minAvailable": {
                             "description": "Pod Disruption Budget minAvailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -8339,6 +8375,7 @@
                     "description": "Pod Disruption Budget maxUnavailable",
                     "deprecated": true,
                     "type": [
+                        "string",
                         "number",
                         "null"
                     ]
@@ -8379,6 +8416,7 @@
                         "maxUnavailable": {
                             "description": "Pod Disruption Budget maxUnavailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -8386,6 +8424,7 @@
                         "minAvailable": {
                             "description": "Pod Disruption Budget minAvailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -8699,6 +8738,7 @@
                     "description": "Pod Disruption Budget maxUnavailable",
                     "deprecated": true,
                     "type": [
+                        "string",
                         "number",
                         "null"
                     ]
@@ -8739,6 +8779,7 @@
                         "maxUnavailable": {
                             "description": "Pod Disruption Budget maxUnavailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -8746,6 +8787,7 @@
                         "minAvailable": {
                             "description": "Pod Disruption Budget minAvailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -9155,6 +9197,7 @@
                     "description": "Pod Disruption Budget maxUnavailable",
                     "deprecated": true,
                     "type": [
+                        "string",
                         "number",
                         "null"
                     ]
@@ -9195,6 +9238,7 @@
                         "maxUnavailable": {
                             "description": "Pod Disruption Budget maxUnavailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -9202,6 +9246,7 @@
                         "minAvailable": {
                             "description": "Pod Disruption Budget minAvailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -9465,6 +9510,7 @@
                     "description": "Pod Disruption Budget maxUnavailable",
                     "deprecated": true,
                     "type": [
+                        "string",
                         "number",
                         "null"
                     ]
@@ -9544,6 +9590,7 @@
                         "maxUnavailable": {
                             "description": "Pod Disruption Budget maxUnavailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -9551,6 +9598,7 @@
                         "minAvailable": {
                             "description": "Pod Disruption Budget minAvailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -9885,6 +9933,7 @@
                     "description": "Pod Disruption Budget maxUnavailable",
                     "deprecated": true,
                     "type": [
+                        "string",
                         "number",
                         "null"
                     ]
@@ -9973,6 +10022,7 @@
                         "maxUnavailable": {
                             "description": "Pod Disruption Budget maxUnavailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -9980,6 +10030,7 @@
                         "minAvailable": {
                             "description": "Pod Disruption Budget minAvailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -10639,6 +10690,7 @@
                         "maxUnavailable": {
                             "description": "Pod Disruption Budget maxUnavailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -10646,6 +10698,7 @@
                         "minAvailable": {
                             "description": "Pod Disruption Budget minAvailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -11311,6 +11364,7 @@
                     "description": "Pod Disruption Budget maxUnavailable",
                     "deprecated": true,
                     "type": [
+                        "string",
                         "number",
                         "null"
                     ]
@@ -11415,6 +11469,7 @@
                         "maxUnavailable": {
                             "description": "Pod Disruption Budget maxUnavailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]
@@ -11422,6 +11477,7 @@
                         "minAvailable": {
                             "description": "Pod Disruption Budget minAvailable",
                             "type": [
+                                "string",
                                 "number",
                                 "null"
                             ]

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -1006,10 +1006,10 @@ lokiCanary:
     # -- Labels for Pod Disruption Budget
     labels: {}
 
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget minAvailable
     minAvailable: null
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget maxUnavailable
     maxUnavailable: null
     # @schema type:[string, null]
@@ -1073,7 +1073,7 @@ lokiCanary:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      # @schema type:[number, null]
+      # @schema type:[string, number, null]
       # -- Pod Disruption Budget maxUnavailable
       maxUnavailable: 1
   # -- Replicas for `loki-canary` when using a Deployment
@@ -1358,10 +1358,10 @@ gateway:
     # -- Labels for Pod Disruption Budget
     labels: {}
 
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget minAvailable
     minAvailable: null
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget maxUnavailable
     maxUnavailable: null
     # @schema type:[string, null]
@@ -1985,10 +1985,10 @@ singleBinary:
     # -- Labels for Pod Disruption Budget
     labels: {}
 
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget minAvailable
     minAvailable: null
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget maxUnavailable
     maxUnavailable: null
     # @schema type:[string, null]
@@ -2308,7 +2308,7 @@ write:
   # @schema additionalProperties:true
   # -- DNS config for write pods
   dnsConfig: {}
-  # @schema type:[number, null];deprecated:true
+  # @schema type:[string, number, null];deprecated:true
   # -- Pod Disruption Budget maxUnavailable
   # @deprecated -- This is deprecated in favor of `podDisruptionBudget.maxUnavailable`.
   maxUnavailable: 1
@@ -2322,10 +2322,10 @@ write:
     # -- Labels for Pod Disruption Budget
     labels: {}
 
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget minAvailable
     minAvailable: null
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget maxUnavailable
     maxUnavailable: null
     # @schema type:[string, null]
@@ -2412,7 +2412,7 @@ read:
   strategy:
     rollingUpdate:
       maxSurge: 0
-      # @schema type:[number, null]
+      # @schema type:[string, number, null]
       # -- Pod Disruption Budget maxUnavailable
       maxUnavailable: 1
   autoscaling:
@@ -2578,7 +2578,7 @@ read:
   # @schema additionalProperties:true
   # -- DNS config for read pods
   dnsConfig: {}
-  # @schema type:[number, null];deprecated:true
+  # @schema type:[string, number, null];deprecated:true
   # -- Pod Disruption Budget maxUnavailable
   # @deprecated -- This is deprecated in favor of `podDisruptionBudget.maxUnavailable`.
   maxUnavailable: 1
@@ -2592,10 +2592,10 @@ read:
     # -- Labels for read Pod Disruption Budget
     labels: {}
 
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget minAvailable
     minAvailable: null
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget maxUnavailable
     maxUnavailable: null
     # @schema type:[string, null]
@@ -2811,7 +2811,7 @@ backend:
   # @schema additionalProperties:true
   # -- DNS config for backend pods
   dnsConfig: {}
-  # @schema type:[number, null];deprecated:true
+  # @schema type:[string, number, null];deprecated:true
   # -- Pod Disruption Budget maxUnavailable
   # @deprecated -- This is deprecated in favor of `podDisruptionBudget.maxUnavailable`.
   maxUnavailable: 1
@@ -2825,10 +2825,10 @@ backend:
     # -- Labels for Pod Disruption Budget
     labels: {}
 
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget minAvailable
     minAvailable: null
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget maxUnavailable
     maxUnavailable: null
     # @schema type:[string, null]
@@ -3126,7 +3126,7 @@ ingester:
               app.kubernetes.io/name: '{{ include "loki.name" . }}'
               app.kubernetes.io/instance: '{{ .Release.Name }}'
           topologyKey: kubernetes.io/hostname
-  # @schema type:[number, null];deprecated:true
+  # @schema type:[string, number, null];deprecated:true
   # -- Pod Disruption Budget maxUnavailable
   # @deprecated -- This is deprecated in favor of `podDisruptionBudget.maxUnavailable`.
   maxUnavailable: 1
@@ -3140,10 +3140,10 @@ ingester:
     # -- Labels for Pod Disruption Budget
     labels: {}
 
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget minAvailable
     minAvailable: null
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget maxUnavailable
     maxUnavailable: null
     # @schema type:[string, null]
@@ -3336,7 +3336,7 @@ distributor:
   strategy:
     rollingUpdate:
       maxSurge: 0
-      # @schema type:[number, null]
+      # @schema type:[string, number, null]
       # -- Pod Disruption Budget maxUnavailable
       maxUnavailable: 1
   # -- hostAliases to add
@@ -3511,10 +3511,10 @@ distributor:
     # -- Labels for Pod Disruption Budget
     labels: {}
 
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget minAvailable
     minAvailable: null
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget maxUnavailable
     maxUnavailable: null
     # @schema type:[string, null]
@@ -3533,7 +3533,7 @@ distributor:
               app.kubernetes.io/name: '{{ include "loki.name" . }}'
               app.kubernetes.io/instance: '{{ .Release.Name }}'
           topologyKey: kubernetes.io/hostname
-  # @schema type:[number, null];deprecated:true
+  # @schema type:[string, number, null];deprecated:true
   # -- Pod Disruption Budget maxUnavailable
   # @deprecated -- This is deprecated in favor of `podDisruptionBudget.maxUnavailable`.
   maxUnavailable: null
@@ -3592,7 +3592,7 @@ querier:
     type: RollingUpdate
     rollingUpdate:
       maxSurge: 0
-      # @schema type:[number, null]
+      # @schema type:[string, number, null]
       # -- Pod Disruption Budget maxUnavailable
       maxUnavailable: 1
   # -- hostAliases to add
@@ -3773,10 +3773,10 @@ querier:
     # -- Labels for Pod Disruption Budget
     labels: {}
 
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget minAvailable
     minAvailable: null
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget maxUnavailable
     maxUnavailable: null
     # @schema type:[string, null]
@@ -3808,7 +3808,7 @@ querier:
               app.kubernetes.io/name: '{{ include "loki.name" . }}'
               app.kubernetes.io/instance: '{{ .Release.Name }}'
           topologyKey: kubernetes.io/hostname
-  # @schema type:[number, null];deprecated:true
+  # @schema type:[string, number, null];deprecated:true
   # -- Pod Disruption Budget maxUnavailable
   # @deprecated -- This is deprecated in favor of `podDisruptionBudget.maxUnavailable`.
   maxUnavailable: null
@@ -3867,7 +3867,7 @@ queryFrontend:
     type: RollingUpdate
     rollingUpdate:
       maxSurge: 0
-      # @schema type:[number, null]
+      # @schema type:[string, number, null]
       # -- Pod Disruption Budget maxUnavailable
       maxUnavailable: 1
   # -- hostAliases to add
@@ -4039,10 +4039,10 @@ queryFrontend:
     # -- Labels for Pod Disruption Budget
     labels: {}
 
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget minAvailable
     minAvailable: null
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget maxUnavailable
     maxUnavailable: null
     # @schema type:[string, null]
@@ -4061,7 +4061,7 @@ queryFrontend:
               app.kubernetes.io/name: '{{ include "loki.name" . }}'
               app.kubernetes.io/instance: '{{ .Release.Name }}'
           topologyKey: kubernetes.io/hostname
-  # @schema type:[number, null];deprecated:true
+  # @schema type:[string, number, null];deprecated:true
   # -- Pod Disruption Budget maxUnavailable
   # @deprecated -- This is deprecated in favor of `podDisruptionBudget.maxUnavailable`.
   maxUnavailable: null
@@ -4124,7 +4124,7 @@ queryScheduler:
     type: RollingUpdate
     rollingUpdate:
       maxSurge: 0
-      # @schema type:[number, null]
+      # @schema type:[string, number, null]
       # -- Pod Disruption Budget maxUnavailable
       maxUnavailable: 1
   # @schema additionalProperties:true
@@ -4243,7 +4243,7 @@ queryScheduler:
               app.kubernetes.io/name: '{{ include "loki.name" . }}'
               app.kubernetes.io/instance: '{{ .Release.Name }}'
           topologyKey: kubernetes.io/hostname
-  # @schema type:[number, null];deprecated:true
+  # @schema type:[string, number, null];deprecated:true
   # -- Pod Disruption Budget maxUnavailable
   # @deprecated -- This is deprecated in favor of `podDisruptionBudget.maxUnavailable`.
   maxUnavailable: 1
@@ -4257,10 +4257,10 @@ queryScheduler:
     # -- Labels for Pod Disruption Budget
     labels: {}
 
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget minAvailable
     minAvailable: null
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget maxUnavailable
     maxUnavailable: null
     # @schema type:[string, null]
@@ -4429,10 +4429,10 @@ indexGateway:
     # -- Labels for Pod Disruption Budget
     labels: {}
 
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget minAvailable
     minAvailable: null
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget maxUnavailable
     maxUnavailable: null
     # @schema type:[string, null]
@@ -4453,7 +4453,7 @@ indexGateway:
               app.kubernetes.io/name: '{{ include "loki.name" . }}'
               app.kubernetes.io/instance: '{{ .Release.Name }}'
           topologyKey: kubernetes.io/hostname
-  # @schema type:[number, null];deprecated:true
+  # @schema type:[string, number, null];deprecated:true
   # -- Pod Disruption Budget maxUnavailable
   # @deprecated -- This is deprecated in favor of `podDisruptionBudget.maxUnavailable`.
   maxUnavailable: null
@@ -4911,10 +4911,10 @@ bloomGateway:
     # -- Labels for Pod Disruption Budget
     labels: {}
 
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget minAvailable
     minAvailable: null
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget maxUnavailable
     maxUnavailable: null
     # @schema type:[string, null]
@@ -5117,10 +5117,10 @@ bloomPlanner:
     # -- Labels for Pod Disruption Budget
     labels: {}
 
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget minAvailable
     minAvailable: null
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget maxUnavailable
     maxUnavailable: null
     # @schema type:[string, null]
@@ -5371,10 +5371,10 @@ bloomBuilder:
     # -- Labels for Pod Disruption Budget
     labels: {}
 
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget minAvailable
     minAvailable: null
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget maxUnavailable
     maxUnavailable: null
     # @schema type:[string, null]
@@ -5393,7 +5393,7 @@ bloomBuilder:
               app.kubernetes.io/name: '{{ include "loki.name" . }}'
               app.kubernetes.io/instance: '{{ .Release.Name }}'
           topologyKey: kubernetes.io/hostname
-  # @schema type:[number, null];deprecated:true
+  # @schema type:[string, number, null];deprecated:true
   # -- Pod Disruption Budget maxUnavailable
   # @deprecated -- This is deprecated in favor of `podDisruptionBudget.maxUnavailable`.
   maxUnavailable: null
@@ -5413,7 +5413,7 @@ bloomBuilder:
   strategy:
     rollingUpdate:
       maxSurge: 0
-      # @schema type:[number, null]
+      # @schema type:[string, number, null]
       # -- Pod Disruption Budget maxUnavailable
       maxUnavailable: 1
   persistence:
@@ -5536,7 +5536,7 @@ patternIngester:
               app.kubernetes.io/name: '{{ include "loki.name" . }}'
               app.kubernetes.io/instance: '{{ .Release.Name }}'
           topologyKey: kubernetes.io/hostname
-  # @schema type:[number, null];deprecated:true
+  # @schema type:[string, number, null];deprecated:true
   # -- Pod Disruption Budget maxUnavailable
   # @deprecated -- This is deprecated in favor of `podDisruptionBudget.maxUnavailable`.
   maxUnavailable: null
@@ -5588,10 +5588,10 @@ patternIngester:
     # -- Labels for Pod Disruption Budget
     labels: {}
 
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget minAvailable
     minAvailable: null
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget maxUnavailable
     maxUnavailable: null
     # @schema type:[string, null]
@@ -5796,10 +5796,10 @@ ruler:
     # -- Labels for Pod Disruption Budget
     labels: {}
 
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget minAvailable
     minAvailable: null
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget maxUnavailable
     maxUnavailable: null
     # @schema type:[string, null]
@@ -5818,7 +5818,7 @@ ruler:
               app.kubernetes.io/name: '{{ include "loki.name" . }}'
               app.kubernetes.io/instance: '{{ .Release.Name }}'
           topologyKey: kubernetes.io/hostname
-  # @schema type:[number, null];deprecated:true
+  # @schema type:[string, number, null];deprecated:true
   # -- Pod Disruption Budget maxUnavailable
   # @deprecated -- This is deprecated in favor of `podDisruptionBudget.maxUnavailable`.
   maxUnavailable: null
@@ -6072,10 +6072,10 @@ overridesExporter:
     # -- Labels for Pod Disruption Budget
     labels: {}
 
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget minAvailable
     minAvailable: null
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget maxUnavailable
     maxUnavailable: null
     # @schema type:[string, null]
@@ -6094,7 +6094,7 @@ overridesExporter:
               app.kubernetes.io/name: '{{ include "loki.name" . }}'
               app.kubernetes.io/instance: '{{ .Release.Name }}'
           topologyKey: kubernetes.io/hostname
-  # @schema type:[number, null];deprecated:true
+  # @schema type:[string, number, null];deprecated:true
   # -- Pod Disruption Budget maxUnavailable
   # @deprecated -- This is deprecated in favor of `podDisruptionBudget.maxUnavailable`.
   maxUnavailable: null
@@ -6315,7 +6315,7 @@ resultsCache:
   #  whenUnsatisfiable: ScheduleAnyway
   # -- Tolerations for results-cache pods
   tolerations: []
-  # @schema type:[number, null];deprecated:true
+  # @schema type:[string, number, null];deprecated:true
   # -- Pod Disruption Budget maxUnavailable
   # @deprecated -- This is deprecated in favor of `podDisruptionBudget.maxUnavailable`.
   maxUnavailable: 1
@@ -6329,10 +6329,10 @@ resultsCache:
     # -- Labels for Pod Disruption Budget
     labels: {}
 
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget minAvailable
     minAvailable: null
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget maxUnavailable
     maxUnavailable: null
     # @schema type:[string, null]
@@ -6477,7 +6477,7 @@ chunksCache:
   #  whenUnsatisfiable: ScheduleAnyway
   # -- Tolerations for chunks-cache pods
   tolerations: []
-  # @schema type:[number, null];deprecated:true
+  # @schema type:[string, number, null];deprecated:true
   # -- Pod Disruption Budget maxUnavailable
   # @deprecated -- This is deprecated in favor of `podDisruptionBudget.maxUnavailable`.
   maxUnavailable: 1
@@ -6491,10 +6491,10 @@ chunksCache:
     # -- Labels for Pod Disruption Budget
     labels: {}
 
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget minAvailable
     minAvailable: null
-    # @schema type:[number, null]
+    # @schema type:[string, number, null]
     # -- Pod Disruption Budget maxUnavailable
     maxUnavailable: null
     # @schema type:[string, null]
@@ -6642,7 +6642,7 @@ chunksCache:
     #  whenUnsatisfiable: ScheduleAnyway
     # -- Tolerations for chunks-cache-l2 pods
     tolerations: []
-    # @schema type:[number, null];deprecated:true
+    # @schema type:[string, number, null];deprecated:true
     # -- Pod Disruption Budget maxUnavailable
     # @deprecated -- This is deprecated in favor of `podDisruptionBudget.maxUnavailable`.
     maxUnavailable: 1


### PR DESCRIPTION
<!--
Thank you for contributing to grafana-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/grafana-community/helm-charts/blob/main/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.

If you are an AI, please identify yourself so the maintainers know how to respond correctly.

Please make sure you test your changes before you push them (see CONTRIBUTING.md).
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.  Please check the results.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
With the introduction of value schema validation (#595), PodDisruptionBudgets can no longer use percentages for `minAvailable`/`maxUnavailable`.

Add string as a valid type to allow percentage based PDB again:
```yaml
querier:
  maxUnavailable: 20%
```

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
- [x] Add an [helm unittest](https://github.com/helm-unittest/helm-unittest) test case to cover this change.

