### PR TITLE
[tempo-distributed] Support a plain dnsConfig with global fallback

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 2.26.0
+version: 2.26.1
 # renovate: docker=docker.io/grafana/tempo
 appVersion: 2.10.7
 kubeVersion: "^1.25.0-0"

--- a/charts/tempo-distributed/templates/_pod.tpl
+++ b/charts/tempo-distributed/templates/_pod.tpl
@@ -79,10 +79,15 @@ spec:
   hostAliases:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- $dnsConfig := coalesce $component.dnsConfig .Values.defaults.dnsConfig .Values.tempo.dnsConfig }}
   {{- $dnsOverride := $component.dnsConfigOverides | default dict }}
-  {{- if and $dnsOverride.enabled $dnsOverride.dnsConfig }}
+  {{- if and (not $dnsConfig) $dnsOverride.enabled $dnsOverride.dnsConfig }}
+  {{/* Deprecated: prefer `dnsConfig` (component / defaults / tempo) over `dnsConfigOverides`. */}}
+  {{- $dnsConfig = $dnsOverride.dnsConfig }}
+  {{- end }}
+  {{- with $dnsConfig }}
   dnsConfig:
-    {{- toYaml $dnsOverride.dnsConfig | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- with $component.initContainers }}
   initContainers:

--- a/charts/tempo-distributed/tests/distributor/dnsconfig_test.yaml
+++ b/charts/tempo-distributed/tests/distributor/dnsconfig_test.yaml
@@ -1,0 +1,69 @@
+# $schema: https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json
+suite: distributor dnsConfig
+templates:
+  - distributor/deployment-distributor.yaml
+  - configmap-tempo.yaml
+tests:
+  - it: renders no dnsConfig by default
+    template: distributor/deployment-distributor.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.dnsConfig
+
+  - it: applies tempo.dnsConfig globally
+    template: distributor/deployment-distributor.yaml
+    set:
+      tempo.dnsConfig:
+        options:
+          - name: ndots
+            value: "3"
+    asserts:
+      - equal:
+          path: spec.template.spec.dnsConfig.options[0].value
+          value: "3"
+
+  - it: defaults.dnsConfig overrides tempo.dnsConfig
+    template: distributor/deployment-distributor.yaml
+    set:
+      tempo.dnsConfig:
+        options:
+          - name: ndots
+            value: "3"
+      defaults.dnsConfig:
+        options:
+          - name: ndots
+            value: "2"
+    asserts:
+      - equal:
+          path: spec.template.spec.dnsConfig.options[0].value
+          value: "2"
+
+  - it: component dnsConfig overrides defaults and tempo
+    template: distributor/deployment-distributor.yaml
+    set:
+      tempo.dnsConfig:
+        options:
+          - name: ndots
+            value: "3"
+      distributor.dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+    asserts:
+      - equal:
+          path: spec.template.spec.dnsConfig.options[0].value
+          value: "1"
+
+  - it: legacy dnsConfigOverides still works when dnsConfig is unset
+    template: distributor/deployment-distributor.yaml
+    set:
+      distributor.dnsConfigOverides:
+        enabled: true
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "5"
+    asserts:
+      - equal:
+          path: spec.template.spec.dnsConfig.options[0].value
+          value: "5"

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -206,6 +206,8 @@ ingester:
   #  - ip: 1.2.3.4
   #    hostnames:
   #      - domain.tld
+  # -- Pod DNS config for this component. Falls back to `defaults.dnsConfig`, then `tempo.dnsConfig`.
+  dnsConfig: {}
   initContainers: []
   autoscaling:
     # -- Enable autoscaling for the ingester. WARNING: Autoscaling ingesters can result in lost data. Only do this if you know what you're doing.
@@ -439,6 +441,8 @@ metricsGenerator:
   #  - ip: 1.2.3.4
   #    hostnames:
   #      - domain.tld
+  # -- Pod DNS config for this component. Falls back to `defaults.dnsConfig`, then `tempo.dnsConfig`.
+  dnsConfig: {}
   # -- Init containers for the metrics generator pod
   initContainers: []
   image:
@@ -612,6 +616,8 @@ distributor:
   #  - ip: 1.2.3.4
   #    hostnames:
   #      - domain.tld
+  # -- Pod DNS config for this component. Falls back to `defaults.dnsConfig`, then `tempo.dnsConfig`.
+  dnsConfig: {}
   autoscaling:
     # -- Enable autoscaling for the distributor
     enabled: false
@@ -782,6 +788,8 @@ backendScheduler:
   #  - ip: 1.2.3.4
   #    hostnames:
   #      - domain.tld
