### PR TITLE
[tempo-distributed] feat: Add traffic distribution option to Tempo

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 3.2.0
+version: 3.2.1
 # renovate: docker=docker.io/grafana/tempo
 appVersion: 3.0.3
 kubeVersion: "^1.25.0-0"

--- a/charts/tempo-distributed/templates/distributor/service-distributor.yaml
+++ b/charts/tempo-distributed/templates/distributor/service-distributor.yaml
@@ -14,6 +14,9 @@ metadata:
     {{- tpl (toYaml . | nindent 4) $ }}
   {{- end }}
 spec:
+  {{- with (coalesce .Values.distributor.service.trafficDistribution .Values.tempo.service.trafficDistribution) }}
+  trafficDistribution: {{ . }}
+  {{- end }}
   internalTrafficPolicy: {{ .Values.distributor.service.internalTrafficPolicy }}
   type: {{ .Values.distributor.service.type }}
   ipFamilies: {{ .Values.tempo.service.ipFamilies }}

--- a/charts/tempo-distributed/templates/gateway/service-gateway.yaml
+++ b/charts/tempo-distributed/templates/gateway/service-gateway.yaml
@@ -14,6 +14,9 @@ metadata:
     {{- tpl (toYaml . | nindent 4) $ }}
   {{- end }}
 spec:
+  {{- with (coalesce .Values.gateway.service.trafficDistribution .Values.tempo.service.trafficDistribution) }}
+  trafficDistribution: {{ . }}
+  {{- end }}
   type: {{ .Values.gateway.service.type }}
   {{- with .Values.gateway.service.clusterIP }}
   clusterIP: {{ . }}

--- a/charts/tempo-distributed/templates/metrics-generator/service-metrics-generator.yaml
+++ b/charts/tempo-distributed/templates/metrics-generator/service-metrics-generator.yaml
@@ -12,6 +12,9 @@ metadata:
     {{- tpl (toYaml . | nindent 4) $ }}
   {{- end }}
 spec:
+  {{- with (coalesce .Values.metricsGenerator.service.trafficDistribution .Values.tempo.service.trafficDistribution) }}
+  trafficDistribution: {{ . }}
+  {{- end }}
   ipFamilies: {{ .Values.tempo.service.ipFamilies }}
   ipFamilyPolicy: {{ .Values.tempo.service.ipFamilyPolicy }}
   ports:

--- a/charts/tempo-distributed/templates/querier/service-querier.yaml
+++ b/charts/tempo-distributed/templates/querier/service-querier.yaml
@@ -10,6 +10,9 @@ metadata:
     {{- tpl (toYaml . | nindent 4) $ }}
   {{- end }}
 spec:
+  {{- with (coalesce .Values.querier.service.trafficDistribution .Values.tempo.service.trafficDistribution) }}
+  trafficDistribution: {{ . }}
+  {{- end }}
   ipFamilies: {{ .Values.tempo.service.ipFamilies }}
   ipFamilyPolicy: {{ .Values.tempo.service.ipFamilyPolicy }}
   ports:

--- a/charts/tempo-distributed/templates/query-frontend/service-query-frontend.yaml
+++ b/charts/tempo-distributed/templates/query-frontend/service-query-frontend.yaml
@@ -13,6 +13,9 @@ metadata:
     {{- tpl (toYaml . | nindent 4) $ }}
   {{- end }}
 spec:
+  {{- with (coalesce .Values.queryFrontend.service.trafficDistribution .Values.tempo.service.trafficDistribution) }}
+  trafficDistribution: {{ . }}
+  {{- end }}
   type: {{ .Values.queryFrontend.service.type }}
   ipFamilies: {{ .Values.tempo.service.ipFamilies }}
   ipFamilyPolicy: {{ .Values.tempo.service.ipFamilyPolicy }}

--- a/charts/tempo-distributed/tests/traffic_distribution_test.yaml
+++ b/charts/tempo-distributed/tests/traffic_distribution_test.yaml
@@ -1,0 +1,57 @@
+# $schema: https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json
+suite: Service trafficDistribution
+templates:
+  - distributor/service-distributor.yaml
+  - gateway/service-gateway.yaml
+  - metrics-generator/service-metrics-generator.yaml
+  - querier/service-querier.yaml
+  - query-frontend/service-query-frontend.yaml
+
+tests:
+  - it: does not render spec.trafficDistribution when unset (default)
+    set:
+      gateway.enabled: true
+      metricsGenerator.enabled: true
+    asserts:
+      - notExists:
+          path: spec.trafficDistribution
+
+  - it: renders the global tempo.service.trafficDistribution on every non-headless Service
+    set:
+      gateway.enabled: true
+      metricsGenerator.enabled: true
+      tempo.service.trafficDistribution: PreferSameZone
+    asserts:
+      - equal:
+          path: spec.trafficDistribution
+          value: PreferSameZone
+
+  - it: per-component value overrides the global default (distributor)
+    template: distributor/service-distributor.yaml
+    set:
+      tempo.service.trafficDistribution: PreferSameZone
+      distributor.service.trafficDistribution: PreferSameNode
+    asserts:
+      - equal:
+          path: spec.trafficDistribution
+          value: PreferSameNode
+
+  - it: per-component value overrides the global default (gateway)
+    template: gateway/service-gateway.yaml
+    set:
+      gateway.enabled: true
+      tempo.service.trafficDistribution: PreferSameZone
+      gateway.service.trafficDistribution: PreferSameNode
+    asserts:
+      - equal:
+          path: spec.trafficDistribution
+          value: PreferSameNode
+
+  - it: per-component value renders alone when global is unset (query-frontend)
+    template: query-frontend/service-query-frontend.yaml
+    set:
+      queryFrontend.service.trafficDistribution: PreferSameZone
+    asserts:
+      - equal:
+          path: spec.trafficDistribution
+          value: PreferSameZone

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -363,7 +363,7 @@ metricsGenerator:
   service:
     # -- Annotations for Metrics Generator service
     annotations: {}
