### PR TITLE
[grafana] Omit replicas on StatefulSet when autoscaling is enabled

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 12.11.0
+version: 12.11.1
 # renovate: docker=docker.io/grafana/grafana
 appVersion: 13.2.0
 kubeVersion: "^1.25.0-0"

--- a/charts/grafana/templates/statefulset.yaml
+++ b/charts/grafana/templates/statefulset.yaml
@@ -12,7 +12,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if (not .Values.autoscaling.enabled) }}
   replicas: {{ .Values.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "grafana.selectorLabels" . | nindent 6 }}

--- a/charts/grafana/tests/statefulset_test.yaml
+++ b/charts/grafana/tests/statefulset_test.yaml
@@ -34,3 +34,17 @@ tests:
           value:
             whenDeleted: Delete
             whenScaled: Delete
+  - it: should set replicas by default
+    asserts:
+      - template: statefulset.yaml
+        equal:
+          path: spec.replicas
+          value: 1
+  - it: should omit replicas when autoscaling is enabled
+    set:
+      autoscaling:
+        enabled: true
+    asserts:
+      - template: statefulset.yaml
+        notExists:
+          path: spec.replicas


### PR DESCRIPTION
#### What this PR does / why we need it

The Deployment template already omits `spec.replicas` when `autoscaling.enabled` is `true`, so HPA fully owns the field. The StatefulSet template never got the same treatment, it unconditionally sets `replicas`.

This causes a real problem for anyone running the StatefulSet with HPA under a GitOps controller with self heal enabled, such as ArgoCD. The controller keeps resetting the HPA managed replica count back to the chart's static value, and HPA keeps scaling it back up, fighting each other in a loop. In our case this repeatedly killed pods mid startup in production.

This change brings the StatefulSet template in line with the existing Deployment template pattern.

#### Special notes for your reviewer

Verified with `helm template` that `spec.replicas` is correctly omitted when `autoscaling.enabled: true` and still set when `false`, matching the Deployment template's existing behavior exactly. Added helm-unittest coverage for both cases in `tests/statefulset_test.yaml`. Full chart test suite passes (26/26).

#### Checklist

- [x] DCO signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
- [x] Add an helm unittest test case to cover this change.
