### PR TITLE
[loki] make grafanaOperator dashboard instanceSelector configurable

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.3
-version: 18.3.1
+version: 18.4.0
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/README.md
+++ b/charts/loki/README.md
@@ -120,6 +120,7 @@ New dashboard configuration options:
 - `monitoring.dashboards.defaultDashboardsEditable` (default: `true`)
 - `monitoring.dashboards.defaultDashboardsInterval` (default: `1m`)
 - `monitoring.dashboards.grafanaOperator` — optional deployment via Grafana Operator CRD instead of ConfigMaps
+- `monitoring.dashboards.grafanaOperator.instanceSelector` — label selector matching your Grafana instance's labels (default: `{}`)
 
 ### From 16.x to 17.0.0 ([#366](https://github.com/grafana-community/helm-charts/pull/366))
 

--- a/charts/loki/hack/sync_grafana_dashboards.py
+++ b/charts/loki/hack/sync_grafana_dashboards.py
@@ -176,11 +176,7 @@ spec:
   resyncPeriod: {{ .Values.monitoring.dashboards.grafanaOperator.resyncPeriod | default "10m" | quote }}
   {{- include "loki.grafana.operator.folder" $ | nindent 2 }}
   instanceSelector:
-    matchLabels:
-      {{- include "loki.selectorLabels" $ | nindent 6 }}
-      {{- with .Values.monitoring.dashboards.labels }}
-      {{- toYaml . | nindent 6 }}
-      {{- end }}
+    {{- toYaml .Values.monitoring.dashboards.grafanaOperator.instanceSelector | nindent 4 }}
   configMapRef:
     name: {{ include "loki.resourceName" (dict "ctx" $ "component" "dashboards" "suffix" "%(name)s") }}
     key: %(name)s.json

--- a/charts/loki/templates/monitoring/dashboards/loki-bloom-build.yaml
+++ b/charts/loki/templates/monitoring/dashboards/loki-bloom-build.yaml
@@ -43,11 +43,7 @@ spec:
   resyncPeriod: {{ .Values.monitoring.dashboards.grafanaOperator.resyncPeriod | default "10m" | quote }}
   {{- include "loki.grafana.operator.folder" $ | nindent 2 }}
   instanceSelector:
-    matchLabels:
-      {{- include "loki.selectorLabels" $ | nindent 6 }}
-      {{- with .Values.monitoring.dashboards.labels }}
-      {{- toYaml . | nindent 6 }}
-      {{- end }}
+    {{- toYaml .Values.monitoring.dashboards.grafanaOperator.instanceSelector | nindent 4 }}
   configMapRef:
     name: {{ include "loki.resourceName" (dict "ctx" $ "component" "dashboards" "suffix" "loki-bloom-build") }}
     key: loki-bloom-build.json

--- a/charts/loki/templates/monitoring/dashboards/loki-bloom-gateway.yaml
+++ b/charts/loki/templates/monitoring/dashboards/loki-bloom-gateway.yaml
@@ -43,11 +43,7 @@ spec:
   resyncPeriod: {{ .Values.monitoring.dashboards.grafanaOperator.resyncPeriod | default "10m" | quote }}
   {{- include "loki.grafana.operator.folder" $ | nindent 2 }}
   instanceSelector:
-    matchLabels:
-      {{- include "loki.selectorLabels" $ | nindent 6 }}
-      {{- with .Values.monitoring.dashboards.labels }}
-      {{- toYaml . | nindent 6 }}
-      {{- end }}
+    {{- toYaml .Values.monitoring.dashboards.grafanaOperator.instanceSelector | nindent 4 }}
   configMapRef:
     name: {{ include "loki.resourceName" (dict "ctx" $ "component" "dashboards" "suffix" "loki-bloom-gateway") }}
     key: loki-bloom-gateway.json

--- a/charts/loki/templates/monitoring/dashboards/loki-chunks.yaml
+++ b/charts/loki/templates/monitoring/dashboards/loki-chunks.yaml
@@ -43,11 +43,7 @@ spec:
   resyncPeriod: {{ .Values.monitoring.dashboards.grafanaOperator.resyncPeriod | default "10m" | quote }}
   {{- include "loki.grafana.operator.folder" $ | nindent 2 }}
   instanceSelector:
-    matchLabels:
-      {{- include "loki.selectorLabels" $ | nindent 6 }}
-      {{- with .Values.monitoring.dashboards.labels }}
-      {{- toYaml . | nindent 6 }}
-      {{- end }}
+    {{- toYaml .Values.monitoring.dashboards.grafanaOperator.instanceSelector | nindent 4 }}
   configMapRef:
     name: {{ include "loki.resourceName" (dict "ctx" $ "component" "dashboards" "suffix" "loki-chunks") }}
     key: loki-chunks.json

