### PR TITLE
[loki] make publishNotReadyAddresses overridable on service helper

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.6
-version: 18.9.0
+version: 18.10.0
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/templates/_service.tpl
+++ b/charts/loki/templates/_service.tpl
@@ -11,7 +11,9 @@ Service helper
 {{- $name := .name }}
 {{- $serviceEnabled := kindIs "bool" .serviceEnabled | ternary .serviceEnabled true }}
 {{- $headlessServiceEnabled := kindIs "bool" .headlessServiceEnabled | ternary .headlessServiceEnabled true }}
-{{- $publishNotReadyAddresses := kindIs "bool" .publishNotReadyAddresses | ternary .publishNotReadyAddresses true }}
+{{- $publishNotReadyAddressesDefault := kindIs "bool" $ctx.Values.defaults.service.publishNotReadyAddresses | ternary $ctx.Values.defaults.service.publishNotReadyAddresses true }}
+{{- $publishNotReadyAddressesComponent := kindIs "bool" $component.service.publishNotReadyAddresses | ternary $component.service.publishNotReadyAddresses $publishNotReadyAddressesDefault }}
+{{- $publishNotReadyAddresses := kindIs "bool" .publishNotReadyAddresses | ternary .publishNotReadyAddresses $publishNotReadyAddressesComponent }}
 {{- with $ctx }}
 {{- if $serviceEnabled }}
 apiVersion: v1

--- a/charts/loki/templates/backend/query-scheduler-discovery.yaml
+++ b/charts/loki/templates/backend/query-scheduler-discovery.yaml
@@ -20,7 +20,8 @@ metadata:
 spec:
   type: ClusterIP
   clusterIP: None
-  publishNotReadyAddresses: true
+  {{- $publishNotReadyAddressesDefault := kindIs "bool" .Values.defaults.service.publishNotReadyAddresses | ternary .Values.defaults.service.publishNotReadyAddresses true }}
+  publishNotReadyAddresses: {{ kindIs "bool" .Values.backend.service.publishNotReadyAddresses | ternary .Values.backend.service.publishNotReadyAddresses $publishNotReadyAddressesDefault }}
   ports:
     - name: http-metrics
       port: {{ .Values.loki.server.http_listen_port }}

--- a/charts/loki/templates/backend/query-scheduler-discovery.yaml
+++ b/charts/loki/templates/backend/query-scheduler-discovery.yaml
@@ -21,7 +21,10 @@ spec:
   type: ClusterIP
   clusterIP: None
   {{- $publishNotReadyAddressesDefault := kindIs "bool" .Values.defaults.service.publishNotReadyAddresses | ternary .Values.defaults.service.publishNotReadyAddresses true }}
-  publishNotReadyAddresses: {{ kindIs "bool" .Values.backend.service.publishNotReadyAddresses | ternary .Values.backend.service.publishNotReadyAddresses $publishNotReadyAddressesDefault }}
+  {{- $publishNotReadyAddresses := kindIs "bool" .Values.backend.service.publishNotReadyAddresses | ternary .Values.backend.service.publishNotReadyAddresses $publishNotReadyAddressesDefault }}
+  {{- with $publishNotReadyAddresses }}
+  publishNotReadyAddresses: {{ . }}
+  {{- end }}
   ports:
     - name: http-metrics
       port: {{ .Values.loki.server.http_listen_port }}

