### PR TITLE
[tempo] Add Gateway API HTTPRoute support

### DIFF
--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 2.2.4
+version: 2.3.0
 # renovate: docker=docker.io/grafana/tempo
 appVersion: 2.10.8
 home: https://grafana.net

--- a/charts/tempo/ci/default-values.yaml
+++ b/charts/tempo/ci/default-values.yaml
@@ -1,0 +1,1 @@
+# Leave this file empty to ensure that CI runs builds against the default configuration in values.yaml.

--- a/charts/tempo/ci/with-gateway-values.yaml
+++ b/charts/tempo/ci/with-gateway-values.yaml
@@ -1,0 +1,48 @@
+route:
+  main:
+    enabled: true
+    apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    annotations:
+      test-annotation: test-value
+    labels:
+      test-label: test-value
+    hostnames:
+      - tempo.example.com
+    parentRefs:
+      - name: my-gateway
+        namespace: default
+    matches:
+      - path:
+          type: PathPrefix
+          value: /
+    filters:
+      - type: RequestHeaderModifier
+        requestHeaderModifier:
+          set:
+            - name: X-Custom-Header
+              value: custom-value
+    timeouts:
+      request: 10s
+      backendRequest: 5s
+  otlp:
+    enabled: true
+    backendPort: 4318
+    hostnames:
+      - otlp.example.com
+    parentRefs:
+      - name: my-gateway
+        namespace: default
+    matches:
+      - path:
+          type: PathPrefix
+          value: /v1/traces
+  redirect:
+    enabled: true
+    hostnames:
+      - tempo.example.com
+    parentRefs:
+      - name: my-gateway
+        namespace: default
+        sectionName: http
+    httpsRedirect: true