--- a/charts/loki/templates/monitoring/dashboards/loki-deletion.yaml
+++ b/charts/loki/templates/monitoring/dashboards/loki-deletion.yaml
@@ -43,11 +43,7 @@ spec:
   resyncPeriod: {{ .Values.monitoring.dashboards.grafanaOperator.resyncPeriod | default "10m" | quote }}
   {{- include "loki.grafana.operator.folder" $ | nindent 2 }}
   instanceSelector:
-    matchLabels:
-      {{- include "loki.selectorLabels" $ | nindent 6 }}
-      {{- with .Values.monitoring.dashboards.labels }}
-      {{- toYaml . | nindent 6 }}
-      {{- end }}
+    {{- toYaml .Values.monitoring.dashboards.grafanaOperator.instanceSelector | nindent 4 }}
   configMapRef:
     name: {{ include "loki.resourceName" (dict "ctx" $ "component" "dashboards" "suffix" "loki-deletion") }}
     key: loki-deletion.json

--- a/charts/loki/templates/monitoring/dashboards/loki-logs.yaml
+++ b/charts/loki/templates/monitoring/dashboards/loki-logs.yaml
@@ -43,11 +43,7 @@ spec:
   resyncPeriod: {{ .Values.monitoring.dashboards.grafanaOperator.resyncPeriod | default "10m" | quote }}
   {{- include "loki.grafana.operator.folder" $ | nindent 2 }}
   instanceSelector:
-    matchLabels:
-      {{- include "loki.selectorLabels" $ | nindent 6 }}
-      {{- with .Values.monitoring.dashboards.labels }}
-      {{- toYaml . | nindent 6 }}
-      {{- end }}
+    {{- toYaml .Values.monitoring.dashboards.grafanaOperator.instanceSelector | nindent 4 }}
   configMapRef:
     name: {{ include "loki.resourceName" (dict "ctx" $ "component" "dashboards" "suffix" "loki-logs") }}
     key: loki-logs.json

--- a/charts/loki/templates/monitoring/dashboards/loki-mixin-recording-rules.yaml
+++ b/charts/loki/templates/monitoring/dashboards/loki-mixin-recording-rules.yaml
@@ -43,11 +43,7 @@ spec:
   resyncPeriod: {{ .Values.monitoring.dashboards.grafanaOperator.resyncPeriod | default "10m" | quote }}
   {{- include "loki.grafana.operator.folder" $ | nindent 2 }}
   instanceSelector:
-    matchLabels:
-      {{- include "loki.selectorLabels" $ | nindent 6 }}
-      {{- with .Values.monitoring.dashboards.labels }}
-      {{- toYaml . | nindent 6 }}
-      {{- end }}
+    {{- toYaml .Values.monitoring.dashboards.grafanaOperator.instanceSelector | nindent 4 }}
   configMapRef:
     name: {{ include "loki.resourceName" (dict "ctx" $ "component" "dashboards" "suffix" "loki-mixin-recording-rules") }}
     key: loki-mixin-recording-rules.json

--- a/charts/loki/templates/monitoring/dashboards/loki-operational.yaml
+++ b/charts/loki/templates/monitoring/dashboards/loki-operational.yaml
@@ -43,11 +43,7 @@ spec:
   resyncPeriod: {{ .Values.monitoring.dashboards.grafanaOperator.resyncPeriod | default "10m" | quote }}
   {{- include "loki.grafana.operator.folder" $ | nindent 2 }}
   instanceSelector:
-    matchLabels:
-      {{- include "loki.selectorLabels" $ | nindent 6 }}
-      {{- with .Values.monitoring.dashboards.labels }}
-      {{- toYaml . | nindent 6 }}
-      {{- end }}
+    {{- toYaml .Values.monitoring.dashboards.grafanaOperator.instanceSelector | nindent 4 }}
   configMapRef:
     name: {{ include "loki.resourceName" (dict "ctx" $ "component" "dashboards" "suffix" "loki-operational") }}
     key: loki-operational.json

--- a/charts/loki/templates/monitoring/dashboards/loki-reads-resources.yaml
+++ b/charts/loki/templates/monitoring/dashboards/loki-reads-resources.yaml
@@ -43,11 +43,7 @@ spec:
   resyncPeriod: {{ .Values.monitoring.dashboards.grafanaOperator.resyncPeriod | default "10m" | quote }}
   {{- include "loki.grafana.operator.folder" $ | nindent 2 }}
   instanceSelector:
