### PR TITLE
[tempo-distributed] Add PodDisruptionBudgets for block-builder and live-store

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 3.1.0
+version: 3.2.0
 # renovate: docker=docker.io/grafana/tempo
 appVersion: 3.0.3
 kubeVersion: "^1.25.0-0"

--- a/charts/tempo-distributed/templates/block-builder/poddisruptionbudget-block-builder.yaml
+++ b/charts/tempo-distributed/templates/block-builder/poddisruptionbudget-block-builder.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.blockBuilder.enabled }}
+{{- if and (gt (int .Values.blockBuilder.replicas) 1) .Values.blockBuilder.podDisruptionBudget.enabled }}
+{{ $dict := dict "ctx" . "component" "block-builder" "memberlist" true }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "tempo.resourceName" $dict }}
+  labels:
+    {{- include "tempo.labels" $dict | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "tempo.selectorLabels" $dict | nindent 6 }}
+  maxUnavailable: {{ .Values.blockBuilder.maxUnavailable }}
+  {{- with .Values.blockBuilder.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/tempo-distributed/templates/live-store/poddisruptionbudget-live-store.yaml
+++ b/charts/tempo-distributed/templates/live-store/poddisruptionbudget-live-store.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.liveStore.enabled }}
+{{- if and (gt (int .Values.liveStore.replicas) 1) .Values.liveStore.podDisruptionBudget.enabled }}
+{{ $dict := dict "ctx" . "component" "live-store" "memberlist" true }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "tempo.resourceName" $dict }}
+  labels:
+    {{- include "tempo.labels" $dict | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "tempo.selectorLabels" $dict | nindent 6 }}
+  maxUnavailable: {{ .Values.liveStore.maxUnavailable }}
+  {{- with .Values.liveStore.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/tempo-distributed/tests/block-builder/poddisruptionbudget_test.yaml
+++ b/charts/tempo-distributed/tests/block-builder/poddisruptionbudget_test.yaml
@@ -1,0 +1,76 @@
+# $schema: https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json
+suite: block-builder PodDisruptionBudget
+templates:
+  - block-builder/poddisruptionbudget-block-builder.yaml
+
+tests:
+  - it: renders a PodDisruptionBudget with correct name and kind by default
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: PodDisruptionBudget
+      - equal:
+          path: apiVersion
+          value: policy/v1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-tempo-block-builder
+
+  - it: does not render when the block-builder is disabled
+    set:
+      blockBuilder.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render when the PodDisruptionBudget is disabled
+    set:
+      blockBuilder.podDisruptionBudget.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render with a single replica
+    set:
+      blockBuilder.replicas: 1
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: selects the block-builder pods
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: block-builder
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+
+  - it: is labelled as part of the memberlist
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/part-of"]
+          value: memberlist
+
+  - it: uses blockBuilder.maxUnavailable
+    set:
+      blockBuilder.maxUnavailable: 2
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 2
+
+  - it: omits unhealthyPodEvictionPolicy by default
+    asserts:
+      - notExists:
+          path: spec.unhealthyPodEvictionPolicy
+
+  - it: renders unhealthyPodEvictionPolicy when set
+    set:
+      blockBuilder.podDisruptionBudget.unhealthyPodEvictionPolicy: AlwaysAllow
+    asserts:
+      - equal:
+          path: spec.unhealthyPodEvictionPolicy
+          value: AlwaysAllow

--- a/charts/tempo-distributed/tests/live-store/poddisruptionbudget_test.yaml
+++ b/charts/tempo-distributed/tests/live-store/poddisruptionbudget_test.yaml
@@ -1,0 +1,76 @@
+# $schema: https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json
+suite: live-store PodDisruptionBudget
+templates:
+  - live-store/poddisruptionbudget-live-store.yaml
+
+tests:
+  - it: renders a PodDisruptionBudget with correct name and kind by default
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: PodDisruptionBudget
+      - equal:
+          path: apiVersion
+          value: policy/v1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-tempo-live-store
+
+  - it: does not render when the live-store is disabled
+    set:
+      liveStore.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render when the PodDisruptionBudget is disabled
+    set:
+      liveStore.podDisruptionBudget.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render with a single replica
+    set:
+      liveStore.replicas: 1
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: selects the live-store pods
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: live-store
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+
+  - it: is labelled as part of the memberlist
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/part-of"]
+          value: memberlist
+
+  - it: uses liveStore.maxUnavailable
+    set:
+      liveStore.maxUnavailable: 2
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 2
+
+  - it: omits unhealthyPodEvictionPolicy by default
+    asserts:
+      - notExists:
+          path: spec.unhealthyPodEvictionPolicy
+
+  - it: renders unhealthyPodEvictionPolicy when set
+    set:
+      liveStore.podDisruptionBudget.unhealthyPodEvictionPolicy: AlwaysAllow
+    asserts:
+      - equal:
+          path: spec.unhealthyPodEvictionPolicy
+          value: AlwaysAllow

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -1013,6 +1013,14 @@ blockBuilder:
   statefulStrategy:
     rollingUpdate:
       partition: 0
+  # -- Pod Disruption Budget configuration
+  podDisruptionBudget:
+    # -- Enable PodDisruptionBudget for block-builder
+    enabled: true
+    # -- Set unhealthyPodEvictionPolicy for the block-builder PodDisruptionBudget. Requires policy/v1.
+    unhealthyPodEvictionPolicy: ""
+  # -- Pod Disruption Budget maxUnavailable
+  maxUnavailable: 1
   service:
     # -- Annotations for block-builder service
     annotations: {}
@@ -1102,6 +1110,14 @@ liveStore:
   statefulStrategy:
     rollingUpdate:
       partition: 0
+  # -- Pod Disruption Budget configuration
+  podDisruptionBudget:
+    # -- Enable PodDisruptionBudget for live-store
+    enabled: true
+    # -- Set unhealthyPodEvictionPolicy for the live-store PodDisruptionBudget. Requires policy/v1.
+    unhealthyPodEvictionPolicy: ""
+  # -- Pod Disruption Budget maxUnavailable
+  maxUnavailable: 1
   service:
     # -- Annotations for live-store service
     annotations: {}


### PR DESCRIPTION
## What

- Add `templates/block-builder/poddisruptionbudget-block-builder.yaml` and `templates/live-store/poddisruptionbudget-live-store.yaml`, following the same shape as the distributor, querier, query-frontend and metrics-generator PDBs.
- Add a `podDisruptionBudget` block (`enabled`, `unhealthyPodEvictionPolicy`) and a `maxUnavailable` key to `blockBuilder` and `liveStore` in `values.yaml`, matching the existing components' defaults.
- Add helm-unittest coverage for both.

## Why

Closes #727. The Tempo 3.x block-builder and live-store StatefulSets shipped without PodDisruptionBudgets, so a node upgrade could evict every replica at once and interrupt the Kafka-backed write path and recent-data queries.

Each PDB renders only when its component is enabled and has more than one replica, so single-replica deployments are unaffected. Defaults mirror the other components (`enabled: true`, `maxUnavailable: 1`); since both components default to 3 replicas, a default install now gets two additional PodDisruptionBudget objects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)