### PR TITLE
[loki] Add graceful drain to distributor

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.3
-version: 18.1.1
+version: 18.2.0
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/templates/distributor/workload.yaml
+++ b/charts/loki/templates/distributor/workload.yaml
@@ -8,5 +8,9 @@
     {{- $args = list "-distributor.zone-awareness-enabled=true" }}
   {{- end }}
 {{- end }}
+{{/* Inject -shutdown-delay before extraArgs so a user-supplied extraArgs override can't drop it. */}}
+{{- with .Values.distributor.shutdownDelay }}
+{{- $args = append $args (printf "-shutdown-delay=%s" .) }}
+{{- end }}
 {{- include "loki.component" (dict "ctx" . "component" .Values.distributor "target" "distributor" "args" $args) }}
 {{- end }}

--- a/charts/loki/templates/distributor/workload.yaml
+++ b/charts/loki/templates/distributor/workload.yaml
@@ -8,9 +8,11 @@
     {{- $args = list "-distributor.zone-awareness-enabled=true" }}
   {{- end }}
 {{- end }}
-{{/* Inject -shutdown-delay before extraArgs so a user-supplied extraArgs override can't drop it. */}}
+{{/* Inject -shutdown-delay before extraArgs so a user-supplied extraArgs override can't drop it. "0s" (default) renders nothing. */}}
 {{- with .Values.distributor.shutdownDelay }}
+{{- if ne (. | toString) "0s" }}
 {{- $args = append $args (printf "-shutdown-delay=%s" .) }}
+{{- end }}
 {{- end }}
 {{- include "loki.component" (dict "ctx" . "component" .Values.distributor "target" "distributor" "args" $args) }}
 {{- end }}

--- a/charts/loki/tests/distributor/shutdown_delay_test.yaml
+++ b/charts/loki/tests/distributor/shutdown_delay_test.yaml
@@ -1,0 +1,70 @@
+suite: distributor graceful drain
+templates:
+  - distributor/workload.yaml
+  - config.yaml
+tests:
+  - it: renders -shutdown-delay and a matching grace period by default
+    template: distributor/workload.yaml
+    set:
+      deploymentMode: Distributed
+      loki.commonConfig.replication_factor: 1
+      loki.useTestSchema: true
+      loki.storage.bucketNames.chunks: chunks
+      loki.storage.bucketNames.ruler: ruler
+      loki.storage.bucketNames.admin: admin
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: -shutdown-delay=60s
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 100
+
+  - it: shutdownDelay is configurable
+    template: distributor/workload.yaml
+    set:
+      deploymentMode: Distributed
+      loki.commonConfig.replication_factor: 1
+      loki.useTestSchema: true
+      loki.storage.bucketNames.chunks: chunks
+      loki.storage.bucketNames.ruler: ruler
+      loki.storage.bucketNames.admin: admin
+      distributor.shutdownDelay: 90s
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: -shutdown-delay=90s
+
+  - it: shutdown-delay is omitted when shutdownDelay is unset
+    template: distributor/workload.yaml
+    set:
+      deploymentMode: Distributed
+      loki.commonConfig.replication_factor: 1
+      loki.useTestSchema: true
+      loki.storage.bucketNames.chunks: chunks
+      loki.storage.bucketNames.ruler: ruler
+      loki.storage.bucketNames.admin: admin
+      distributor.shutdownDelay: null
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: -shutdown-delay=60s
+
+  - it: shutdown-delay survives a user-supplied extraArgs override
+    template: distributor/workload.yaml
+    set:
+      deploymentMode: Distributed
+      loki.commonConfig.replication_factor: 1
+      loki.useTestSchema: true
+      loki.storage.bucketNames.chunks: chunks
+      loki.storage.bucketNames.ruler: ruler
+      loki.storage.bucketNames.admin: admin
+      distributor.extraArgs:
+        - -log.level=debug
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: -shutdown-delay=60s
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: -log.level=debug

--- a/charts/loki/tests/distributor/shutdown_delay_test.yaml
+++ b/charts/loki/tests/distributor/shutdown_delay_test.yaml
@@ -3,7 +3,7 @@ templates:
   - distributor/workload.yaml
   - config.yaml
 tests:
-  - it: renders -shutdown-delay and a matching grace period by default
+  - it: renders no -shutdown-delay by default (0s) and leaves grace at 30
     template: distributor/workload.yaml
     set:
       deploymentMode: Distributed
@@ -13,14 +13,14 @@ tests:
       loki.storage.bucketNames.ruler: ruler
       loki.storage.bucketNames.admin: admin
     asserts:
-      - contains:
+      - notContains:
           path: spec.template.spec.containers[0].args
-          content: -shutdown-delay=60s
+          content: -shutdown-delay=0s
       - equal:
           path: spec.template.spec.terminationGracePeriodSeconds
-          value: 100
+          value: 30
 
-  - it: shutdownDelay is configurable
+  - it: shutdownDelay is opt-in and configurable
     template: distributor/workload.yaml
     set:
       deploymentMode: Distributed
@@ -35,21 +35,6 @@ tests:
           path: spec.template.spec.containers[0].args
           content: -shutdown-delay=90s
 
-  - it: shutdown-delay is omitted when shutdownDelay is unset
-    template: distributor/workload.yaml
-    set:
-      deploymentMode: Distributed
-      loki.commonConfig.replication_factor: 1
-      loki.useTestSchema: true
-      loki.storage.bucketNames.chunks: chunks
-      loki.storage.bucketNames.ruler: ruler
-      loki.storage.bucketNames.admin: admin
-      distributor.shutdownDelay: null
-    asserts:
-      - notContains:
-          path: spec.template.spec.containers[0].args
-          content: -shutdown-delay=60s
-
   - it: shutdown-delay survives a user-supplied extraArgs override
     template: distributor/workload.yaml
     set:
