### PR TITLE
[loki] Fix write statefulset deletion policy

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.6
-version: 18.7.6
+version: 18.8.0
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/tests/write/statefulset_test.yaml
+++ b/charts/loki/tests/write/statefulset_test.yaml
@@ -1,0 +1,42 @@
+# $schema: https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json
+suite: write workload
+templates:
+  - write/workload.yaml
+  - config.yaml
+set:
+  deploymentMode: SimpleScalable
+  loki.useTestSchema: true
+  loki.storage.bucketNames.chunks: chunks
+  loki.storage.bucketNames.ruler: ruler
+
+tests:
+  - it: should render persistentVolumeClaimRetentionPolicy when auto delete PVC is enabled with volume claims
+    set:
+      write.persistence.enableStatefulSetAutoDeletePVC: true
+      write.persistence.volumeClaimsEnabled: true
+    asserts:
+      - equal:
+          path: spec.persistentVolumeClaimRetentionPolicy.whenDeleted
+          value: Delete
+        template: write/workload.yaml
+      - equal:
+          path: spec.persistentVolumeClaimRetentionPolicy.whenScaled
+          value: Delete
+        template: write/workload.yaml
+
+  - it: should not render persistentVolumeClaimRetentionPolicy when auto delete PVC is disabled
+    set:
+      write.persistence.enableStatefulSetAutoDeletePVC: false
+    asserts:
+      - notExists:
+          path: spec.persistentVolumeClaimRetentionPolicy
+        template: write/workload.yaml
+
+  - it: should not render persistentVolumeClaimRetentionPolicy when volume claims are disabled
+    set:
+      write.persistence.enableStatefulSetAutoDeletePVC: true
+      write.persistence.volumeClaimsEnabled: false
+    asserts:
+      - notExists:
+          path: spec.persistentVolumeClaimRetentionPolicy
+        template: write/workload.yaml

--- a/charts/loki/values.schema.json
+++ b/charts/loki/values.schema.json
@@ -11610,6 +11610,14 @@
                         "volumeClaimsEnabled": {
                             "description": "Enable volume claims in pod spec",
                             "type": "boolean"
+                        },
+                        "whenDeleted": {
+                            "description": "What to do with the volumes when the StatefulSet is deleted.",
+                            "type": "string"
+                        },
+                        "whenScaled": {
+                            "description": "What to do with the volume when the StatefulSet is scaled down.",
+                            "type": "string"
                         }
                     }
                 },

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -2349,6 +2349,10 @@ write:
     # -- Parameters used for the `data` volume when volumeClaimEnabled if false
     dataVolumeParameters:
       emptyDir: {}
+    # -- What to do with the volume when the StatefulSet is scaled down.
+    whenScaled: Delete
+    # -- What to do with the volumes when the StatefulSet is deleted.
+    whenDeleted: Delete
     # -- Enable StatefulSetAutoDeletePVC feature
     enableStatefulSetAutoDeletePVC: false
     # -- Size of persistent disk


### PR DESCRIPTION

#### What this PR does / why we need it

#### Which issue this PR fixes



- fixes #730 

#### Special notes for your reviewer

Setting `persistentVolumeClaimRetentionPolicy` to `true` was adding the policy, but with empty values. This was a change of behaviour since chart `17.1.0` / PR #502.

This PR sets the default policy values to `Delete` (default, but only added when `persistentVolumeClaimRetentionPolicy=true`), to restore the pre-`17.1.0` behaviour.

AI disclaimer: I am not an AI, but I have been working with Claude Code :robot: on this PR.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
- [x] Add an [helm unittest](https://github.com/helm-unittest/helm-unittest) test case to cover this change.

