### PR TITLE
[grafana] Add startupProbe support to the main container

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 12.10.0
+version: 12.10.1
 # renovate: docker=docker.io/grafana/grafana
 appVersion: 13.1.1
 kubeVersion: "^1.25.0-0"

--- a/charts/grafana/templates/_pod.tpl
+++ b/charts/grafana/templates/_pod.tpl
@@ -1522,6 +1522,10 @@ containers:
         {{- end }}
       {{- end }}
     {{- end }}
+    {{- with .Values.startupProbe }}
+    startupProbe:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     {{- with .Values.livenessProbe }}
     livenessProbe:
       {{- toYaml . | nindent 6 }}

--- a/charts/grafana/tests/startup_probe_test.yaml
+++ b/charts/grafana/tests/startup_probe_test.yaml
@@ -1,0 +1,23 @@
+suite: startup probe
+templates:
+  - deployment.yaml
+tests:
+  - it: should not render a startupProbe by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].startupProbe
+  - it: should render a startupProbe on the main container when set
+    set:
+      startupProbe:
+        httpGet:
+          path: /api/health
+          port: grafana
+        periodSeconds: 10
+        failureThreshold: 30
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /api/health
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 30

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -83,6 +83,10 @@ deploymentStrategy:
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#progress-deadline-seconds
 progressDeadlineSeconds: null
 
+## Startup probe. Holds off the liveness and readiness probes until it succeeds, useful for slow starts.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+startupProbe: {}
+
 readinessProbe:
   httpGet:
     path: /api/health


### PR DESCRIPTION
#### What this PR does / why we need it

Adds a `startupProbe` value that renders a startup probe on the main Grafana container, mirroring how `livenessProbe` and `readinessProbe` are handled. It is empty (`{}`) by default, so existing installs are unaffected.

Today the chart only templates a startup probe for the sidecars, not the main container. When Grafana's own startup is slow (for example a slow/locked database at boot), the liveness probe can trip and restart the pod before it has finished starting.

#### Which issue this PR fixes

_N/A_

#### Special notes for your reviewer

- Non-breaking: `startupProbe` defaults to `{}`, so nothing is rendered unless a user sets it.
- Same `{{- with .Values.startupProbe }}` pattern as the existing liveness/readiness probes.
- Chart version bumped patch (12.10.0 → 12.10.1).
- Added a helm unittest case covering both the default (no probe) and the when-set case.

#### Checklist

- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
- [x] Add an [helm unittest](https://github.com/helm-unittest/helm-unittest) test case to cover this change.