--- a/charts/loki/tests/service/publish_not_ready_addresses_test.yaml
+++ b/charts/loki/tests/service/publish_not_ready_addresses_test.yaml
@@ -1,0 +1,101 @@
+# $schema: https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json
+suite: service publishNotReadyAddresses
+templates:
+  - query-frontend/service.yaml
+  - ingester/service.yaml
+  - backend/query-scheduler-discovery.yaml
+  - config.yaml
+
+set:
+  loki.useTestSchema: true
+  loki.storage.bucketNames.chunks: chunks
+  loki.storage.bucketNames.ruler: ruler
+
+tests:
+  - it: defaults to true on non-headless query-frontend service
+    set:
+      deploymentMode: Distributed
+    asserts:
+      - equal:
+          path: spec.publishNotReadyAddresses
+          value: true
+        documentIndex: 0
+        template: query-frontend/service.yaml
+
+  - it: sets publishNotReadyAddresses on query-frontend service via component value
+    set:
+      deploymentMode: Distributed
+      queryFrontend.service.publishNotReadyAddresses: false
+    asserts:
+      - notExists:
+          path: spec.publishNotReadyAddresses
+        documentIndex: 0
+        template: query-frontend/service.yaml
+
+  - it: sets publishNotReadyAddresses on query-frontend headless service via component value
+    set:
+      deploymentMode: Distributed
+      queryFrontend.service.publishNotReadyAddresses: false
+    asserts:
+      - notExists:
+          path: spec.publishNotReadyAddresses
+        documentIndex: 1
+        template: query-frontend/service.yaml
+
+  - it: sets publishNotReadyAddresses on query-frontend service via defaults.service
+    set:
+      deploymentMode: Distributed
+      defaults.service.publishNotReadyAddresses: false
+    asserts:
+      - notExists:
+          path: spec.publishNotReadyAddresses
+        documentIndex: 0
+        template: query-frontend/service.yaml
+
+  - it: component publishNotReadyAddresses overrides defaults.service.publishNotReadyAddresses
+    set:
+      deploymentMode: Distributed
+      defaults.service.publishNotReadyAddresses: false
+      queryFrontend.service.publishNotReadyAddresses: true
+    asserts:
+      - equal:
+          path: spec.publishNotReadyAddresses
+          value: true
+        documentIndex: 0
+        template: query-frontend/service.yaml
+
+  - it: keeps zone-aware ingester headless service publishNotReadyAddresses false regardless of defaults.service
+    set:
+      deploymentMode: Distributed
+      read.replicas: 0
+      write.replicas: 0
+      backend.replicas: 0
+      ingester.replicas: 3
+      ingester.zoneAwareReplication.enabled: true
+      defaults.service.publishNotReadyAddresses: true
+    asserts:
+      - notExists:
+          path: spec.publishNotReadyAddresses
+        documentIndex: 2
+        template: ingester/service.yaml
+
+  - it: defaults to true on the query-scheduler-discovery service
+    set:
+      deploymentMode: SimpleScalable
+      read.legacyReadTarget: false
+    asserts:
+      - equal:
+          path: spec.publishNotReadyAddresses
+          value: true
+        template: backend/query-scheduler-discovery.yaml
+
+  - it: sets publishNotReadyAddresses on the query-scheduler-discovery service via backend.service value
+    set:
+      deploymentMode: SimpleScalable
+      read.legacyReadTarget: false
+      backend.service.publishNotReadyAddresses: false
+    asserts:
+      - equal:
+          path: spec.publishNotReadyAddresses
+          value: false
+        template: backend/query-scheduler-discovery.yaml

--- a/charts/loki/tests/service/publish_not_ready_addresses_test.yaml
+++ b/charts/loki/tests/service/publish_not_ready_addresses_test.yaml
@@ -95,7 +95,6 @@ tests:
       read.legacyReadTarget: false
       backend.service.publishNotReadyAddresses: false
     asserts:
-      - equal:
+      - notExists:
           path: spec.publishNotReadyAddresses
-          value: false
         template: backend/query-scheduler-discovery.yaml

--- a/charts/loki/values.schema.json
+++ b/charts/loki/values.schema.json
@@ -3142,6 +3142,13 @@
                                 "type": "string"
                             }
                         },