+  # -- Pod DNS config for this component. Falls back to `defaults.dnsConfig`, then `tempo.dnsConfig`.
+  dnsConfig: {}
   # -- Init containers to add to the backend-scheduler pod
   initContainers: []
   image:
@@ -1033,6 +1041,8 @@ backendWorker:
   #  - ip: 1.2.3.4
   #    hostnames:
   #      - domain.tld
+  # -- Pod DNS config for this component. Falls back to `defaults.dnsConfig`, then `tempo.dnsConfig`.
+  dnsConfig: {}
   # -- Init containers to add to the backend-worker pods
   initContainers: []
   image:
@@ -1235,6 +1245,8 @@ compactor:
   #  - ip: 1.2.3.4
   #    hostnames:
   #      - domain.tld
+  # -- Pod DNS config for this component. Falls back to `defaults.dnsConfig`, then `tempo.dnsConfig`.
+  dnsConfig: {}
   image:
     # -- The Docker registry for the compactor image. Overrides `tempo.image.registry`
     registry: null
@@ -1368,6 +1380,8 @@ blockBuilder:
   labels: {}
   # -- hostAliases to add
   hostAliases: []
+  # -- Pod DNS config for this component. Falls back to `defaults.dnsConfig`, then `tempo.dnsConfig`.
+  dnsConfig: {}
   # -- Init containers to add to the block-builder pod
   initContainers: []
   image:
@@ -1455,6 +1469,8 @@ liveStore:
   labels: {}
   # -- hostAliases to add
   hostAliases: []
+  # -- Pod DNS config for this component. Falls back to `defaults.dnsConfig`, then `tempo.dnsConfig`.
+  dnsConfig: {}
   # -- Init containers to add to the live-store pod
   initContainers: []
   image:
@@ -1542,6 +1558,8 @@ querier:
   #  - ip: 1.2.3.4
   #    hostnames:
   #      - domain.tld
+  # -- Pod DNS config for this component. Falls back to `defaults.dnsConfig`, then `tempo.dnsConfig`.
+  dnsConfig: {}
   # -- Annotations for querier deployment
   annotations: {}
   autoscaling:
@@ -1699,6 +1717,8 @@ queryFrontend:
   #  - ip: 1.2.3.4
   #    hostnames:
   #      - domain.tld
+  # -- Pod DNS config for this component. Falls back to `defaults.dnsConfig`, then `tempo.dnsConfig`.
+  dnsConfig: {}
   config:
     # -- Maximum number of outstanding requests per tenant per frontend; requests beyond this error with HTTP 429.
     max_outstanding_per_tenant: 2000

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -72,6 +72,8 @@ reportingEnabled: true
 streamOverHTTPEnabled: false
 
 tempo:
+  # -- Pod DNS config applied to all components. Override per component with `<component>.dnsConfig` or `defaults.dnsConfig`.
+  dnsConfig: {}
   image:
     # -- The Docker registry. Overrides `global.image.registry`
     registry: null
@@ -135,6 +137,8 @@ tempo:
 # -- Default values applied to every pod in this chart.
 # These values are overridden by component-specific settings.
 defaults:
+  # -- Default pod DNS config for all pods. Overridden per component by `<component>.dnsConfig`; falls back to `tempo.dnsConfig`.
+  dnsConfig: {}
   # -- Default pod-level security context for all pods
   podSecurityContext: {}
   # -- Default container-level security context for all containers


### PR DESCRIPTION
#### What this PR does / why we need it

`dnsConfig` on tempo-distributed components could only be set through the
misspelled, `enabled`-gated `dnsConfigOverides` key, and the chart ships that
default block on only a few components — there is no way to set DNS options
(e.g. `ndots`) once for the whole release.

This adds a plain `dnsConfig` value rendered via coalesce
`component -> defaults -> tempo`, matching the pattern already used for
`hostAliases` and other shared pod settings:

- `tempo.dnsConfig` — applies to all components
- `defaults.dnsConfig` — overrides the tempo-wide value
- `<component>.dnsConfig` — overrides per component

The legacy `dnsConfigOverides` path is retained for backward compatibility and
used only when `dnsConfig` is unset, so there is **no behavior change** for
existing values.

#### Which issue this PR fixes

- fixes #

#### Special notes for your reviewer

Default render is unchanged (no `dnsConfig` emitted unless set). The `coalesce`
mirrors the existing `hostAliases` handling in `_pod.tpl`. Unit tests cover the
precedence chain and the legacy `dnsConfigOverides` fallback.

Disclosure: prepared by the maintainer with assistance from Claude Code (AI).

#### Checklist

- [x] DCO signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
- [x] Add an helm unittest test case to cover this change.