-    matchLabels:
-      {{- include "loki.selectorLabels" $ | nindent 6 }}
-      {{- with .Values.monitoring.dashboards.labels }}
-      {{- toYaml . | nindent 6 }}
-      {{- end }}
+    {{- toYaml .Values.monitoring.dashboards.grafanaOperator.instanceSelector | nindent 4 }}
   configMapRef:
     name: {{ include "loki.resourceName" (dict "ctx" $ "component" "dashboards" "suffix" "loki-reads-resources") }}
     key: loki-reads-resources.json

--- a/charts/loki/templates/monitoring/dashboards/loki-reads.yaml
+++ b/charts/loki/templates/monitoring/dashboards/loki-reads.yaml
@@ -43,11 +43,7 @@ spec:
   resyncPeriod: {{ .Values.monitoring.dashboards.grafanaOperator.resyncPeriod | default "10m" | quote }}
   {{- include "loki.grafana.operator.folder" $ | nindent 2 }}
   instanceSelector:
-    matchLabels:
-      {{- include "loki.selectorLabels" $ | nindent 6 }}
-      {{- with .Values.monitoring.dashboards.labels }}
-      {{- toYaml . | nindent 6 }}
-      {{- end }}
+    {{- toYaml .Values.monitoring.dashboards.grafanaOperator.instanceSelector | nindent 4 }}
   configMapRef:
     name: {{ include "loki.resourceName" (dict "ctx" $ "component" "dashboards" "suffix" "loki-reads") }}
     key: loki-reads.json

--- a/charts/loki/templates/monitoring/dashboards/loki-retention.yaml
+++ b/charts/loki/templates/monitoring/dashboards/loki-retention.yaml
@@ -43,11 +43,7 @@ spec:
   resyncPeriod: {{ .Values.monitoring.dashboards.grafanaOperator.resyncPeriod | default "10m" | quote }}
   {{- include "loki.grafana.operator.folder" $ | nindent 2 }}
   instanceSelector:
-    matchLabels:
-      {{- include "loki.selectorLabels" $ | nindent 6 }}
-      {{- with .Values.monitoring.dashboards.labels }}
-      {{- toYaml . | nindent 6 }}
-      {{- end }}
+    {{- toYaml .Values.monitoring.dashboards.grafanaOperator.instanceSelector | nindent 4 }}
   configMapRef:
     name: {{ include "loki.resourceName" (dict "ctx" $ "component" "dashboards" "suffix" "loki-retention") }}
     key: loki-retention.json

--- a/charts/loki/templates/monitoring/dashboards/loki-thanos-object-storage.yaml
+++ b/charts/loki/templates/monitoring/dashboards/loki-thanos-object-storage.yaml
@@ -43,11 +43,7 @@ spec:
   resyncPeriod: {{ .Values.monitoring.dashboards.grafanaOperator.resyncPeriod | default "10m" | quote }}
   {{- include "loki.grafana.operator.folder" $ | nindent 2 }}
   instanceSelector:
-    matchLabels:
-      {{- include "loki.selectorLabels" $ | nindent 6 }}
-      {{- with .Values.monitoring.dashboards.labels }}
-      {{- toYaml . | nindent 6 }}
-      {{- end }}
+    {{- toYaml .Values.monitoring.dashboards.grafanaOperator.instanceSelector | nindent 4 }}
   configMapRef:
     name: {{ include "loki.resourceName" (dict "ctx" $ "component" "dashboards" "suffix" "loki-thanos-object-storage") }}
     key: loki-thanos-object-storage.json

--- a/charts/loki/templates/monitoring/dashboards/loki-writes-resources.yaml
+++ b/charts/loki/templates/monitoring/dashboards/loki-writes-resources.yaml
@@ -43,11 +43,7 @@ spec:
   resyncPeriod: {{ .Values.monitoring.dashboards.grafanaOperator.resyncPeriod | default "10m" | quote }}
   {{- include "loki.grafana.operator.folder" $ | nindent 2 }}
   instanceSelector:
-    matchLabels:
-      {{- include "loki.selectorLabels" $ | nindent 6 }}
-      {{- with .Values.monitoring.dashboards.labels }}
-      {{- toYaml . | nindent 6 }}
-      {{- end }}
+    {{- toYaml .Values.monitoring.dashboards.grafanaOperator.instanceSelector | nindent 4 }}
   configMapRef:
     name: {{ include "loki.resourceName" (dict "ctx" $ "component" "dashboards" "suffix" "loki-writes-resources") }}
     key: loki-writes-resources.json

--- a/charts/loki/templates/monitoring/dashboards/loki-writes.yaml
+++ b/charts/loki/templates/monitoring/dashboards/loki-writes.yaml
@@ -43,11 +43,7 @@ spec:
   resyncPeriod: {{ .Values.monitoring.dashboards.grafanaOperator.resyncPeriod | default "10m" | quote }}
   {{- include "loki.grafana.operator.folder" $ | nindent 2 }}
   instanceSelector:
-    matchLabels:
-      {{- include "loki.selectorLabels" $ | nindent 6 }}
-      {{- with .Values.monitoring.dashboards.labels }}
-      {{- toYaml . | nindent 6 }}
-      {{- end }}
+    {{- toYaml .Values.monitoring.dashboards.grafanaOperator.instanceSelector | nindent 4 }}
   configMapRef:
     name: {{ include "loki.resourceName" (dict "ctx" $ "component" "dashboards" "suffix" "loki-writes") }}
     key: loki-writes.json

--- a/charts/loki/tests/monitoring/dashboards_test.yaml
+++ b/charts/loki/tests/monitoring/dashboards_test.yaml
@@ -109,3 +109,27 @@ tests:
       - matchRegex:
           path: data["loki-chunks.json"]
           pattern: '"name":"app_instance"'
+
+  # instanceSelector is taken from values and passed through to the GrafanaDashboard CR
+  - it: should default the GrafanaDashboard instanceSelector to match-all
+    set:
+      monitoring.dashboards.enabled: true
+      monitoring.dashboards.grafanaOperator.enabled: true
+    asserts:
+      - equal:
+          path: spec.instanceSelector
+          value: {}
+        documentIndex: 1
+
+  - it: should allow overriding the GrafanaDashboard instanceSelector from values
+    set:
+      monitoring.dashboards.enabled: true
+      monitoring.dashboards.grafanaOperator.enabled: true
+      monitoring.dashboards.grafanaOperator.instanceSelector.matchLabels.dashboards: grafana
+    asserts:
+      - equal:
+          path: spec.instanceSelector
+          value:
+            matchLabels:
+              dashboards: grafana
+        documentIndex: 1

--- a/charts/loki/values.schema.json
+++ b/charts/loki/values.schema.json
@@ -6637,6 +6637,17 @@
                                         "null"
                                     ]
                                 },
+                                "instanceSelector": {
+                                    "allOf": [
+                                        {
+                                            "description": "instanceSelector for the GrafanaDashboard resources # The grafana-operator matches this against the labels on your Grafana CR # An empty selector (the default) matches every Grafana instance",
+                                            "type": "object"
+                                        },
+                                        {
+                                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+                                        }
+                                    ]
+                                },
                                 "labels": {
                                     "description": "Additional labels for the GrafanaOperator resources",
                                     "type": "object",
@@ -11689,5 +11700,56 @@
             }
         }
     },
-    "additionalProperties": true
+    "additionalProperties": true,
+    "$defs": {
+        "_definitions.json": {
+            "definitions": {
+                "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                    "type": "object",
+                    "properties": {
+                        "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement"
+                            }
+                        },
+                        "matchLabels": {
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement": {
+                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                    "type": "object",
+                    "required": [
+                        "key",
+                        "operator"
+                    ],
+                    "properties": {
+                        "key": {
+                            "description": "key is the label key that the selector applies to.",
+                            "type": "string"
+                        },
+                        "operator": {
+                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                            "type": "string"
+                        },
+                        "values": {
+                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -7065,6 +7065,13 @@ monitoring:
       ## Only one of 'folder', 'folderUID' or 'folderRef' can be set
       ##
       folderRef: null
+
+      # @schema $ref: $k8s/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+      # -- instanceSelector for the GrafanaDashboard resources
+      ## The grafana-operator matches this against the labels on your Grafana CR
+      ## An empty selector (the default) matches every Grafana instance
+      instanceSelector: {}
+
   # -- Recording rules for monitoring Loki, required for some dashboards
   rules:
     # -- If enabled, create a PrometheusRule resource with Loki recording rules


### PR DESCRIPTION
#### What this PR does / why we need it

The GrafanaDashboard resources added in #193 hardcodes the following instanceSelector spec:
```
spec:
  instanceSelector:
    matchLabels:
      app.kubernetes.io/instance: loki
      app.kubernetes.io/name: loki
      grafana_dashboard: "1"
```

More specifically, the `app.kubernetes.io/*: loki` labels will likely never match any existing Grafana instance labels. This PR lets the use choose a selector, and defaults to target all Grafana instances (tested working):

```
spec:
  instanceSelector: {}
```

#### Which issue this PR fixes

(no open issue) 

#### Special notes for your reviewer

- Introduces the first $ref helm-schema reference in values.yaml for this repo, but it's already configured properly to use them.
- Claude was used to research some parts of these changes.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
- [x] Add an [helm unittest](https://github.com/helm-unittest/helm-unittest) test case to cover this change.