--- a/charts/tempo/templates/_helpers.tpl
+++ b/charts/tempo/templates/_helpers.tpl
@@ -80,3 +80,16 @@ app.kubernetes.io/version: {{ mustRegexReplaceAllLiteral "@sha.*" .Values.image.
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
+{{/*
+Return the appropriate apiVersion for Gateway API resources.
+*/}}
+{{- define "tempo.gatewayApi.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1" }}
+{{- print "gateway.networking.k8s.io/v1" }}
+{{- else if .Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1beta1" }}
+{{- print "gateway.networking.k8s.io/v1beta1" }}
+{{- else }}
+{{- print "gateway.networking.k8s.io/v1" }}
+{{- end }}
+{{- end -}}
+

--- a/charts/tempo/templates/_helpers.tpl
+++ b/charts/tempo/templates/_helpers.tpl
@@ -81,6 +81,25 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
 {{/*
+Ports of the tempo service, as a YAML list. Mirrors the protocol selection of
+templates/service.yaml, so a caller can check whether a port is reachable.
+*/}}
+{{- define "tempo.servicePorts" -}}
+{{- if (eq .Values.service.type "LoadBalancer") }}
+{{- $protocol := .Values.service.protocol | default "TCP" }}
+{{- if contains "UDP" $protocol }}
+{{- include "tempo.udp" . }}
+{{- end }}
+{{- if contains "TCP" $protocol }}
+{{- include "tempo.tcp" . }}
+{{- end }}
+{{- else }}
+{{- include "tempo.udp" . }}
+{{- include "tempo.tcp" . }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Return the appropriate apiVersion for Gateway API resources.
 */}}
 {{- define "tempo.gatewayApi.apiVersion" -}}

--- a/charts/tempo/templates/route.yaml
+++ b/charts/tempo/templates/route.yaml
@@ -1,0 +1,58 @@
+{{- range $name, $route := .Values.route }}
+{{- if $route.enabled }}
+---
+apiVersion: {{ $route.apiVersion | default (include "tempo.gatewayApi.apiVersion" $) }}
+kind: {{ $route.kind | default "HTTPRoute" }}
+metadata:
+  name: {{ include "tempo.fullname" $ }}{{ if ne $name "main" }}-{{ $name }}{{ end }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "tempo.labels" $ | nindent 4 }}
+    {{- with $route.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $route.annotations }}
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with $route.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $route.hostnames }}
+  hostnames:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- with $route.additionalRules }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+    {{- if $route.httpsRedirect }}
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+    {{- else }}
+    - backendRefs:
+        - name: {{ include "tempo.fullname" $ }}
+          port: {{ $route.backendPort | default 3200 }}
+          group: ''
+          kind: Service
+          weight: 1
+      {{- with $route.filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $route.matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/tempo/templates/route.yaml
+++ b/charts/tempo/templates/route.yaml
@@ -1,5 +1,16 @@
+{{- $servicePorts := include "tempo.servicePorts" . | fromYamlArray }}
+{{- $exposedPorts := list }}
+{{- range $servicePorts }}
+{{- $exposedPorts = append $exposedPorts (.port | int) }}
+{{- end }}
 {{- range $name, $route := .Values.route }}
 {{- if $route.enabled }}
+{{- if not $route.httpsRedirect }}
+{{- $backendPort := $route.backendPort | default 3200 | int }}
+{{- if not (has $backendPort $exposedPorts) }}
+{{- fail (printf "route.%s.backendPort is %d, but the tempo service does not expose that port. Enable the matching receiver, or use one of: %v" $name $backendPort $exposedPorts) }}
+{{- end }}
+{{- end }}
 ---
 apiVersion: {{ $route.apiVersion | default (include "tempo.gatewayApi.apiVersion" $) }}
 kind: {{ $route.kind | default "HTTPRoute" }}

--- a/charts/tempo/tests/route_test.yaml
+++ b/charts/tempo/tests/route_test.yaml
@@ -1,0 +1,197 @@
+# $schema: https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json
+suite: HTTPRoute
+templates:
+  - route.yaml
+
+set:
+  route.main.enabled: true
+  route.main.parentRefs:
+    - name: my-gateway
+      namespace: gateway-namespace
+  route.main.hostnames:
+    - tempo.example.com
+
+tests:
+  - it: should render an HTTPRoute when route is enabled
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HTTPRoute
+
+  - it: should not render when all routes are disabled
+    set:
+      route.main.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should fall back to gateway.networking.k8s.io/v1 when no Gateway API CRD is present
+    asserts:
+      - equal:
+          path: apiVersion
+          value: gateway.networking.k8s.io/v1
+
+  - it: should detect gateway.networking.k8s.io/v1 when the v1 CRD is present
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1
+    asserts:
+      - equal:
+          path: apiVersion
+          value: gateway.networking.k8s.io/v1
+
+  - it: should detect gateway.networking.k8s.io/v1beta1 when only the beta CRD is present
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1beta1
+    asserts:
+      - equal:
+          path: apiVersion
+          value: gateway.networking.k8s.io/v1beta1
+
+  - it: should support a custom apiVersion
+    set:
+      route.main.apiVersion: gateway.networking.k8s.io/v1beta1
+    asserts:
+      - equal:
+          path: apiVersion
+          value: gateway.networking.k8s.io/v1beta1
+
+  - it: should use the tempo fullname as the route name for the main route
+    release:
+      name: my-release
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-release-tempo
+
+  - it: should append the route key as suffix for non-main routes
+    release:
+      name: my-release
+    set:
+      route.main.enabled: false
+      route.otlp.enabled: true
+      route.otlp.backendPort: 4318
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: my-release-tempo-otlp
+
+  - it: should render parentRefs and hostnames
+    asserts:
+      - equal:
+          path: spec.parentRefs[0].name
+          value: my-gateway
+      - equal:
+          path: spec.parentRefs[0].namespace
+          value: gateway-namespace
+      - equal:
+          path: spec.hostnames[0]
+          value: tempo.example.com
+
+  - it: should route to the tempo service on the Tempo HTTP API port by default
+    release:
+      name: my-release
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: my-release-tempo
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 3200
+      - equal:
+          path: spec.rules[0].backendRefs[0].kind
+          value: Service
+
+  - it: should support a custom backendPort
+    set:
+      route.main.backendPort: 4318
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 4318
+
+  - it: should render the default path prefix match
+    asserts:
+      - equal:
+          path: spec.rules[0].matches[0].path.type
+          value: PathPrefix
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /
+
+  - it: should render filters and timeouts
+    set:
+      route.main.filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            set:
+              - name: X-Custom-Header
+                value: custom-value
+      route.main.timeouts:
+        request: 10s
+        backendRequest: 5s
+    asserts:
+      - equal:
+          path: spec.rules[0].filters[0].type
+          value: RequestHeaderModifier
+      - equal:
+          path: spec.rules[0].timeouts.request
+          value: 10s
+      - equal:
+          path: spec.rules[0].timeouts.backendRequest
+          value: 5s
+
+  - it: should prepend additionalRules before the generated rule
+    set:
+      route.main.additionalRules:
+        - backendRefs:
+            - name: special-backend
+              port: 8080
+          matches:
+            - path:
+                type: PathPrefix
+                value: /special
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: special-backend
+      - equal:
+          path: spec.rules[1].backendRefs[0].port
+          value: 3200
+
+  - it: should render a redirect filter and no backendRefs when httpsRedirect is enabled
+    set:
+      route.main.httpsRedirect: true
+    asserts:
+      - equal:
+          path: spec.rules[0].filters[0].type
+          value: RequestRedirect
+      - equal:
+          path: spec.rules[0].filters[0].requestRedirect.scheme
+          value: https
+      - equal:
+          path: spec.rules[0].filters[0].requestRedirect.statusCode
+          value: 301
+      - notExists:
+          path: spec.rules[0].backendRefs
+
+  - it: should template annotations and hostnames
+    set:
+      global.clusterDomain: example.com
+      route.main.annotations:
+        test-annotation: "{{ .Release.Name }}-value"
+      route.main.hostnames:
+        - "{{ .Release.Name }}.example.com"
+    release:
+      name: my-release
+    asserts:
+      - equal:
+          path: metadata.annotations.test-annotation
+          value: my-release-value
+      - equal:
+          path: spec.hostnames[0]
+          value: my-release.example.com

--- a/charts/tempo/tests/route_test.yaml
+++ b/charts/tempo/tests/route_test.yaml
@@ -195,3 +195,42 @@ tests:
       - equal:
           path: spec.hostnames[0]
           value: my-release.example.com
+
+  - it: should render every enabled route and skip the disabled ones
+    set:
+      route.otlp.enabled: true
+      route.otlp.backendPort: 4318
+      route.jaeger.enabled: false
+      route.jaeger.backendPort: 16686
+    release:
+      name: my-release
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: should fail when the backend port is not exposed by the service
+    set:
+      route.main.backendPort: 4318
+      tempo.receivers.otlp.protocols.http: null
+    asserts:
+      - failedTemplate:
+          errorPattern: "route.main.backendPort is 4318, but the tempo service does not expose that port"
+
+  - it: should skip the backend port check for a redirect route
+    set:
+      route.main.httpsRedirect: true
+      route.main.backendPort: 4318
+      tempo.receivers.otlp.protocols.http: null
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.rules[0].filters[0].type
+          value: RequestRedirect
+
+  - it: should render the configured route kind
+    set:
+      route.main.kind: GRPCRoute
+    asserts:
+      - isKind:
+          of: GRPCRoute

--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -375,8 +375,8 @@ route:
     # -- Set the route apiVersion, e.g. gateway.networking.k8s.io/v1 or gateway.networking.k8s.io/v1beta1
     # If not set, the latest available version will be auto-detected
     apiVersion: ""
-    # -- Set the route kind
-    # Valid options are GRPCRoute, HTTPRoute, TCPRoute, TLSRoute, UDPRoute
+    # -- Set the route kind. The template renders an HTTPRoute body, so only
+    # HTTPRoute is supported. The field stays configurable for a future route kind.
     kind: HTTPRoute
 
     # -- Route annotations
@@ -394,6 +394,8 @@ route:
 
     # -- Port of the tempo service to route to. Defaults to the Tempo HTTP API port.
     # Use 4318 for the OTLP HTTP receiver or tempoQuery.service.port for the Jaeger UI.
+    # The port must be one that the tempo service exposes. The receiver ports follow
+    # `tempo.receivers`, so a route to a disabled receiver fails the render.
     backendPort: 3200
 
     matches:

--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -363,6 +363,62 @@ service:
   labels: {}
   targetPort: ""
 
+# -- BETA: Configure the gateway routes for the chart here.
+# More routes can be added by adding a dictionary key like the 'main' route.
+# Being BETA this can/will change in the future without notice, do not use unless you want to take that risk
+# [[ref]](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io%2fv1alpha2)
+route:
+  main:
+    # -- Enables or disables the route
+    enabled: false
+
+    # -- Set the route apiVersion, e.g. gateway.networking.k8s.io/v1 or gateway.networking.k8s.io/v1beta1
+    # If not set, the latest available version will be auto-detected
+    apiVersion: ""
+    # -- Set the route kind
+    # Valid options are GRPCRoute, HTTPRoute, TCPRoute, TLSRoute, UDPRoute
+    kind: HTTPRoute
+
+    # -- Route annotations
+    annotations: {}
+    # -- Route labels
+    labels: {}
+
+    # -- Hostnames for the route
+    hostnames: []
+    # - tempo.example.com
+    # -- Parent references (gateway to attach to)
+    parentRefs: []
+    # - name: my-gateway
+    #   namespace: gateway-namespace
+
+    # -- Port of the tempo service to route to. Defaults to the Tempo HTTP API port.
+    # Use 4318 for the OTLP HTTP receiver or tempoQuery.service.port for the Jaeger UI.
+    backendPort: 3200
+
+    matches:
+      - path:
+          type: PathPrefix
+          value: /
+
+    ## Timeouts define the timeouts that can be configured for an HTTP request.
+    ## Ref. https://gateway-api.sigs.k8s.io/api-types/httproute/#timeouts-optional
+    timeouts: {}
+    # request: 10s
+    # backendRequest: 5s
+
+    ## Filters define the filters that are applied to requests that match this rule.
+    filters: []
+
+    ## Additional custom rules that can be added to the route
+    additionalRules: []
+
+    ## httpsRedirect adds a filter for redirecting to https (HTTP 301 Moved Permanently).
+    ## To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners.
+    ## Matches and filters do not take effect if enabled.
+    ## Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
+    httpsRedirect: false
+
 serviceMonitor:
   enabled: false
   interval: ""


### PR DESCRIPTION
## What

- Add `templates/route.yaml` to the single-binary `tempo` chart: a dict of named Gateway API routes, where `main` uses the chart fullname and any other key gets a `-<key>` suffix.
- Add a `route:` values block with `enabled`, `apiVersion`, `kind`, `annotations`, `labels`, `hostnames`, `parentRefs`, `backendPort`, `matches`, `filters`, `timeouts`, `additionalRules` and `httpsRedirect`.
- Add a `tempo.gatewayApi.apiVersion` helper that auto-detects the available Gateway API version (`v1`, then `v1beta1`, defaulting to `v1`).
- Add helm-unittest coverage in `tests/route_test.yaml` and chart-testing install values in `ci/`.

## Why

Closes #246. The `grafana`, `loki`, `grafana-mcp` and `tempo-distributed` charts already ship Gateway API route templates; the single-binary `tempo` chart was the remaining gap.

The template follows the `grafana` shape (one dict entry per route, single backendRef) rather than the `tempo-distributed` shape (paths fanned out across component services), because single-binary tempo exposes every port on one Service. `backendPort` defaults to `3200`, the Tempo HTTP API port; routing to the OTLP HTTP receiver or the Jaeger UI is done by adding another dict entry with a different port.

Defaults are unchanged — with `route.main.enabled: false` nothing is rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)