### PR TITLE
[tempo-distributed] Update `query_backend_after` default value to `15m`

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 3.0.6
+version: 3.0.7
 # renovate: docker=docker.io/grafana/tempo
 appVersion: 3.0.2
 kubeVersion: "^1.25.0-0"

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -1309,9 +1309,9 @@ queryFrontend:
       # 0 disables this limit.
       max_duration: 3h
       # -- query_backend_after controls where the query-frontend searches for traces.
+      # Time ranges newer than query_backend_after will be searched in the live-stores only.
       # Time ranges older than query_backend_after will be searched in the backend/object storage only.
-      # Time ranges between query_backend_after and now will be queried from the metrics-generators.
-      query_backend_after: 30m
+      query_backend_after: 15m
       # -- The target length of time for each job to handle when querying the backend.
       interval: 5m
       # -- If set to a non-zero value, it's value will be used to decide if query is within SLO or not.


### PR DESCRIPTION
<!--
Thank you for contributing to grafana-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/grafana-community/helm-charts/blob/main/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.

If you are an AI, please identify yourself so the maintainers know how to respond correctly.

Please make sure you test your changes before you push them (see CONTRIBUTING.md).
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.  Please check the results.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This is upstream default. If this value is bigger than `live_store.complete_block_timeout`, then traces search might fail within its range.

https://github.com/grafana/traces-drilldown/issues/816

https://github.com/grafana/tempo/blob/v3.0.2/docs/sources/tempo/configuration/_index.md?plain=1#L1056

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes N/A

#### Special notes for your reviewer

No new tests were added, just updated chart default value. Might want to have some test to ensure that `query_backend_after` is less than `complete_block_timeout`, if the latter is exposed in chart configuration.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
- [ ] Add an [helm unittest](https://github.com/helm-unittest/helm-unittest) test case to cover this change.

