### PR TITLE
[grafana] Fix env var quoting to handle backslashes/special characters

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 12.4.7
+version: 12.4.8
 # renovate: docker=docker.io/grafana/grafana
 appVersion: 13.0.2
 kubeVersion: "^1.25.0-0"

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -1492,8 +1492,8 @@ containers:
           {{- tpl (toYaml $value) $ | nindent 10 }}
       {{- end }}
       {{- range $key, $value := .Values.env }}
-      - name: "{{ tpl $key $ }}"
-        value: "{{ tpl (print $value) $ }}"
+      - name: {{ tpl $key $ | quote }}
+        value: {{ tpl (print $value) $ | quote }}
       {{- end }}
     {{- if or .Values.envFromSecret (or .Values.envRenderSecret .Values.envFromSecrets) .Values.envFromConfigMaps }}
     envFrom:


### PR DESCRIPTION
## Description

Fixes #4020 (filed on the now-migrated `grafana/helm-charts` repo).

The grafana pod template rendered env entries with **manual double-quote wrapping**:

```yaml
- name: "{{ tpl $key $ }}"
  value: "{{ tpl (print $value) $ }}"
```

Any value containing a backslash (or other character that forms an invalid double-quoted-YAML escape) — e.g. a Windows path `C:\Users\test` — then renders invalid YAML, and `helm template` / `helm install` fails with:

```
Error: YAML parse error on grafana/templates/deployment.yaml: ... did not find expected hexdecimal number
```

This switches to Helm's `quote` function, which escapes the value correctly — the same idiom the adjacent `envValueFrom` block and `secret-env.yaml` already use:

```yaml
- name: {{ tpl $key $ | quote }}
  value: {{ tpl (print $value) $ | quote }}
```

## Verification

- **Before:** `helm template -f values.yaml` with `env: { MY_VAR: 'C:\Users\test' }` → fails (`did not find expected hexdecimal number`).
- **After:** renders valid YAML (`value: "C:\\Users\\test"`).
- For ordinary string/numeric values the rendered output is **byte-identical**.
- `helm lint` passes. Chart version bumped 12.4.7 → 12.4.8.