+                        "publishNotReadyAddresses": {
+                            "description": "publishNotReadyAddresses for all services. Set to false so a pod's Service endpoint is withdrawn as soon as it becomes unready, instead of staying routable for the full termination window. Overridable per component via \u003ccomponent\u003e.service.publishNotReadyAddresses.",
+                            "type": [
+                                "boolean",
+                                "null"
+                            ]
+                        },
                         "trafficDistribution": {
                             "description": "trafficDistribution for services Ref: https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution",
                             "type": "string"

--- a/charts/loki/values.schema.json
+++ b/charts/loki/values.schema.json
@@ -3144,10 +3144,7 @@
                         },
                         "publishNotReadyAddresses": {
                             "description": "publishNotReadyAddresses for all services. Set to false so a pod's Service endpoint is withdrawn as soon as it becomes unready, instead of staying routable for the full termination window. Overridable per component via \u003ccomponent\u003e.service.publishNotReadyAddresses.",
-                            "type": [
-                                "boolean",
-                                "null"
-                            ]
+                            "type": "boolean"
                         },
                         "trafficDistribution": {
                             "description": "trafficDistribution for services Ref: https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution",

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -171,11 +171,10 @@ defaults:
     # -- ipFamilies for all services
     # Ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services
     ipFamilies: []
-    # @schema type:[boolean, null]
     # -- publishNotReadyAddresses for all services. Set to false so a pod's Service endpoint is
     # withdrawn as soon as it becomes unready, instead of staying routable for the full termination
     # window. Overridable per component via <component>.service.publishNotReadyAddresses.
-    publishNotReadyAddresses: null
+    publishNotReadyAddresses: true
   # -- KEDA autoscaling shared configuration for all components that support KEDA
   kedaAutoscaling:
     # -- Prometheus server address for KEDA triggers

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -171,6 +171,11 @@ defaults:
     # -- ipFamilies for all services
     # Ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services
     ipFamilies: []
+    # @schema type:[boolean, null]
+    # -- publishNotReadyAddresses for all services. Set to false so a pod's Service endpoint is
+    # withdrawn as soon as it becomes unready, instead of staying routable for the full termination
+    # window. Overridable per component via <component>.service.publishNotReadyAddresses.
+    publishNotReadyAddresses: null
   # -- KEDA autoscaling shared configuration for all components that support KEDA
   kedaAutoscaling:
     # -- Prometheus server address for KEDA triggers


### PR DESCRIPTION
#### What this PR does / why we need it

We changed our local calls to go to headless endpoints due to envoy ip propogation delays breaking gossip. This meant that now, terminating pods keep getting the requests and result in EOFs which was not the case before. I had to use post_render to turn this to false as there is no way to plug this in via values.yaml as reported in the parent issue. 

This pr fixes exactly that gap. Since `loki.service` hardcodes `publishNotReadyAddresses` to `true` for every component Service, with no values key to override it (only `memberlist.service.publishNotReadyAddresses` is wired to a value). Terminating pods therefore stay routable through the full termination window, which surfaces as 502/503s at the gateway on scale-down and rollout.

Adds `defaults.service.publishNotReadyAddresses` (global) and a per-component `<component>.service.publishNotReadyAddresses` override, following the same `coalesce` pattern already used for `ipFamilyPolicy`/`trafficDistribution`. Also fixes the one template that hardcoded the value outside the shared helper (`backend/query-scheduler-discovery.yaml`).

Both a global default and a per-component override are included, not just one: the issue itself asks for per-component control (its example is `distributor.service.publishNotReadyAddresses: false`), and in my case only a handful of components needed this flipped — a global-only toggle would force the same value onto every component's Service at once, which is broader than what either the issue or my own use case needs.

Default stays `true`, so this is backward compatible — existing installs render identical manifests until the value is explicitly overridden.

#### Which issue this PR fixes

- fixes #744

#### Special notes for your reviewer

I verified this on my local kind cluster. 

<details><summary>Test plan</summary>

```
$ helm lint charts/loki -f charts/loki/values.yaml --set ignoreMinioDeprecation=true
==> Linting charts/loki
1 chart(s) linted, 0 chart(s) failed
```

Rendered default output for distributor/query-frontend/query-scheduler/overrides-exporter services — unchanged, `publishNotReadyAddresses: true` still emitted (green path, backward compat).

Rendered with `--set queryFrontend.service.publishNotReadyAddresses=false`, `--set defaults.service.publishNotReadyAddresses=false`, and `--set backend.service.publishNotReadyAddresses=false` — each correctly omits/sets the field on the targeted service(s) only (override path).

Rendered zone-aware ingester headless services with `--set defaults.service.publishNotReadyAddresses=true` — still omit the field, confirming the explicit `false` those templates pass for ring correctness is not overridable by the new global/component values (negative/guard path).

Added `charts/loki/tests/service/publish_not_ready_addresses_test.yaml` (8 cases) covering all of the above. Full suite:

```
$ make helm-unittest HELM_CHART=loki
Charts:      1 passed, 1 total
Test Suites: 62 passed, 62 total
Tests:       548 passed, 548 total
```

Regenerated `values.schema.json` via `make helm-schema` — diff is limited to the new key.

Also installed against a real kind cluster (`SimpleScalable` mode, bundled minio) to confirm the API server accepts the changed manifests and the override actually flips a live Service, not just the rendered template:

```
$ helm install pr747-verify charts/loki -n loki-pr747-verify -f pr747-verify-values.yaml --wait
# ... pods Running

$ kubectl get svc -n loki-pr747-verify -o custom-columns=NAME:.metadata.name,PNRA:.spec.publishNotReadyAddresses
NAME                                          PNRA
pr747-verify-loki-backend                     true
pr747-verify-loki-query-scheduler-discovery   true
pr747-verify-loki-read                        true
pr747-verify-loki-write                        true

$ helm upgrade pr747-verify charts/loki -n loki-pr747-verify -f pr747-verify-values.yaml \
    --set backend.service.publishNotReadyAddresses=false --wait
$ kubectl get svc -n loki-pr747-verify -o custom-columns=NAME:.metadata.name,PNRA:.spec.publishNotReadyAddresses
NAME                                          PNRA
pr747-verify-loki-backend                     <none>
pr747-verify-loki-query-scheduler-discovery   <none>
pr747-verify-loki-read                        true
pr747-verify-loki-write                        true

$ helm upgrade pr747-verify charts/loki -n loki-pr747-verify -f pr747-verify-values.yaml \
    --set defaults.service.publishNotReadyAddresses=false --wait
$ kubectl get svc -n loki-pr747-verify -o custom-columns=NAME:.metadata.name,PNRA:.spec.publishNotReadyAddresses
NAME                                          PNRA
pr747-verify-loki-backend                     <none>
pr747-verify-loki-query-scheduler-discovery   <none>
pr747-verify-loki-read                        <none>
pr747-verify-loki-write                        <none>
```

`helm upgrade` against the live StatefulSets/Deployments succeeded with no immutable-field errors (`publishNotReadyAddresses` is a mutable Service field). Component override correctly scoped to `backend` only in the second step; global default correctly propagated to all loki-managed services in the third.

</details>

#### Checklist

- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
- [x] Add an [helm unittest](https://github.com/helm-unittest/helm-unittest) test case to cover this change.