@@ -59,6 +44,7 @@ tests:
       loki.storage.bucketNames.chunks: chunks
       loki.storage.bucketNames.ruler: ruler
       loki.storage.bucketNames.admin: admin
+      distributor.shutdownDelay: 60s
       distributor.extraArgs:
         - -log.level=debug
     asserts:

--- a/charts/loki/values.schema.json
+++ b/charts/loki/values.schema.json
@@ -3541,7 +3541,7 @@
                     "type": "string"
                 },
                 "shutdownDelay": {
-                    "description": "On SIGTERM, report 503 on /ready and wait this long before shutdown so the LB drains the pod. \"0s\" disables.",
+                    "description": "On SIGTERM, report 503 on /ready and wait this long before shutdown so the LB drains the pod before connections are cut. \"0s\" (default) disables. When enabling, keep terminationGracePeriodSeconds above shutdownDelay + server.graceful_shutdown_timeout.",
                     "type": [
                         "string",
                         "null"
@@ -3553,7 +3553,7 @@
                     "additionalProperties": true
                 },
                 "terminationGracePeriodSeconds": {
-                    "description": "Grace period before the distributor is killed. Must exceed shutdownDelay + server graceful_shutdown_timeout (30s).",
+                    "description": "Grace period to allow the distributor to shutdown before it is killed",
                     "type": "integer"
                 },
                 "tolerations": {

--- a/charts/loki/values.schema.json
+++ b/charts/loki/values.schema.json
@@ -3540,13 +3540,20 @@
                     "deprecated": true,
                     "type": "string"
                 },
+                "shutdownDelay": {
+                    "description": "On SIGTERM, report 503 on /ready and wait this long before shutdown so the LB drains the pod. \"0s\" disables.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "strategy": {
                     "description": "UpdateStrategy or Strategy for the distributor.",
                     "type": "object",
                     "additionalProperties": true
                 },
                 "terminationGracePeriodSeconds": {
-                    "description": "Grace period to allow the distributor to shutdown before it is killed",
+                    "description": "Grace period before the distributor is killed. Must exceed shutdownDelay + server graceful_shutdown_timeout (30s).",
                     "type": "integer"
                 },
                 "tolerations": {

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -3497,8 +3497,11 @@ distributor:
   # @schema type:[string, array, null]
   # -- Containers to add to the distributor pods
   extraContainers: []
-  # -- Grace period to allow the distributor to shutdown before it is killed
-  terminationGracePeriodSeconds: 30
+  # @schema type:[string, null]
+  # -- On SIGTERM, report 503 on /ready and wait this long before shutdown so the LB drains the pod. "0s" disables.
+  shutdownDelay: 60s
+  # -- Grace period before the distributor is killed. Must exceed shutdownDelay + server graceful_shutdown_timeout (30s).
+  terminationGracePeriodSeconds: 100
   podDisruptionBudget:
     # -- Enable Pod Disruption Budget
     enabled: true

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -3498,10 +3498,11 @@ distributor:
   # -- Containers to add to the distributor pods
   extraContainers: []
   # @schema type:[string, null]
-  # -- On SIGTERM, report 503 on /ready and wait this long before shutdown so the LB drains the pod. "0s" disables.
-  shutdownDelay: 60s
-  # -- Grace period before the distributor is killed. Must exceed shutdownDelay + server graceful_shutdown_timeout (30s).
-  terminationGracePeriodSeconds: 100
+  # -- On SIGTERM, report 503 on /ready and wait this long before shutdown so the LB drains the pod before connections are cut.
+  # "0s" (default) disables. When enabling, keep terminationGracePeriodSeconds above shutdownDelay + server.graceful_shutdown_timeout.
+  shutdownDelay: 0s
+  # -- Grace period to allow the distributor to shutdown before it is killed
+  terminationGracePeriodSeconds: 30
   podDisruptionBudget:
     # -- Enable Pod Disruption Budget
     enabled: true


### PR DESCRIPTION
#### What this PR does / why we need it

In Distributed mode the distributor receives SIGTERM and shuts down immediately
while the load balancer still routes traffic to it, cutting in-flight connections
(502/504). Loki's `-shutdown-delay` flag, on SIGTERM, reports 503 via `/ready` and
waits before shutting down, so the pod is deregistered from the load balancer
before it exits.

This adds graceful-drain defaults to the distributor:
- new `distributor.shutdownDelay` (default `60s`) — exceeds readiness-probe
  propagation so the LB deregisters the pod during the delay window
- `distributor.terminationGracePeriodSeconds` raised `30` -> `100` to satisfy
  `shutdownDelay + server graceful_shutdown_timeout (30s)`

The flag is injected through the template-built `args` list ahead of `extraArgs`,
so a user-supplied `distributor.extraArgs` cannot accidentally drop it. Set
`distributor.shutdownDelay: "0s"` to disable.

Scoped to the Distributed-mode distributor only. Stateful targets
(`write`/`backend`/`ingester`) already drain via the ingester
`/ingester/shutdown?flush=true` preStop hook plus a longer grace period and are
intentionally left untouched.

#### Which issue this PR fixes

- fixes #

#### Special notes for your reviewer

This is a default behavior change for Distributed mode: distributor pods now linger
up to ~60-100s on termination (the drain window) instead of exiting immediately.
That is the intended trade-off to stop dropping connections on every rollout.
`values.schema.json` was regenerated with the pinned plugin version (2.5.0).

Disclosure: prepared by the maintainer with assistance from Claude Code (AI).

#### Checklist

- [x] DCO signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
- [x] Add an helm unittest test case to cover this change.