-    # -- Traffic distribution for the Metrics Generator service (e.g. PreferClose). Overrides tempo.service.trafficDistribution.
+    # -- Traffic distribution for the Metrics Generator service (PreferSameZone or PreferSameNode). Overrides tempo.service.trafficDistribution.
     trafficDistribution: null
   serviceDiscovery:
     # -- Annotations for Metrics Generator discovery service
@@ -423,7 +423,7 @@ distributor:
     externalTrafficPolicy: null
     # -- https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/
     internalTrafficPolicy: Cluster
-    # -- Traffic distribution for the distributor service (e.g. PreferClose). Overrides tempo.service.trafficDistribution.
+    # -- Traffic distribution for the distributor service (PreferSameZone or PreferSameNode). Overrides tempo.service.trafficDistribution.
     trafficDistribution: null
   serviceDiscovery:
     # -- Annotations for distributorDiscovery service
@@ -1262,7 +1262,7 @@ querier:
   service:
     # -- Annotations for querier service
     annotations: {}
-    # -- Traffic distribution for the querier service (e.g. PreferClose). Overrides tempo.service.trafficDistribution.
+    # -- Traffic distribution for the querier service (PreferSameZone or PreferSameNode). Overrides tempo.service.trafficDistribution.
     trafficDistribution: null
   # -- Adds the appProtocol field to the querier service. This allows querier to work with istio protocol selection.
   appProtocol:
@@ -1382,7 +1382,7 @@ queryFrontend:
     labels: {}
     # -- Type of service for the queryFrontend
     type: ClusterIP
-    # -- Traffic distribution for the queryFrontend service (e.g. PreferClose). Overrides tempo.service.trafficDistribution.
+    # -- Traffic distribution for the queryFrontend service (PreferSameZone or PreferSameNode). Overrides tempo.service.trafficDistribution.
     trafficDistribution: null
     # -- If type is LoadBalancer you can assign the IP to the LoadBalancer
     loadBalancerIP: ""
@@ -2797,7 +2797,7 @@ gateway:
     port: 80
     # -- Type of the gateway service
     type: ClusterIP
-    # -- Traffic distribution for the gateway service (e.g. PreferClose). Overrides tempo.service.trafficDistribution.
+    # -- Traffic distribution for the gateway service (PreferSameZone or PreferSameNode). Overrides tempo.service.trafficDistribution.
     trafficDistribution: null
     # -- ClusterIP of the gateway service
     clusterIP: null

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -133,6 +133,10 @@ tempo:
     #   - 'IPv6'
     # -- Configure the IP family policy for all tempo services.  SingleStack, PreferDualStack or RequireDualStack
     ipFamilyPolicy: 'SingleStack'
+    # -- Default traffic distribution for all non-headless tempo services (PreferSameZone or PreferSameNode).
+    # See https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution.
+    # Can be overridden per component via <component>.service.trafficDistribution.
+    trafficDistribution: null
 
 # -- Default values applied to every pod in this chart.
 # These values are overridden by component-specific settings.
@@ -359,6 +363,8 @@ metricsGenerator:
   service:
     # -- Annotations for Metrics Generator service
     annotations: {}
+    # -- Traffic distribution for the Metrics Generator service (e.g. PreferClose). Overrides tempo.service.trafficDistribution.
+    trafficDistribution: null
   serviceDiscovery:
     # -- Annotations for Metrics Generator discovery service
     annotations: {}
@@ -417,6 +423,8 @@ distributor:
     externalTrafficPolicy: null
     # -- https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/
     internalTrafficPolicy: Cluster
+    # -- Traffic distribution for the distributor service (e.g. PreferClose). Overrides tempo.service.trafficDistribution.
+    trafficDistribution: null
   serviceDiscovery:
     # -- Annotations for distributorDiscovery service
     annotations: {}
@@ -1254,6 +1262,8 @@ querier:
   service:
     # -- Annotations for querier service
     annotations: {}
+    # -- Traffic distribution for the querier service (e.g. PreferClose). Overrides tempo.service.trafficDistribution.
+    trafficDistribution: null
   # -- Adds the appProtocol field to the querier service. This allows querier to work with istio protocol selection.
   appProtocol:
     # -- Set the optional gRPC service protocol. Ex: "grpc", "http2" or "https"
@@ -1372,6 +1382,8 @@ queryFrontend:
     labels: {}
     # -- Type of service for the queryFrontend
     type: ClusterIP
+    # -- Traffic distribution for the queryFrontend service (e.g. PreferClose). Overrides tempo.service.trafficDistribution.
+    trafficDistribution: null
     # -- If type is LoadBalancer you can assign the IP to the LoadBalancer
     loadBalancerIP: ""
     # -- If type is LoadBalancer limit incoming traffic from IPs.
@@ -2785,6 +2797,8 @@ gateway:
     port: 80
     # -- Type of the gateway service
     type: ClusterIP
+    # -- Traffic distribution for the gateway service (e.g. PreferClose). Overrides tempo.service.trafficDistribution.
+    trafficDistribution: null
     # -- ClusterIP of the gateway service
     clusterIP: null
     # -- Node port if service type is NodePort


### PR DESCRIPTION

#### What this PR does / why we need it
This PR adds possibility to specify the Traffic Distribution on Tempo services. This is critical to cut cross with certain deployments to help users avoid cross AZ costs.

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[grafana]`)
- [x] Add an [helm unittest](https://github.com/helm-unittest/helm-unittest) test case to cover this change.

