### PR TITLE
[tempo-distributed] Add blocklist_poll_tenant_concurrency to values.yaml

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 3.0.6
+version: 3.0.7
 # renovate: docker=docker.io/grafana/tempo
 appVersion: 3.0.2
 kubeVersion: "^1.25.0-0"

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -2043,6 +2043,9 @@ config: |
       {{- if .Values.storage.trace.blocklist_poll_stale_tenant_index }}
       blocklist_poll_stale_tenant_index: {{ .Values.storage.trace.blocklist_poll_stale_tenant_index }}
       {{- end }}
+      {{- if .Values.storage.trace.blocklist_poll_tenant_concurrency }}
+      blocklist_poll_tenant_concurrency: {{ .Values.storage.trace.blocklist_poll_tenant_concurrency }}
+      {{- end }}
       {{- if .Values.storage.trace.empty_tenant_deletion_age }}
       empty_tenant_deletion_age: {{ .Values.storage.trace.empty_tenant_deletion_age }}
       {{- end }}
@@ -2125,6 +2128,8 @@ storage:
     blocklist_poll_tenant_index_builders: null
     # -- The oldest allowable tenant index.
     blocklist_poll_stale_tenant_index: null
+    # -- Number of tenants to poll concurrently. Default is 1.
+    blocklist_poll_tenant_concurrency: null
     # -- How fast the poller will delete a tenant if it is empty. Will need to be enabled in 'empty_tenant_deletion_enabled'.
     empty_tenant_deletion_age: null
     # -- Delete empty tenants.


### PR DESCRIPTION
This pull request adds support for configuring the tenant concurrency for blocklist polling in the `tempo-distributed` Helm chart. The main change is the introduction of a new configuration option that allows users to control how many tenants are polled concurrently during the blocklist polling process.

**Configuration Enhancements:**

* Added a new value `blocklist_poll_tenant_concurrency` under `storage.trace` in `values.yaml`, allowing users to specify the number of tenants to poll concurrently (default is 1).
* Updated the Helm template to include the `blocklist_poll_tenant_concurrency` field in the generated configuration if the value is set.

**Notes**
KV mapping might be a better approach but requires bigger overhaul.
This setting should be backported if possible.

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[grafana]`)
- [ ] Add an [helm unittest](https://github.com/helm-unittest/helm-unittest) test case to cover this change.

