### PR TITLE
[grafana] Mark admin credential secretKeyRef optional

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 12.7.1
+version: 12.7.2
 # renovate: docker=docker.io/grafana/grafana
 appVersion: 13.1.0
 kubeVersion: "^1.25.0-0"

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -287,6 +287,7 @@ initContainers:
           secretKeyRef:
             name: {{ (tpl .Values.admin.existingSecret .) | default (include "grafana.fullname" .) }}
             key: {{ .Values.admin.userKey | default "admin-user" }}
+            optional: true
       {{- end }}
       {{- if and (not .Values.env.GF_SECURITY_ADMIN_PASSWORD) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
       - name: REQ_PASSWORD
@@ -294,6 +295,7 @@ initContainers:
           secretKeyRef:
             name: {{ (tpl .Values.admin.existingSecret .) | default (include "grafana.fullname" .) }}
             key: {{ .Values.admin.passwordKey | default "admin-password" }}
+            optional: true
       {{- end }}
       {{- if not .Values.sidecar.datasources.skipReload }}
       - name: REQ_URL
@@ -526,6 +528,7 @@ initContainers:
           secretKeyRef:
             name: {{ (tpl .Values.admin.existingSecret .) | default (include "grafana.fullname" .) }}
             key: {{ .Values.admin.userKey | default "admin-user" }}
+            optional: true
       {{- end }}
       {{- if and (not .Values.env.GF_SECURITY_ADMIN_PASSWORD) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
       - name: REQ_PASSWORD
@@ -533,6 +536,7 @@ initContainers:
           secretKeyRef:
             name: {{ (tpl .Values.admin.existingSecret .) | default (include "grafana.fullname" .) }}
             key: {{ .Values.admin.passwordKey | default "admin-password" }}
+            optional: true
       {{- end }}
       - name: REQ_URL
         value: {{ .Values.sidecar.dashboards.reloadURL }}
@@ -669,6 +673,7 @@ containers:
           secretKeyRef:
             name: {{ (tpl .Values.admin.existingSecret .) | default (include "grafana.fullname" .) }}
             key: {{ .Values.admin.userKey | default "admin-user" }}
+            optional: true
       {{- end }}
       {{- if and (not .Values.env.GF_SECURITY_ADMIN_PASSWORD) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
       - name: REQ_PASSWORD
@@ -676,6 +681,7 @@ containers:
           secretKeyRef:
             name: {{ (tpl .Values.admin.existingSecret .) | default (include "grafana.fullname" .) }}
             key: {{ .Values.admin.passwordKey | default "admin-password" }}
+            optional: true
       {{- end }}
       {{- if not .Values.sidecar.alerts.skipReload }}
       - name: REQ_URL
@@ -803,6 +809,7 @@ containers:
           secretKeyRef:
             name: {{ (tpl .Values.admin.existingSecret .) | default (include "grafana.fullname" .) }}
             key: {{ .Values.admin.userKey | default "admin-user" }}
+            optional: true
       {{- end }}
       {{- if and (not .Values.env.GF_SECURITY_ADMIN_PASSWORD) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
       - name: REQ_PASSWORD
@@ -810,6 +817,7 @@ containers:
           secretKeyRef:
             name: {{ (tpl .Values.admin.existingSecret .) | default (include "grafana.fullname" .) }}
             key: {{ .Values.admin.passwordKey | default "admin-password" }}
+            optional: true
       {{- end }}
       - name: REQ_URL
         value: {{ .Values.sidecar.dashboards.reloadURL }}
@@ -931,6 +939,7 @@ containers:
           secretKeyRef:
             name: {{ (tpl .Values.admin.existingSecret .) | default (include "grafana.fullname" .) }}
             key: {{ .Values.admin.userKey | default "admin-user" }}
+            optional: true
       {{- end }}
       {{- if and (not .Values.env.GF_SECURITY_ADMIN_PASSWORD) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
       - name: REQ_PASSWORD
@@ -938,6 +947,7 @@ containers:
           secretKeyRef:
             name: {{ (tpl .Values.admin.existingSecret .) | default (include "grafana.fullname" .) }}
             key: {{ .Values.admin.passwordKey | default "admin-password" }}
+            optional: true
       {{- end }}
       {{- if not .Values.sidecar.datasources.skipReload }}
       - name: REQ_URL
@@ -1055,6 +1065,7 @@ containers:
           secretKeyRef:
             name: {{ (tpl .Values.admin.existingSecret .) | default (include "grafana.fullname" .) }}
             key: {{ .Values.admin.userKey | default "admin-user" }}
+            optional: true
       {{- end }}
       {{- if and (not .Values.env.GF_SECURITY_ADMIN_PASSWORD) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
       - name: REQ_PASSWORD
@@ -1062,6 +1073,7 @@ containers:
           secretKeyRef:
             name: {{ (tpl .Values.admin.existingSecret .) | default (include "grafana.fullname" .) }}
             key: {{ .Values.admin.passwordKey | default "admin-password" }}
+            optional: true
       {{- end }}
       {{- if not .Values.sidecar.notifiers.skipReload }}
       - name: REQ_URL
@@ -1179,6 +1191,7 @@ containers:
           secretKeyRef:
             name: {{ (tpl .Values.admin.existingSecret .) | default (include "grafana.fullname" .) }}
             key: {{ .Values.admin.userKey | default "admin-user" }}
+            optional: true
       {{- end }}
       {{- if and (not .Values.env.GF_SECURITY_ADMIN_PASSWORD) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
       - name: REQ_PASSWORD
@@ -1186,6 +1199,7 @@ containers:
           secretKeyRef:
             name: {{ (tpl .Values.admin.existingSecret .) | default (include "grafana.fullname" .) }}
             key: {{ .Values.admin.passwordKey | default "admin-password" }}
+            optional: true
       {{- end }}
       {{- if not .Values.sidecar.plugins.skipReload }}
       - name: REQ_URL
@@ -1423,6 +1437,7 @@ containers:
           secretKeyRef:
             name: {{ (tpl .Values.admin.existingSecret .) | default (include "grafana.fullname" .) }}
             key: {{ .Values.admin.userKey | default "admin-user" }}
+            optional: true
       {{- end }}
       {{- if and (not .Values.env.GF_SECURITY_ADMIN_PASSWORD) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
       - name: GF_SECURITY_ADMIN_PASSWORD
@@ -1430,6 +1445,7 @@ containers:
           secretKeyRef:
             name: {{ (tpl .Values.admin.existingSecret .) | default (include "grafana.fullname" .) }}
             key: {{ .Values.admin.passwordKey | default "admin-password" }}
+            optional: true
       {{- end }}
       {{- if .Values.plugins }}
       - name: GF_PLUGINS_PREINSTALL_SYNC


### PR DESCRIPTION
## What

The admin-credential `secretKeyRef`s in `charts/grafana/templates/_pod.tpl` reference `admin.existingSecret` **without** `optional: true` — both `GF_SECURITY_ADMIN_USER`/`GF_SECURITY_ADMIN_PASSWORD` on the Grafana container and the `REQ_USER`/`REQ_PASSWORD` variants on the sidecar reload containers (16 references across 8 container/sidecar env blocks).

A consumer that sets `admin.existingSecret` but deliberately omits the `admin-user`/`admin-password` keys — e.g. an **OIDC-only** deployment that wants no local admin account — therefore hits `CreateContainerConfigError` and the pod never starts. There is no published-value path to express this today:

- dropping `existingSecret` bakes a `randAlphaNum` password (non-deterministic; breaks GitOps byte-stability),
- `GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION` set as a direct `env:` is not consumer-overridable (`env` beats `envFrom`).

## Change

Add `optional: true` to every admin-credential `secretKeyRef`, consistent with the chart's existing `optional:` usage. Chart `version` bump 12.7.1 → 12.7.2 (PATCH, backwards-compatible).

- Consumers that **do** supply the admin keys: unchanged.
- Consumers that supply `admin.existingSecret` **without** the admin keys (OIDC-only, no local admin): the pod now starts — no credential baked, no forced `DISABLE_INITIAL_ADMIN_CREATION`.

Both auth directions become freely selectable.

## Testing

Verified the diff: 16 `optional: true` additions, each directly under the admin `secretKeyRef` (after `key:`), correct indentation; `optional` is a valid `SecretKeySelector` field. `chart-testing` (lint + install) in CI validates the render.

## AI disclosure

Per the template's request: this change was prepared with the assistance of an AI coding agent (Claude) and reviewed by the human contributors before submission.

---

Originated from review of our internal catalog component (`devobagmbh/talos-platform-apps#333`); the `optional: true` direction was proposed by @Nosmoht (co-author credited in the commit trailer).