### PR TITLE
[tempo-distributed] Add zone-aware replication for the live-store

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 3.3.0
+version: 3.4.0
 # renovate: docker=docker.io/grafana/tempo
 appVersion: 3.0.3
 kubeVersion: "^1.25.0-0"

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -454,8 +454,11 @@ exactly one live-store. If that pod goes away, recent-trace queries for its
 partition fail until the pod comes back.
 
 Zone-aware replication renders one StatefulSet per zone. Each zone runs a full
-set of live-stores, gets its own Kafka consumer group and passes its own
-`-live-store.instance-availability-zone` to Tempo. A partition therefore has one
+set of live-stores and passes its own
+`-live-store.instance-availability-zone` to Tempo. A live-store reads Kafka
+under a consumer group of its own, because the chart leaves
+`ingest.kafka.consumer_group` unset and Tempo then falls back to the pod name,
+so the zones consume every partition independently. A partition therefore has one
 owner per zone, and a querier needs an answer from one zone only. The loss of a
 zone no longer breaks recent-trace queries.
 
@@ -515,8 +518,9 @@ Notes:
 
 The switch replaces the flat StatefulSet with the per-zone ones, so every
 live-store restarts at once and the recent-read tier is unavailable until the
-pods are ready. Each zone also gets its own Kafka consumer group, which has no
-committed offset yet, so every live-store replays the Kafka lookback period to
+pods are ready. The new pods also carry new names, and a live-store takes its
+Kafka consumer group from its pod name, so every consumer group is new and has
+no committed offset. Every live-store replays the Kafka lookback period to
 rebuild its query state. Plan the switch like a full live-store restart.
 
 #### Draining a node

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -446,6 +446,64 @@ traces:
       enabled: true
 ```
 
+### Zone-aware replication for the live-store
+
+The live-store serves the recent part of every trace query. Without zone
+awareness the chart renders one flat StatefulSet, so each Kafka partition has
+exactly one live-store. If that pod goes away, recent-trace queries for its
+partition fail until the pod comes back.
+
+Zone-aware replication renders one StatefulSet per zone. Each zone runs a full
+set of live-stores, gets its own Kafka consumer group and passes its own
+`-live-store.instance-availability-zone` to Tempo. A partition therefore has one
+owner per zone, and a querier needs an answer from one zone only. The loss of a
+zone no longer breaks recent-trace queries.
+
+The rollout-operator coordinates the rollout. It moves one zone at a time and
+restarts at most `maxUnavailable` live-stores inside that zone, so the other
+zones keep serving. Zone-aware StatefulSets use the `OnDelete` update strategy,
+which means nothing restarts them unless a rollout-operator watches the
+namespace. The chart refuses to render without one.
+
+```yaml
+rollout_operator:
+  enabled: true
+
+liveStore:
+  enabled: true
+  replicas: 3  # partitions per zone; must equal the Kafka partition count
+  zoneAwareReplication:
+    enabled: true
+    topologyKey: topology.kubernetes.io/zone
+    zones:
+      - name: zone-a
+        nodeSelector:
+          topology.kubernetes.io/zone: eu-west-1a
+      - name: zone-b
+        nodeSelector:
+          topology.kubernetes.io/zone: eu-west-1b
+```
+
+The example above runs 6 live-stores: 3 partitions in each of the 2 zones.
+
+Notes:
+
+- `liveStore.replicas` stays the Kafka partition count. It is the size of one
+  zone, not the total. Adding a zone multiplies the live-store count and the
+  Kafka read traffic.
+- At least 2 zones are required.
+- `topologyKey` adds an anti-affinity rule that keeps the live-stores of one
+  zone off the domains that run another zone. Leave it unset to let the
+  scheduler place the pods freely.
+- `liveStore.topologySpreadConstraints` is ignored while zone-awareness is on,
+  because the zones already define the spread.
+- Set `zoneAwareReplication.rolloutOperatorManagedExternally: true` when a
+  rollout-operator already runs in the namespace and this chart must not
+  install one.
+- Scaling down is not coordinated across zones. Reduce the live-stores of one
+  zone at a time, and remember that `liveStore.replicas` must keep matching the
+  Kafka partition count.
+
 ### Memcached cache configuration
 
 By default, the chart deploys a single shared memcached StatefulSet (`memcached`) used for all cache roles — bloom filters, parquet footer, and frontend search. This is the simplest setup and works well for most deployments.

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -500,6 +500,14 @@ Notes:
 - Set `zoneAwareReplication.rolloutOperatorManagedExternally: true` when a
   rollout-operator already runs in the namespace and this chart must not
   install one.
+#### Turning zone-awareness on
+
+The switch replaces the flat StatefulSet with the per-zone ones, so every
+live-store restarts at once and the recent-read tier is unavailable until the
+pods are ready. Each zone also gets its own Kafka consumer group, which has no
+committed offset yet, so every live-store replays the Kafka lookback period to
+rebuild its query state. Plan the switch like a full live-store restart.
+
 #### Scaling down
 
 A live-store count must keep matching the Kafka partition count, and a partition

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -502,10 +502,7 @@ Notes:
   because the zones already define the spread. `liveStore.affinity` and the node
   selector of the component are kept: a zone merges its own `extraAffinity` and
   `nodeSelector` on top of them.
-- The PodDisruptionBudget covers the live-stores of every zone together, with
-  `liveStore.maxUnavailable` as the budget for the whole set. One budget per zone
-  would let a drain evict the same pod ordinal in two zones at once, and those
-  pods are every owner of one partition.
+- Voluntary evictions are guarded per partition, not per pod count. See below.
 - Set `zoneAwareReplication.rolloutOperatorManagedExternally: true` when a
   rollout-operator already runs in the namespace and this chart must not
   install one.
@@ -521,6 +518,49 @@ live-store restarts at once and the recent-read tier is unavailable until the
 pods are ready. Each zone also gets its own Kafka consumer group, which has no
 committed offset yet, so every live-store replays the Kafka lookback period to
 rebuild its query state. Plan the switch like a full live-store restart.
+
+#### Draining a node
+
+The same pod ordinal in every zone holds every owner of one Kafka partition:
+`live-store-zone-a-2` and `live-store-zone-b-2` both own partition 2. A native
+PodDisruptionBudget counts pods and cannot express that, so it either allows
+both to go at once, or it has to be tightened to one eviction for the whole
+live-store set.
+
+Zone-awareness therefore renders a `ZoneAwarePodDisruptionBudget` instead, which
+the rollout-operator enforces on the eviction of a pod. It reads the partition
+from the pod name and counts the unavailable live-stores of that partition over
+every zone:
+
+```yaml
+liveStore:
+  zoneAwareReplication:
+    podDisruptionBudget:
+      enabled: true
+      maxUnavailable: 1
+```
+
+With `maxUnavailable: 1`, a drain can take one live-store per partition and many
+partitions at the same time, and it can never take the last owner of a
+partition. The rollout-operator rejects an eviction while it is unreachable, so
+this opens no window. It replaces the `liveStore.podDisruptionBudget` object.
+
+Set `crossZoneEvictionDelay` when the live-stores run with the default
+`readiness-target-lag` of 0, because a live-store then reports ready while it
+still replays its partition:
+
+```yaml
+liveStore:
+  zoneAwareReplication:
+    podDisruptionBudget:
+      crossZoneEvictionDelay: 20m
+```
+
+The budget needs the `ZoneAwarePodDisruptionBudget` CRD and the pod eviction
+webhook. The bundled rollout-operator installs both, and the chart refuses to
+render when either is turned off. Set `podDisruptionBudget.enabled: false` to
+fall back to a single native PodDisruptionBudget over all zones, with
+`liveStore.maxUnavailable` as the budget for the whole set.
 
 #### Scaling down
 

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -492,14 +492,22 @@ Notes:
   zone, not the total. Adding a zone multiplies the live-store count and the
   Kafka read traffic.
 - At least 2 zones are required.
-- `topologyKey` adds an anti-affinity rule that keeps the live-stores of one
-  zone off the domains that run another zone. Leave it unset to let the
-  scheduler place the pods freely.
+- `topologyKey` adds a required anti-affinity rule that keeps the live-stores of
+  one zone off the domains that run another zone. The cluster must hold at least
+  as many domains as there are zones, otherwise the extra zones stay
+  unschedulable. `kubernetes.io/hostname` is the conservative choice, and
+  `topology.kubernetes.io/zone` needs one availability zone per zone. Leave it
+  unset when a `nodeSelector` on every zone already pins the zones.
 - `liveStore.topologySpreadConstraints` is ignored while zone-awareness is on,
   because the zones already define the spread.
 - Set `zoneAwareReplication.rolloutOperatorManagedExternally: true` when a
   rollout-operator already runs in the namespace and this chart must not
   install one.
+- With no `topologyKey` and no per-zone `nodeSelector`, the zones still give
+  separate pods, separate consumer groups and one partition owner each, but the
+  scheduler can place two zones in one failure domain. Nothing then protects the
+  partition from the loss of that domain.
+
 #### Turning zone-awareness on
 
 The switch replaces the flat StatefulSet with the per-zone ones, so every
@@ -510,10 +518,11 @@ rebuild its query state. Plan the switch like a full live-store restart.
 
 #### Scaling down
 
-A live-store count must keep matching the Kafka partition count, and a partition
-that loses its last owner loses its recent-read tier. Two opt-in settings guard
-the scale-down. Both need the rollout-operator admission webhooks, which the
-subchart enables by default.
+A live-store count must keep matching the Kafka partition count, so a lower
+`liveStore.replicas` retires the last Kafka partitions, and a partition that
+loses its last owner loses its recent-read tier. Two opt-in settings guard that
+change. Both need the rollout-operator admission webhooks, which the subchart
+enables by default.
 
 `noDownscale` rejects every scale-down of the live-stores:
 
@@ -525,7 +534,7 @@ liveStore:
 
 `prepareDownscale` coordinates the scale-down instead. On a scale-down the
 webhook calls `live-store/prepare-partition-downscale` on every live-store that
-goes away, which moves its partition to INACTIVE before the pod stops. The
+goes away, which moves its partition to INACTIVE and stops the writes to it. The
 webhook then rejects the scale-down of a second zone until
 `minTimeBetweenZonesDownscale` has passed, so the zones go down one at a time:
 
@@ -539,6 +548,27 @@ liveStore:
 
 A rejected scale-down fails the `helm upgrade`, and the zones that were already
 accepted stay scaled down. Wait for the window, then run the upgrade again.
+
+The pod stops as soon as its partition is INACTIVE. The zones that are still up
+own that partition too and hold the same recent traces, so the read path stays
+whole until the last zone goes down. The last zone is the one that takes the
+last owner away, which is why `minTimeBetweenZonesDownscale` must be longer than
+the period a live-store still serves recent traces. Writes to the partition stop
+at the first zone, so the window starts there.
+
+Two limits follow from the same design:
+
+- Remove a zone from the `zones` list and Helm deletes its StatefulSet. A
+  deletion is not a scale-down, so the webhook never sees it and no partition
+  goes INACTIVE. This is safe, because every remaining zone still owns every
+  partition, but do not combine it with a lower `liveStore.replicas` in one
+  step.
+- The chart does not configure the delayed-downscale mechanism of the
+  rollout-operator, which needs a `ReplicaTemplate` resource and the
+  mirror-replicas annotations. That mechanism is what lets the Tempo jsonnet
+  point the webhook at `live-store/prepare-downscale`, the endpoint that also
+  keeps the pod from re-creating its partition on start. Here the zone stagger
+  does that job instead.
 
 The webhook reaches the live-stores through the pod DNS names of the headless
 service, and it builds them with its own cluster domain, which defaults to

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -499,7 +499,9 @@ Notes:
   `topology.kubernetes.io/zone` needs one availability zone per zone. Leave it
   unset when a `nodeSelector` on every zone already pins the zones.
 - `liveStore.topologySpreadConstraints` is ignored while zone-awareness is on,
-  because the zones already define the spread.
+  because the zones already define the spread. `liveStore.affinity` and the node
+  selector of the component are kept: a zone merges its own `extraAffinity` and
+  `nodeSelector` on top of them.
 - Set `zoneAwareReplication.rolloutOperatorManagedExternally: true` when a
   rollout-operator already runs in the namespace and this chart must not
   install one.

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -502,6 +502,10 @@ Notes:
   because the zones already define the spread. `liveStore.affinity` and the node
   selector of the component are kept: a zone merges its own `extraAffinity` and
   `nodeSelector` on top of them.
+- The PodDisruptionBudget covers the live-stores of every zone together, with
+  `liveStore.maxUnavailable` as the budget for the whole set. One budget per zone
+  would let a drain evict the same pod ordinal in two zones at once, and those
+  pods are every owner of one partition.
 - Set `zoneAwareReplication.rolloutOperatorManagedExternally: true` when a
   rollout-operator already runs in the namespace and this chart must not
   install one.

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -500,9 +500,50 @@ Notes:
 - Set `zoneAwareReplication.rolloutOperatorManagedExternally: true` when a
   rollout-operator already runs in the namespace and this chart must not
   install one.
-- Scaling down is not coordinated across zones. Reduce the live-stores of one
-  zone at a time, and remember that `liveStore.replicas` must keep matching the
-  Kafka partition count.
+#### Scaling down
+
+A live-store count must keep matching the Kafka partition count, and a partition
+that loses its last owner loses its recent-read tier. Two opt-in settings guard
+the scale-down. Both need the rollout-operator admission webhooks, which the
+subchart enables by default.
+
+`noDownscale` rejects every scale-down of the live-stores:
+
+```yaml
+liveStore:
+  zoneAwareReplication:
+    noDownscale: true
+```
+
+`prepareDownscale` coordinates the scale-down instead. On a scale-down the
+webhook calls `live-store/prepare-partition-downscale` on every live-store that
+goes away, which moves its partition to INACTIVE before the pod stops. The
+webhook then rejects the scale-down of a second zone until
+`minTimeBetweenZonesDownscale` has passed, so the zones go down one at a time:
+
+```yaml
+liveStore:
+  zoneAwareReplication:
+    prepareDownscale:
+      enabled: true
+      minTimeBetweenZonesDownscale: 12h
+```
+
+A rejected scale-down fails the `helm upgrade`, and the zones that were already
+accepted stay scaled down. Wait for the window, then run the upgrade again.
+
+The webhook reaches the live-stores through the pod DNS names of the headless
+service, and it builds them with its own cluster domain, which defaults to
+`cluster.local`. When `global.clusterDomain` differs, pass the same domain to
+the rollout-operator, otherwise the chart refuses to render:
+
+```yaml
+global:
+  clusterDomain: custom.local
+rollout_operator:
+  extraArgs:
+    - -cluster-domain=custom.local
+```
 
 ### Memcached cache configuration
 

--- a/charts/tempo-distributed/UPGRADE.md
+++ b/charts/tempo-distributed/UPGRADE.md
@@ -109,6 +109,31 @@ partition**. If you use `ingest.kafka.auto_create_topic_enabled: true`, set
 `ingest.kafka.auto_create_topic_default_partitions` to the desired partition
 count and set `blockBuilder.replicas` and `liveStore.replicas` to match.
 
+### Live-store headless service name (planned change in 4.0.0)
+
+The flat live-store StatefulSet sets `spec.serviceName: live-store`, which
+matches no Service in the release. `spec.serviceName` names the headless Service
+that governs the pod DNS names: the controller copies it into the `subdomain` of
+every pod, which produces the record
+`<pod>.<serviceName>.<namespace>.svc.<clusterDomain>`. With a name that matches
+no Service, the live-store pods have no resolvable DNS name.
+
+Nothing in the chart depends on that record today. The live-stores join the ring
+through the `gossip-ring` Service, and queriers reach them by the addresses in
+the ring, so the wrong name has no effect. Zone-aware live-stores already use
+the correct name, `<release>-tempo-live-store`, because the rollout-operator
+scale-down webhook addresses the pods through it.
+
+`spec.serviceName` is immutable, so correcting it on the flat StatefulSet needs
+the object to be recreated. Chart 4.0.0 will make the change. Prepare for it
+with:
+
+```bash
+kubectl delete statefulset <release>-tempo-live-store --cascade=orphan
+```
+
+The pods keep running while Helm recreates the StatefulSet on the next upgrade.
+
 ### Legacy overrides format
 
 Tempo 3.0 disables the legacy flat overrides format by default. If your

--- a/charts/tempo-distributed/ci/live-store-zone-aware-values.yaml
+++ b/charts/tempo-distributed/ci/live-store-zone-aware-values.yaml
@@ -1,0 +1,32 @@
+# Installs the flat live-store from the base branch, then upgrades to the
+# zone-aware live-stores of this branch, so the switch documented in README.md
+# runs on a real cluster. The kind cluster has two worker nodes, so one zone can
+# land on each.
+blockBuilder:
+  replicas: 1
+
+liveStore:
+  replicas: 1
+  zoneAwareReplication:
+    enabled: true
+    topologyKey: kubernetes.io/hostname
+    zones:
+      - name: zone-a
+      - name: zone-b
+
+rollout_operator:
+  enabled: true
+
+ingest:
+  kafka:
+    address: "kafka.kafka-ci.svc.cluster.local:9092"
+    auto_create_topic_default_partitions: 1
+
+traces:
+  otlp:
+    http:
+      enabled: true
+
+tests:
+  integration:
+    enabled: true

--- a/charts/tempo-distributed/ci/live-store-zone-aware-values.yaml
+++ b/charts/tempo-distributed/ci/live-store-zone-aware-values.yaml
@@ -13,6 +13,8 @@ liveStore:
     zones:
       - name: zone-a
       - name: zone-b
+    podDisruptionBudget:
+      crossZoneEvictionDelay: 20m
 
 rollout_operator:
   enabled: true

--- a/charts/tempo-distributed/templates/_helpers.tpl
+++ b/charts/tempo-distributed/templates/_helpers.tpl
@@ -140,6 +140,10 @@ app.kubernetes.io/part-of: memberlist
 app.kubernetes.io/version: {{ .ctx.Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .ctx.Release.Service }}
+{{- if .rolloutZoneName }}
+rollout-group: {{ .component }}
+zone: {{ .rolloutZoneName }}
+{{- end }}
 {{- if .ctx.Values.global.commonLabels }}
 {{ toYaml .ctx.Values.global.commonLabels | indent 0 }}
 {{- end }}
@@ -150,12 +154,23 @@ app.kubernetes.io/managed-by: {{ .ctx.Release.Service }}
 
 {{/*
 Simple service selector labels
+Params:
+  ctx = . context
+  component = name of the component (optional)
+  rolloutZoneName = rollout zone name (optional); makes the selector match one zone only
 */}}
 {{- define "tempo.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "tempo.name" .ctx }}
 app.kubernetes.io/instance: {{ .ctx.Release.Name }}
 {{- if .component }}
 app.kubernetes.io/component: {{ .component }}
+{{- end }}
+{{- if .rolloutZoneName }}
+{{- if not .component }}
+{{- printf "Component name cannot be empty if rolloutZoneName (%s) is set" .rolloutZoneName | fail }}
+{{- end }}
+rollout-group: {{ .component }}
+zone: {{ .rolloutZoneName }}
 {{- end -}}
 {{- end -}}
 
@@ -172,9 +187,13 @@ Create the name of the service account to use
 
 {{/*
 Resource name template
+Params:
+  ctx = . context
+  component = name of the component (optional)
+  rolloutZoneName = rollout zone name (optional); appended as a suffix
 */}}
 {{- define "tempo.resourceName" -}}
-{{ include "tempo.fullname" .ctx }}{{- if .component -}}-{{ .component }}{{- end -}}
+{{ include "tempo.fullname" .ctx }}{{- if .component -}}-{{ .component }}{{- end -}}{{- if .rolloutZoneName -}}-{{ .rolloutZoneName }}{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/tempo-distributed/templates/_pod.tpl
+++ b/charts/tempo-distributed/templates/_pod.tpl
@@ -10,10 +10,11 @@ Parameters:
   target         - component name string used in args and volume names (e.g. "distributor")
   rolloutZoneName - (optional) zone name string; when non-empty, emits zone-aware pod labels
                     and uses rolloutZone affinity/nodeSelector instead of component values
-  rolloutZone    - (optional) precomputed zone dict from ingester.zoneAwareReplicationMap
-                    (keys: affinity, nodeSelector, podAnnotations)
+  rolloutZone    - (optional) precomputed zone dict from a component zone map
+                    such as live-store.zoneAwareReplicationMap
+                    (keys: affinity, nodeSelector, podAnnotations, replicas)
   args           - (optional) extra args list prepended before extraArgs concat
-                    (used for -ingester.availability-zone=<zone>)
+                    (used for -<target>.instance-availability-zone=<zone>)
   persistence    - (optional) persistence dict; when provided drives the data volume:
                     enabled=false  → emptyDir (custom spec from dataEmptyDir, else {})
                     enabled=true, inMemory=true → emptyDir medium:Memory with sizeLimit
@@ -169,9 +170,11 @@ spec:
     {{- end }}
     {{- end }}
   terminationGracePeriodSeconds: {{ $component.terminationGracePeriodSeconds }}
+  {{- if not $rolloutZoneName }}
   {{- with $component.topologySpreadConstraints }}
   topologySpreadConstraints:
     {{- tpl . $ctx | nindent 4 }}
+  {{- end }}
   {{- end }}
   {{- if $rolloutZoneName }}
   {{- with $rolloutZone.affinity }}

--- a/charts/tempo-distributed/templates/_pod.tpl
+++ b/charts/tempo-distributed/templates/_pod.tpl
@@ -56,9 +56,7 @@ metadata:
     {{- end }}
     {{- if .Values.enterprise.legacyLabels }}
     app: {{ include "tempo.name" . }}-{{ $target }}
-    {{- if $rolloutZoneName }}
-    name: {{ $target }}-{{ $rolloutZoneName }}
-    {{- else }}
+    {{- if not $rolloutZoneName }}
     name: {{ $target }}
     {{- end }}
     gossip_ring_member: "true"

--- a/charts/tempo-distributed/templates/live-store/_helpers-live-store.tpl
+++ b/charts/tempo-distributed/templates/live-store/_helpers-live-store.tpl
@@ -5,10 +5,11 @@ Returns a map keyed by zone name. The key "" is used when zone-aware replication
 is disabled and renders the single flat StatefulSet.
 
 Each zone runs a full set of live-stores. A live-store derives its Kafka
-partition from the numeric suffix of its pod name and its consumer group from
-the StatefulSet name, so every zone consumes all partitions independently and
-each partition ends up with one owner per zone. Therefore the replica count of a
-zone is liveStore.replicas, not a share of it.
+partition from the numeric suffix of its pod name, and its Kafka consumer group
+defaults to its own pod name because the chart leaves ingest.kafka.consumer_group
+unset. Every zone therefore consumes all partitions independently and each
+partition ends up with one owner per zone. Therefore the replica count of a zone
+is liveStore.replicas, not a share of it.
 
 Params:
   ctx = root context ($)

--- a/charts/tempo-distributed/templates/live-store/_helpers-live-store.tpl
+++ b/charts/tempo-distributed/templates/live-store/_helpers-live-store.tpl
@@ -29,17 +29,29 @@ Params:
 {{- if not .name -}}
 {{- fail "every entry of liveStore.zoneAwareReplication.zones must set a name." -}}
 {{- end -}}
+{{- if not (regexMatch "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$" (.name | toString)) -}}
+{{- fail (printf "liveStore.zoneAwareReplication zone name %q is not a DNS label. A zone name becomes both a StatefulSet name suffix and the value of the zone label, so it must hold lowercase letters, digits and dashes only, and start and end with a letter or a digit." .name) -}}
+{{- end -}}
 {{- $zoneNames = append $zoneNames .name -}}
 {{- end -}}
 {{- if ne (len ($zoneNames | uniq)) (len $zoneNames) -}}
 {{- fail "liveStore.zoneAwareReplication.zones must have unique names." -}}
 {{- end -}}
+{{- $baseAffinity := dict -}}
+{{- with $liveStore.affinity -}}
+{{- if kindIs "string" . -}}
+{{- $baseAffinity = tpl . $ctx | fromYaml -}}
+{{- else -}}
+{{- $baseAffinity = . -}}
+{{- end -}}
+{{- end -}}
+{{- $baseNodeSelector := coalesce $liveStore.nodeSelector $ctx.Values.defaults.nodeSelector | default dict -}}
 {{- range $zone := $zones -}}
 {{- $antiAffinity := include "live-store.zoneAntiAffinity" (dict "ctx" $ctx "rolloutZoneName" $zone.name "topologyKey" $zoneAware.topologyKey) | fromYaml -}}
-{{- $affinity := mergeOverwrite (deepCopy ($zone.extraAffinity | default dict)) $antiAffinity -}}
+{{- $affinity := mergeOverwrite (deepCopy $baseAffinity) (deepCopy ($zone.extraAffinity | default dict)) $antiAffinity -}}
 {{- $_ := set $zonesMap $zone.name (dict
       "affinity" $affinity
-      "nodeSelector" ($zone.nodeSelector | default dict)
+      "nodeSelector" (mergeOverwrite (deepCopy $baseNodeSelector) ($zone.nodeSelector | default dict))
       "annotations" ($zone.annotations | default dict)
       "podAnnotations" ($zone.podAnnotations | default dict)
       "replicas" $replicas

--- a/charts/tempo-distributed/templates/live-store/_helpers-live-store.tpl
+++ b/charts/tempo-distributed/templates/live-store/_helpers-live-store.tpl
@@ -14,6 +14,7 @@ Params:
   ctx = root context ($)
 */}}
 {{- define "live-store.zoneAwareReplicationMap" -}}
+{{- $ctx := .ctx -}}
 {{- $zonesMap := dict -}}
 {{- $liveStore := .ctx.Values.liveStore -}}
 {{- $zoneAware := $liveStore.zoneAwareReplication | default dict -}}
@@ -34,7 +35,7 @@ Params:
 {{- fail "liveStore.zoneAwareReplication.zones must have unique names." -}}
 {{- end -}}
 {{- range $zone := $zones -}}
-{{- $antiAffinity := include "live-store.zoneAntiAffinity" (dict "rolloutZoneName" $zone.name "topologyKey" $zoneAware.topologyKey) | fromYaml -}}
+{{- $antiAffinity := include "live-store.zoneAntiAffinity" (dict "ctx" $ctx "rolloutZoneName" $zone.name "topologyKey" $zoneAware.topologyKey) | fromYaml -}}
 {{- $affinity := mergeOverwrite (deepCopy ($zone.extraAffinity | default dict)) $antiAffinity -}}
 {{- $_ := set $zonesMap $zone.name (dict
       "affinity" $affinity
@@ -52,10 +53,12 @@ Params:
 
 {{/*
 Anti-affinity that keeps the live-stores of one zone away from the nodes, racks
-or availability zones that already run another zone. Renders an empty dict when
-no topologyKey is set.
+or availability zones that already run another zone. The selector is scoped to
+this release, so two tempo releases in one namespace do not push each other
+apart. Renders an empty dict when no topologyKey is set.
 
 Params:
+  ctx             = root context ($)
   rolloutZoneName = name of the rollout zone
   topologyKey     = topology key of the failure domain
 */}}
@@ -65,6 +68,14 @@ podAntiAffinity:
   requiredDuringSchedulingIgnoredDuringExecution:
     - labelSelector:
         matchExpressions:
+          - key: app.kubernetes.io/name
+            operator: In
+            values:
+              - {{ include "tempo.name" .ctx }}
+          - key: app.kubernetes.io/instance
+            operator: In
+            values:
+              - {{ .ctx.Release.Name }}
           - key: rollout-group
             operator: In
             values:

--- a/charts/tempo-distributed/templates/live-store/_helpers-live-store.tpl
+++ b/charts/tempo-distributed/templates/live-store/_helpers-live-store.tpl
@@ -1,0 +1,80 @@
+{{/*
+Rollout zones for the live-store.
+
+Returns a map keyed by zone name. The key "" is used when zone-aware replication
+is disabled and renders the single flat StatefulSet.
+
+Each zone runs a full set of live-stores. A live-store derives its Kafka
+partition from the numeric suffix of its pod name and its consumer group from
+the StatefulSet name, so every zone consumes all partitions independently and
+each partition ends up with one owner per zone. Therefore the replica count of a
+zone is liveStore.replicas, not a share of it.
+
+Params:
+  ctx = root context ($)
+*/}}
+{{- define "live-store.zoneAwareReplicationMap" -}}
+{{- $zonesMap := dict -}}
+{{- $liveStore := .ctx.Values.liveStore -}}
+{{- $zoneAware := $liveStore.zoneAwareReplication | default dict -}}
+{{- $replicas := $liveStore.replicas | int -}}
+{{- if $zoneAware.enabled -}}
+{{- $zones := $zoneAware.zones | default list -}}
+{{- if lt (len $zones) 2 -}}
+{{- fail "liveStore.zoneAwareReplication.zones must define at least 2 zones. A partition needs an owner in more than one zone before the read path can survive the loss of a zone." -}}
+{{- end -}}
+{{- $zoneNames := list -}}
+{{- range $zones -}}
+{{- if not .name -}}
+{{- fail "every entry of liveStore.zoneAwareReplication.zones must set a name." -}}
+{{- end -}}
+{{- $zoneNames = append $zoneNames .name -}}
+{{- end -}}
+{{- if ne (len ($zoneNames | uniq)) (len $zoneNames) -}}
+{{- fail "liveStore.zoneAwareReplication.zones must have unique names." -}}
+{{- end -}}
+{{- range $zone := $zones -}}
+{{- $antiAffinity := include "live-store.zoneAntiAffinity" (dict "rolloutZoneName" $zone.name "topologyKey" $zoneAware.topologyKey) | fromYaml -}}
+{{- $affinity := mergeOverwrite (deepCopy ($zone.extraAffinity | default dict)) $antiAffinity -}}
+{{- $_ := set $zonesMap $zone.name (dict
+      "affinity" $affinity
+      "nodeSelector" ($zone.nodeSelector | default dict)
+      "annotations" ($zone.annotations | default dict)
+      "podAnnotations" ($zone.podAnnotations | default dict)
+      "replicas" $replicas
+    ) -}}
+{{- end -}}
+{{- else -}}
+{{- $_ := set $zonesMap "" (dict "replicas" $replicas) -}}
+{{- end -}}
+{{- $zonesMap | toYaml -}}
+{{- end -}}
+
+{{/*
+Anti-affinity that keeps the live-stores of one zone away from the nodes, racks
+or availability zones that already run another zone. Renders an empty dict when
+no topologyKey is set.
+
+Params:
+  rolloutZoneName = name of the rollout zone
+  topologyKey     = topology key of the failure domain
+*/}}
+{{- define "live-store.zoneAntiAffinity" -}}
+{{- if .topologyKey -}}
+podAntiAffinity:
+  requiredDuringSchedulingIgnoredDuringExecution:
+    - labelSelector:
+        matchExpressions:
+          - key: rollout-group
+            operator: In
+            values:
+              - live-store
+          - key: zone
+            operator: NotIn
+            values:
+              - {{ .rolloutZoneName }}
+      topologyKey: {{ .topologyKey | quote }}
+{{- else -}}
+{}
+{{- end -}}
+{{- end -}}

--- a/charts/tempo-distributed/templates/live-store/poddisruptionbudget-live-store.yaml
+++ b/charts/tempo-distributed/templates/live-store/poddisruptionbudget-live-store.yaml
@@ -1,6 +1,9 @@
 {{- if .Values.liveStore.enabled }}
 {{- if and (gt (int .Values.liveStore.replicas) 1) .Values.liveStore.podDisruptionBudget.enabled }}
-{{ $dict := dict "ctx" . "component" "live-store" "memberlist" true }}
+{{- $zonesMap := include "live-store.zoneAwareReplicationMap" (dict "ctx" $) | fromYaml -}}
+{{- range $zoneName, $rolloutZone := $zonesMap -}}
+{{- with $ -}}
+{{ $dict := dict "ctx" . "component" "live-store" "memberlist" true "rolloutZoneName" $zoneName }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -16,5 +19,8 @@ spec:
   {{- with .Values.liveStore.podDisruptionBudget.unhealthyPodEvictionPolicy }}
   unhealthyPodEvictionPolicy: {{ . }}
   {{- end }}
+---
+{{ end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/live-store/poddisruptionbudget-live-store.yaml
+++ b/charts/tempo-distributed/templates/live-store/poddisruptionbudget-live-store.yaml
@@ -1,10 +1,8 @@
 {{- if .Values.liveStore.enabled }}
-{{- if and (gt (int .Values.liveStore.replicas) 1) .Values.liveStore.podDisruptionBudget.enabled }}
 {{- $zonesMap := include "live-store.zoneAwareReplicationMap" (dict "ctx" $) | fromYaml -}}
-{{- range $zoneName, $rolloutZone := $zonesMap -}}
-{{- with $ -}}
-{{- $dict := dict "ctx" . "component" "live-store" "memberlist" true "rolloutZoneName" $zoneName }}
----
+{{- $totalReplicas := mul (int .Values.liveStore.replicas) (len $zonesMap) -}}
+{{- if and (gt $totalReplicas 1) .Values.liveStore.podDisruptionBudget.enabled }}
+{{- $dict := dict "ctx" . "component" "live-store" "memberlist" true }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -20,7 +18,5 @@ spec:
   {{- with .Values.liveStore.podDisruptionBudget.unhealthyPodEvictionPolicy }}
   unhealthyPodEvictionPolicy: {{ . }}
   {{- end }}
-{{ end }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/live-store/poddisruptionbudget-live-store.yaml
+++ b/charts/tempo-distributed/templates/live-store/poddisruptionbudget-live-store.yaml
@@ -1,7 +1,9 @@
 {{- if .Values.liveStore.enabled }}
 {{- $zonesMap := include "live-store.zoneAwareReplicationMap" (dict "ctx" $) | fromYaml -}}
 {{- $totalReplicas := mul (int .Values.liveStore.replicas) (len $zonesMap) -}}
-{{- if and (gt $totalReplicas 1) .Values.liveStore.podDisruptionBudget.enabled }}
+{{- $zoneAware := .Values.liveStore.zoneAwareReplication -}}
+{{- $zpdbTakesOver := and $zoneAware.enabled (($zoneAware.podDisruptionBudget | default dict).enabled) -}}
+{{- if and (gt $totalReplicas 1) .Values.liveStore.podDisruptionBudget.enabled (not $zpdbTakesOver) }}
 {{- $dict := dict "ctx" . "component" "live-store" "memberlist" true }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget

--- a/charts/tempo-distributed/templates/live-store/poddisruptionbudget-live-store.yaml
+++ b/charts/tempo-distributed/templates/live-store/poddisruptionbudget-live-store.yaml
@@ -3,7 +3,8 @@
 {{- $zonesMap := include "live-store.zoneAwareReplicationMap" (dict "ctx" $) | fromYaml -}}
 {{- range $zoneName, $rolloutZone := $zonesMap -}}
 {{- with $ -}}
-{{ $dict := dict "ctx" . "component" "live-store" "memberlist" true "rolloutZoneName" $zoneName }}
+{{- $dict := dict "ctx" . "component" "live-store" "memberlist" true "rolloutZoneName" $zoneName }}
+---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -19,7 +20,6 @@ spec:
   {{- with .Values.liveStore.podDisruptionBudget.unhealthyPodEvictionPolicy }}
   unhealthyPodEvictionPolicy: {{ . }}
   {{- end }}
----
 {{ end }}
 {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/live-store/statefulset-live-store.yaml
+++ b/charts/tempo-distributed/templates/live-store/statefulset-live-store.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.liveStore.enabled }}
-{{- $dict := dict "ctx" . "component" "live-store" "memberlist" true -}}
+{{- $zonesMap := include "live-store.zoneAwareReplicationMap" (dict "ctx" $) | fromYaml -}}
+{{- $zoneAware := .Values.liveStore.zoneAwareReplication -}}
+{{- range $zoneName, $rolloutZone := $zonesMap -}}
+{{- with $ -}}
+{{- $dict := dict "ctx" . "component" "live-store" "memberlist" true "rolloutZoneName" $zoneName -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -10,12 +14,18 @@ metadata:
     {{- with .Values.liveStore.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.liveStore.annotations }}
+  {{- $annotations := mergeOverwrite (deepCopy (.Values.liveStore.annotations | default dict)) ($rolloutZone.annotations | default dict) }}
+  {{- if $zoneName }}
+  {{- with $zoneAware.maxUnavailable }}
+  {{- $_ := set $annotations "rollout-max-unavailable" (. | toString) }}
+  {{- end }}
+  {{- end }}
+  {{- with $annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  replicas: {{ .Values.liveStore.replicas }}
+  replicas: {{ $rolloutZone.replicas }}
   revisionHistoryLimit: {{ .Values.tempo.revisionHistoryLimit }}
   selector:
     matchLabels:
@@ -23,7 +33,18 @@ spec:
   serviceName: live-store
   podManagementPolicy: Parallel
   updateStrategy:
+    {{- if $zoneName }}
+    type: OnDelete
+    {{- else }}
     {{- toYaml .Values.liveStore.statefulStrategy | nindent 4 }}
+    {{- end }}
   template:
-    {{- include "tempo.podTemplate" (dict "ctx" $ "component" .Values.liveStore "target" "live-store") | nindent 4 }}
+    {{- $podArgs := list }}
+    {{- if $zoneName }}
+    {{- $podArgs = list (printf "-live-store.instance-availability-zone=%s" $zoneName) }}
+    {{- end }}
+    {{- include "tempo.podTemplate" (dict "ctx" $ "component" .Values.liveStore "target" "live-store" "rolloutZoneName" $zoneName "rolloutZone" $rolloutZone "args" $podArgs) | nindent 4 }}
+---
+{{ end }}
+{{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/live-store/statefulset-live-store.yaml
+++ b/charts/tempo-distributed/templates/live-store/statefulset-live-store.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.liveStore.enabled }}
 {{- $zonesMap := include "live-store.zoneAwareReplicationMap" (dict "ctx" $) | fromYaml -}}
 {{- $zoneAware := .Values.liveStore.zoneAwareReplication -}}
+{{- $prepareDownscale := $zoneAware.prepareDownscale | default dict -}}
 {{- range $zoneName, $rolloutZone := $zonesMap -}}
 {{- with $ -}}
 {{- $dict := dict "ctx" . "component" "live-store" "memberlist" true "rolloutZoneName" $zoneName -}}
@@ -14,10 +15,24 @@ metadata:
     {{- with .Values.liveStore.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+    {{- if $zoneName }}
+    {{- if $zoneAware.noDownscale }}
+    grafana.com/no-downscale: "true"
+    {{- else if $prepareDownscale.enabled }}
+    grafana.com/prepare-downscale: "true"
+    {{- with $prepareDownscale.minTimeBetweenZonesDownscale }}
+    grafana.com/min-time-between-zones-downscale: {{ . | quote }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
   {{- $annotations := mergeOverwrite (deepCopy (.Values.liveStore.annotations | default dict)) ($rolloutZone.annotations | default dict) }}
   {{- if $zoneName }}
   {{- with $zoneAware.maxUnavailable }}
   {{- $_ := set $annotations "rollout-max-unavailable" (. | toString) }}
+  {{- end }}
+  {{- if and $prepareDownscale.enabled (not $zoneAware.noDownscale) }}
+  {{- $_ := set $annotations "grafana.com/prepare-downscale-http-path" $prepareDownscale.httpPath }}
+  {{- $_ := set $annotations "grafana.com/prepare-downscale-http-port" "3200" }}
   {{- end }}
   {{- end }}
   {{- with $annotations }}
@@ -30,7 +45,11 @@ spec:
   selector:
     matchLabels:
       {{- include "tempo.selectorLabels" $dict | nindent 6 }}
+  {{- if $zoneName }}
+  serviceName: {{ include "tempo.resourceName" (dict "ctx" . "component" "live-store") }}
+  {{- else }}
   serviceName: live-store
+  {{- end }}
   podManagementPolicy: Parallel
   updateStrategy:
     {{- if $zoneName }}

--- a/charts/tempo-distributed/templates/live-store/statefulset-live-store.yaml
+++ b/charts/tempo-distributed/templates/live-store/statefulset-live-store.yaml
@@ -25,8 +25,8 @@ metadata:
     {{- end }}
   {{- $annotations := mergeOverwrite (deepCopy (.Values.liveStore.annotations | default dict)) ($rolloutZone.annotations | default dict) }}
   {{- if $zoneName }}
-  {{- with $zoneAware.maxUnavailable }}
-  {{- $_ := set $annotations "rollout-max-unavailable" (. | toString) }}
+  {{- if not (kindIs "invalid" $zoneAware.maxUnavailable) }}
+  {{- $_ := set $annotations "rollout-max-unavailable" ($zoneAware.maxUnavailable | toString) }}
   {{- end }}
   {{- if and $prepareDownscale.enabled (not $zoneAware.noDownscale) }}
   {{- $_ := set $annotations "grafana.com/prepare-downscale-http-path" $prepareDownscale.httpPath }}

--- a/charts/tempo-distributed/templates/live-store/statefulset-live-store.yaml
+++ b/charts/tempo-distributed/templates/live-store/statefulset-live-store.yaml
@@ -5,6 +5,7 @@
 {{- range $zoneName, $rolloutZone := $zonesMap -}}
 {{- with $ -}}
 {{- $dict := dict "ctx" . "component" "live-store" "memberlist" true "rolloutZoneName" $zoneName -}}
+---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -20,9 +21,6 @@ metadata:
     grafana.com/no-downscale: "true"
     {{- else if $prepareDownscale.enabled }}
     grafana.com/prepare-downscale: "true"
-    {{- with $prepareDownscale.minTimeBetweenZonesDownscale }}
-    grafana.com/min-time-between-zones-downscale: {{ . | quote }}
-    {{- end }}
     {{- end }}
     {{- end }}
   {{- $annotations := mergeOverwrite (deepCopy (.Values.liveStore.annotations | default dict)) ($rolloutZone.annotations | default dict) }}
@@ -32,7 +30,10 @@ metadata:
   {{- end }}
   {{- if and $prepareDownscale.enabled (not $zoneAware.noDownscale) }}
   {{- $_ := set $annotations "grafana.com/prepare-downscale-http-path" $prepareDownscale.httpPath }}
-  {{- $_ := set $annotations "grafana.com/prepare-downscale-http-port" "3200" }}
+  {{- $_ := set $annotations "grafana.com/prepare-downscale-http-port" (.Values.server.httpListenPort | toString) }}
+  {{- with $prepareDownscale.minTimeBetweenZonesDownscale }}
+  {{- $_ := set $annotations "grafana.com/min-time-between-zones-downscale" (. | toString) }}
+  {{- end }}
   {{- end }}
   {{- end }}
   {{- with $annotations }}
@@ -63,7 +64,6 @@ spec:
     {{- $podArgs = list (printf "-live-store.instance-availability-zone=%s" $zoneName) }}
     {{- end }}
     {{- include "tempo.podTemplate" (dict "ctx" $ "component" .Values.liveStore "target" "live-store" "rolloutZoneName" $zoneName "rolloutZone" $rolloutZone "args" $podArgs) | nindent 4 }}
----
 {{ end }}
 {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/templates/live-store/zonepoddisruptionbudget-live-store.yaml
+++ b/charts/tempo-distributed/templates/live-store/zonepoddisruptionbudget-live-store.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.liveStore.enabled }}
+{{- $zoneAware := .Values.liveStore.zoneAwareReplication }}
+{{- $zpdb := $zoneAware.podDisruptionBudget | default dict }}
+{{- if and $zoneAware.enabled $zpdb.enabled .Values.liveStore.podDisruptionBudget.enabled }}
+{{- $dict := dict "ctx" . "component" "live-store" "memberlist" true }}
+apiVersion: rollout-operator.grafana.com/v1
+kind: ZoneAwarePodDisruptionBudget
+metadata:
+  name: {{ include "tempo.resourceName" $dict }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tempo.labels" $dict | nindent 4 }}
+spec:
+  maxUnavailable: {{ $zpdb.maxUnavailable | int }}
+  selector:
+    matchLabels:
+      {{- include "tempo.selectorLabels" $dict | nindent 6 }}
+  {{- with $zpdb.podNamePartitionRegex }}
+  podNamePartitionRegex: {{ . | quote }}
+  {{- end }}
+  {{- with $zpdb.podNameRegexGroup }}
+  podNameRegexGroup: {{ . | int }}
+  {{- end }}
+  {{- with $zpdb.crossZoneEvictionDelay }}
+  crossZoneEvictionDelay: {{ . | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/tempo-distributed/templates/live-store/zonepoddisruptionbudget-live-store.yaml
+++ b/charts/tempo-distributed/templates/live-store/zonepoddisruptionbudget-live-store.yaml
@@ -18,8 +18,8 @@ spec:
   {{- with $zpdb.podNamePartitionRegex }}
   podNamePartitionRegex: {{ . | quote }}
   {{- end }}
-  {{- with $zpdb.podNameRegexGroup }}
-  podNameRegexGroup: {{ . | int }}
+  {{- if not (kindIs "invalid" $zpdb.podNameRegexGroup) }}
+  podNameRegexGroup: {{ $zpdb.podNameRegexGroup | int }}
   {{- end }}
   {{- with $zpdb.crossZoneEvictionDelay }}
   crossZoneEvictionDelay: {{ . | quote }}

--- a/charts/tempo-distributed/templates/validate.yaml
+++ b/charts/tempo-distributed/templates/validate.yaml
@@ -21,6 +21,20 @@
 {{- fail "liveStore.zoneAwareReplication.noDownscale and liveStore.zoneAwareReplication.prepareDownscale.enabled are enforced by the rollout-operator admission webhooks, which rollout_operator.webhooks.enabled turns off. Turn the webhooks back on, or drop these settings." }}
 {{- end }}
 {{- end }}
+{{- $zpdb := $zoneAware.podDisruptionBudget | default dict }}
+{{- if and $zoneAware.enabled $zpdb.enabled .Values.liveStore.podDisruptionBudget.enabled }}
+{{- if .Values.rollout_operator.enabled }}
+{{- if not .Values.rollout_operator.webhooks.enabled }}
+{{- fail "liveStore.zoneAwareReplication.podDisruptionBudget.enabled is enforced by the rollout-operator pod eviction webhook, which rollout_operator.webhooks.enabled turns off. Turn the webhooks back on, or set liveStore.zoneAwareReplication.podDisruptionBudget.enabled to false to keep a native PodDisruptionBudget over all zones." }}
+{{- end }}
+{{- if not .Values.rollout_operator.crds.enabled }}
+{{- fail "liveStore.zoneAwareReplication.podDisruptionBudget.enabled needs the ZoneAwarePodDisruptionBudget CRD, which rollout_operator.crds.enabled turns off. Install the CRD out of band, or set liveStore.zoneAwareReplication.podDisruptionBudget.enabled to false to keep a native PodDisruptionBudget over all zones." }}
+{{- end }}
+{{- end }}
+{{- if and $zpdb.crossZoneEvictionDelay (not $zpdb.podNamePartitionRegex) }}
+{{- fail "liveStore.zoneAwareReplication.podDisruptionBudget.crossZoneEvictionDelay needs podNamePartitionRegex. The delay applies between the owners of one partition, so without the regex the rollout-operator has no partition to compare and rejects the object." }}
+{{- end }}
+{{- end }}
 {{- if and $zoneAware.enabled $prepareDownscale.enabled (ne .Values.global.clusterDomain "cluster.local") (not $zoneAware.rolloutOperatorManagedExternally) }}
 {{- $clusterDomainArg := printf "-cluster-domain=%s" .Values.global.clusterDomain }}
 {{- $extraArgs := join " " (.Values.rollout_operator.extraArgs | default list) }}

--- a/charts/tempo-distributed/templates/validate.yaml
+++ b/charts/tempo-distributed/templates/validate.yaml
@@ -4,3 +4,6 @@
 {{- if and (or .Values.blockBuilder.enabled .Values.liveStore.enabled) (not .Values.ingest.kafka.address) }}
 {{- fail "ingest.kafka.address is required when blockBuilder or liveStore is enabled. Tempo 3.0 uses a Kafka-backed write path: block-builder and live-store consume spans from Kafka and will not start without a broker. Set ingest.kafka.address to your Kafka broker (e.g. \"kafka.kafka-namespace.svc.cluster.local:9092\"), or disable blockBuilder and liveStore. See UPGRADE.md for details." }}
 {{- end }}
+{{- if and .Values.liveStore.enabled .Values.liveStore.zoneAwareReplication.enabled (not .Values.rollout_operator.enabled) (not .Values.liveStore.zoneAwareReplication.rolloutOperatorManagedExternally) }}
+{{- fail "liveStore.zoneAwareReplication.enabled needs a rollout-operator in this namespace. Zone-aware live-stores use the OnDelete update strategy, so without one no live-store pod is ever restarted on an upgrade. Set rollout_operator.enabled to true, or install a rollout-operator into this namespace yourself and set liveStore.zoneAwareReplication.rolloutOperatorManagedExternally to true." }}
+{{- end }}

--- a/charts/tempo-distributed/templates/validate.yaml
+++ b/charts/tempo-distributed/templates/validate.yaml
@@ -7,3 +7,24 @@
 {{- if and .Values.liveStore.enabled .Values.liveStore.zoneAwareReplication.enabled (not .Values.rollout_operator.enabled) (not .Values.liveStore.zoneAwareReplication.rolloutOperatorManagedExternally) }}
 {{- fail "liveStore.zoneAwareReplication.enabled needs a rollout-operator in this namespace. Zone-aware live-stores use the OnDelete update strategy, so without one no live-store pod is ever restarted on an upgrade. Set rollout_operator.enabled to true, or install a rollout-operator into this namespace yourself and set liveStore.zoneAwareReplication.rolloutOperatorManagedExternally to true." }}
 {{- end }}
+{{- if .Values.liveStore.enabled }}
+{{- $zoneAware := .Values.liveStore.zoneAwareReplication }}
+{{- $prepareDownscale := $zoneAware.prepareDownscale | default dict }}
+{{- if and $zoneAware.noDownscale $prepareDownscale.enabled }}
+{{- fail "liveStore.zoneAwareReplication.noDownscale and liveStore.zoneAwareReplication.prepareDownscale.enabled are mutually exclusive. noDownscale rejects every scale-down, so a coordinated scale-down can never run. Keep one of the two." }}
+{{- end }}
+{{- if and (not $zoneAware.enabled) (or $zoneAware.noDownscale $prepareDownscale.enabled) }}
+{{- fail "liveStore.zoneAwareReplication.noDownscale and liveStore.zoneAwareReplication.prepareDownscale.enabled only apply to zone-aware live-stores. Set liveStore.zoneAwareReplication.enabled to true, or remove these settings." }}
+{{- end }}
+{{- if and $zoneAware.enabled (or $zoneAware.noDownscale $prepareDownscale.enabled) }}
+{{- if and .Values.rollout_operator.enabled (not .Values.rollout_operator.webhooks.enabled) }}
+{{- fail "liveStore.zoneAwareReplication.noDownscale and liveStore.zoneAwareReplication.prepareDownscale.enabled are enforced by the rollout-operator admission webhooks, which rollout_operator.webhooks.enabled turns off. Turn the webhooks back on, or drop these settings." }}
+{{- end }}
+{{- end }}
+{{- if and $zoneAware.enabled $prepareDownscale.enabled (ne .Values.global.clusterDomain "cluster.local") }}
+{{- $clusterDomainArg := printf "-cluster-domain=%s" .Values.global.clusterDomain }}
+{{- if not (has $clusterDomainArg (.Values.rollout_operator.extraArgs | default list)) }}
+{{- fail (printf "liveStore.zoneAwareReplication.prepareDownscale.enabled builds live-store pod addresses from the cluster domain of the rollout-operator, which defaults to cluster.local and does not follow global.clusterDomain. Add \"%s\" to rollout_operator.extraArgs, or the webhook rejects every scale-down." $clusterDomainArg) }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/tempo-distributed/templates/validate.yaml
+++ b/charts/tempo-distributed/templates/validate.yaml
@@ -21,9 +21,10 @@
 {{- fail "liveStore.zoneAwareReplication.noDownscale and liveStore.zoneAwareReplication.prepareDownscale.enabled are enforced by the rollout-operator admission webhooks, which rollout_operator.webhooks.enabled turns off. Turn the webhooks back on, or drop these settings." }}
 {{- end }}
 {{- end }}
-{{- if and $zoneAware.enabled $prepareDownscale.enabled (ne .Values.global.clusterDomain "cluster.local") }}
+{{- if and $zoneAware.enabled $prepareDownscale.enabled (ne .Values.global.clusterDomain "cluster.local") (not $zoneAware.rolloutOperatorManagedExternally) }}
 {{- $clusterDomainArg := printf "-cluster-domain=%s" .Values.global.clusterDomain }}
-{{- if not (has $clusterDomainArg (.Values.rollout_operator.extraArgs | default list)) }}
+{{- $extraArgs := join " " (.Values.rollout_operator.extraArgs | default list) }}
+{{- if not (or (contains $clusterDomainArg $extraArgs) (contains (printf "-cluster-domain %s" .Values.global.clusterDomain) $extraArgs)) }}
 {{- fail (printf "liveStore.zoneAwareReplication.prepareDownscale.enabled builds live-store pod addresses from the cluster domain of the rollout-operator, which defaults to cluster.local and does not follow global.clusterDomain. Add \"%s\" to rollout_operator.extraArgs, or the webhook rejects every scale-down." $clusterDomainArg) }}
 {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/tests/live-store/zone_aware_test.yaml
+++ b/charts/tempo-distributed/tests/live-store/zone_aware_test.yaml
@@ -267,8 +267,10 @@ tests:
           path: metadata.labels["grafana.com/prepare-downscale"]
           value: "true"
       - equal:
-          path: metadata.labels["grafana.com/min-time-between-zones-downscale"]
+          path: metadata.annotations["grafana.com/min-time-between-zones-downscale"]
           value: 12h
+      - notExists:
+          path: metadata.labels["grafana.com/min-time-between-zones-downscale"]
       - equal:
           path: metadata.annotations["grafana.com/prepare-downscale-http-path"]
           value: live-store/prepare-partition-downscale
@@ -290,7 +292,7 @@ tests:
           path: metadata.annotations["grafana.com/prepare-downscale-http-path"]
           value: live-store/prepare-downscale
       - equal:
-          path: metadata.labels["grafana.com/min-time-between-zones-downscale"]
+          path: metadata.annotations["grafana.com/min-time-between-zones-downscale"]
           value: 30m
 
   - it: rejects every scale-down when noDownscale is set
@@ -306,3 +308,54 @@ tests:
           value: "true"
       - notExists:
           path: metadata.labels["grafana.com/prepare-downscale"]
+
+  - it: scopes the zone anti-affinity to this release
+    template: live-store/statefulset-live-store.yaml
+    set:
+      rollout_operator.enabled: true
+      liveStore.zoneAwareReplication.enabled: true
+      liveStore.zoneAwareReplication.topologyKey: kubernetes.io/hostname
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions
+          content:
+            key: app.kubernetes.io/instance
+            operator: In
+            values:
+              - RELEASE-NAME
+      - contains:
+          path: spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions
+          content:
+            key: app.kubernetes.io/name
+            operator: In
+            values:
+              - tempo
+
+  - it: takes the downscale port from the configured HTTP listen port
+    template: live-store/statefulset-live-store.yaml
+    set:
+      rollout_operator.enabled: true
+      liveStore.zoneAwareReplication.enabled: true
+      liveStore.zoneAwareReplication.prepareDownscale.enabled: true
+      server.httpListenPort: 3100
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: metadata.annotations["grafana.com/prepare-downscale-http-port"]
+          value: "3100"
+
+  - it: emits one name label per pod with the legacy enterprise labels
+    template: live-store/statefulset-live-store.yaml
+    set:
+      rollout_operator.enabled: true
+      liveStore.zoneAwareReplication.enabled: true
+      enterprise.legacyLabels: true
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.name
+          value: live-store-zone-a
+      - equal:
+          path: spec.template.metadata.labels.target
+          value: live-store

--- a/charts/tempo-distributed/tests/live-store/zone_aware_test.yaml
+++ b/charts/tempo-distributed/tests/live-store/zone_aware_test.yaml
@@ -131,7 +131,7 @@ tests:
       - notExists:
           path: spec.template.spec.topologySpreadConstraints
 
-  - it: sets no affinity when no topology key is given
+  - it: adds no cross-zone rule when no topology key is given, and keeps the component affinity
     template: live-store/statefulset-live-store.yaml
     set:
       rollout_operator.enabled: true
@@ -139,7 +139,56 @@ tests:
     documentIndex: 0
     asserts:
       - notExists:
-          path: spec.template.spec.affinity
+          path: spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchLabels["app.kubernetes.io/component"]
+          value: live-store
+
+  - it: keeps the node selector of the component and lets a zone add to it
+    template: live-store/statefulset-live-store.yaml
+    set:
+      rollout_operator.enabled: true
+      liveStore.zoneAwareReplication.enabled: true
+      defaults.nodeSelector:
+        pool: tempo
+      liveStore.zoneAwareReplication.zones:
+        - name: zone-a
+          nodeSelector:
+            topology.kubernetes.io/zone: eu-west-1a
+        - name: zone-b
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector.pool
+          value: tempo
+      - equal:
+          path: spec.template.spec.nodeSelector["topology.kubernetes.io/zone"]
+          value: eu-west-1a
+
+  - it: gives the zones of one release their own anti-affinity scope only
+    template: live-store/statefulset-live-store.yaml
+    set:
+      rollout_operator.enabled: true
+      liveStore.zoneAwareReplication.enabled: true
+      liveStore.zoneAwareReplication.topologyKey: kubernetes.io/hostname
+    documentIndex: 0
+    asserts:
+      - exists:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution
+      - exists:
+          path: spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution
+
+  - it: fails on a zone name that is not a DNS label
+    template: live-store/statefulset-live-store.yaml
+    set:
+      rollout_operator.enabled: true
+      liveStore.zoneAwareReplication.enabled: true
+      liveStore.zoneAwareReplication.zones:
+        - name: zone-a
+        - name: Zone_B
+    asserts:
+      - failedTemplate:
+          errorPattern: is not a DNS label
 
   - it: merges extraAffinity and nodeSelector of a zone
     template: live-store/statefulset-live-store.yaml

--- a/charts/tempo-distributed/tests/live-store/zone_aware_test.yaml
+++ b/charts/tempo-distributed/tests/live-store/zone_aware_test.yaml
@@ -1,0 +1,231 @@
+# $schema: https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json
+suite: live-store zone-aware replication
+templates:
+  - live-store/statefulset-live-store.yaml
+  - live-store/poddisruptionbudget-live-store.yaml
+  - configmap-tempo.yaml
+
+tests:
+  - it: renders a single flat StatefulSet when zone-awareness is off
+    template: live-store/statefulset-live-store.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-tempo-live-store
+      - notExists:
+          path: metadata.labels["rollout-group"]
+      - notExists:
+          path: metadata.annotations["rollout-max-unavailable"]
+      - exists:
+          path: spec.template.spec.topologySpreadConstraints
+
+  - it: renders one StatefulSet per zone
+    template: live-store/statefulset-live-store.yaml
+    set:
+      rollout_operator.enabled: true
+      liveStore.zoneAwareReplication.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-tempo-live-store-zone-a
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-tempo-live-store-zone-b
+        documentIndex: 1
+
+  - it: gives every zone the full replica set so each partition has one owner per zone
+    template: live-store/statefulset-live-store.yaml
+    set:
+      rollout_operator.enabled: true
+      liveStore.replicas: 6
+      liveStore.zoneAwareReplication.enabled: true
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 6
+        documentIndex: 0
+      - equal:
+          path: spec.replicas
+          value: 6
+        documentIndex: 1
+
+  - it: passes the availability zone to the live-store
+    template: live-store/statefulset-live-store.yaml
+    set:
+      rollout_operator.enabled: true
+      liveStore.zoneAwareReplication.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: -live-store.instance-availability-zone=zone-a
+        documentIndex: 0
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: -live-store.instance-availability-zone=zone-b
+        documentIndex: 1
+
+  - it: hands the rollout over to the rollout-operator
+    template: live-store/statefulset-live-store.yaml
+    set:
+      rollout_operator.enabled: true
+      liveStore.zoneAwareReplication.enabled: true
+      liveStore.zoneAwareReplication.maxUnavailable: 4
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.updateStrategy.type
+          value: OnDelete
+      - equal:
+          path: metadata.labels["rollout-group"]
+          value: live-store
+      - equal:
+          path: metadata.labels.zone
+          value: zone-a
+      - equal:
+          path: metadata.annotations["rollout-max-unavailable"]
+          value: "4"
+      - equal:
+          path: spec.template.metadata.labels.name
+          value: live-store-zone-a
+
+  - it: scopes the selector of a zone to that zone
+    template: live-store/statefulset-live-store.yaml
+    set:
+      rollout_operator.enabled: true
+      liveStore.zoneAwareReplication.enabled: true
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["rollout-group"]
+          value: live-store
+      - equal:
+          path: spec.selector.matchLabels.zone
+          value: zone-b
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: live-store
+
+  - it: keeps the zones apart when a topology key is set
+    template: live-store/statefulset-live-store.yaml
+    set:
+      rollout_operator.enabled: true
+      liveStore.zoneAwareReplication.enabled: true
+      liveStore.zoneAwareReplication.topologyKey: topology.kubernetes.io/zone
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].topologyKey
+          value: topology.kubernetes.io/zone
+      - contains:
+          path: spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions
+          content:
+            key: zone
+            operator: NotIn
+            values:
+              - zone-a
+      - notExists:
+          path: spec.template.spec.topologySpreadConstraints
+
+  - it: sets no affinity when no topology key is given
+    template: live-store/statefulset-live-store.yaml
+    set:
+      rollout_operator.enabled: true
+      liveStore.zoneAwareReplication.enabled: true
+    documentIndex: 0
+    asserts:
+      - notExists:
+          path: spec.template.spec.affinity
+
+  - it: merges extraAffinity and nodeSelector of a zone
+    template: live-store/statefulset-live-store.yaml
+    set:
+      rollout_operator.enabled: true
+      liveStore.zoneAwareReplication.enabled: true
+      liveStore.zoneAwareReplication.zones:
+        - name: zone-a
+          nodeSelector:
+            topology.kubernetes.io/zone: eu-west-1a
+          extraAffinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: dedicated
+                        operator: In
+                        values:
+                          - tempo
+        - name: zone-b
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector["topology.kubernetes.io/zone"]
+          value: eu-west-1a
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
+          value: dedicated
+
+  - it: renders one PodDisruptionBudget per zone
+    template: live-store/poddisruptionbudget-live-store.yaml
+    set:
+      rollout_operator.enabled: true
+      liveStore.zoneAwareReplication.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-tempo-live-store-zone-a
+        documentIndex: 0
+      - equal:
+          path: spec.selector.matchLabels.zone
+          value: zone-b
+        documentIndex: 1
+
+  - it: fails when fewer than two zones are defined
+    template: live-store/statefulset-live-store.yaml
+    set:
+      rollout_operator.enabled: true
+      liveStore.zoneAwareReplication.enabled: true
+      liveStore.zoneAwareReplication.zones:
+        - name: zone-a
+    asserts:
+      - failedTemplate:
+          errorPattern: must define at least 2 zones
+
+  - it: fails on duplicate zone names
+    template: live-store/statefulset-live-store.yaml
+    set:
+      rollout_operator.enabled: true
+      liveStore.zoneAwareReplication.enabled: true
+      liveStore.zoneAwareReplication.zones:
+        - name: zone-a
+        - name: zone-a
+    asserts:
+      - failedTemplate:
+          errorPattern: must have unique names
+
+  - it: fails on a zone without a name
+    template: live-store/statefulset-live-store.yaml
+    set:
+      rollout_operator.enabled: true
+      liveStore.zoneAwareReplication.enabled: true
+      liveStore.zoneAwareReplication.zones:
+        - name: zone-a
+        - nodeSelector: {}
+    asserts:
+      - failedTemplate:
+          errorPattern: must set a name
+
+  - it: accepts a rollout-operator that the chart does not install
+    template: live-store/statefulset-live-store.yaml
+    set:
+      liveStore.zoneAwareReplication.enabled: true
+      liveStore.zoneAwareReplication.rolloutOperatorManagedExternally: true
+    asserts:
+      - hasDocuments:
+          count: 2

--- a/charts/tempo-distributed/tests/live-store/zone_aware_test.yaml
+++ b/charts/tempo-distributed/tests/live-store/zone_aware_test.yaml
@@ -229,3 +229,80 @@ tests:
     asserts:
       - hasDocuments:
           count: 2
+
+  - it: points the zone StatefulSets at the live-store headless service
+    template: live-store/statefulset-live-store.yaml
+    set:
+      rollout_operator.enabled: true
+      liveStore.zoneAwareReplication.enabled: true
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.serviceName
+          value: RELEASE-NAME-tempo-live-store
+
+  - it: adds no downscale markers by default
+    template: live-store/statefulset-live-store.yaml
+    set:
+      rollout_operator.enabled: true
+      liveStore.zoneAwareReplication.enabled: true
+    documentIndex: 0
+    asserts:
+      - notExists:
+          path: metadata.labels["grafana.com/prepare-downscale"]
+      - notExists:
+          path: metadata.labels["grafana.com/no-downscale"]
+      - notExists:
+          path: metadata.annotations["grafana.com/prepare-downscale-http-path"]
+
+  - it: wires the coordinated scale-down
+    template: live-store/statefulset-live-store.yaml
+    set:
+      rollout_operator.enabled: true
+      liveStore.zoneAwareReplication.enabled: true
+      liveStore.zoneAwareReplication.prepareDownscale.enabled: true
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: metadata.labels["grafana.com/prepare-downscale"]
+          value: "true"
+      - equal:
+          path: metadata.labels["grafana.com/min-time-between-zones-downscale"]
+          value: 12h
+      - equal:
+          path: metadata.annotations["grafana.com/prepare-downscale-http-path"]
+          value: live-store/prepare-partition-downscale
+      - equal:
+          path: metadata.annotations["grafana.com/prepare-downscale-http-port"]
+          value: "3200"
+
+  - it: honours a custom downscale endpoint and window
+    template: live-store/statefulset-live-store.yaml
+    set:
+      rollout_operator.enabled: true
+      liveStore.zoneAwareReplication.enabled: true
+      liveStore.zoneAwareReplication.prepareDownscale.enabled: true
+      liveStore.zoneAwareReplication.prepareDownscale.httpPath: live-store/prepare-downscale
+      liveStore.zoneAwareReplication.prepareDownscale.minTimeBetweenZonesDownscale: 30m
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: metadata.annotations["grafana.com/prepare-downscale-http-path"]
+          value: live-store/prepare-downscale
+      - equal:
+          path: metadata.labels["grafana.com/min-time-between-zones-downscale"]
+          value: 30m
+
+  - it: rejects every scale-down when noDownscale is set
+    template: live-store/statefulset-live-store.yaml
+    set:
+      rollout_operator.enabled: true
+      liveStore.zoneAwareReplication.enabled: true
+      liveStore.zoneAwareReplication.noDownscale: true
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: metadata.labels["grafana.com/no-downscale"]
+          value: "true"
+      - notExists:
+          path: metadata.labels["grafana.com/prepare-downscale"]

--- a/charts/tempo-distributed/tests/live-store/zone_aware_test.yaml
+++ b/charts/tempo-distributed/tests/live-store/zone_aware_test.yaml
@@ -335,6 +335,17 @@ tests:
           path: spec.crossZoneEvictionDelay
           value: 20m
 
+  - it: keeps a capture group of 0
+    template: live-store/zonepoddisruptionbudget-live-store.yaml
+    set:
+      rollout_operator.enabled: true
+      liveStore.zoneAwareReplication.enabled: true
+      liveStore.zoneAwareReplication.podDisruptionBudget.podNameRegexGroup: 0
+    asserts:
+      - equal:
+          path: spec.podNameRegexGroup
+          value: 0
+
   - it: fails when fewer than two zones are defined
     template: live-store/statefulset-live-store.yaml
     set:

--- a/charts/tempo-distributed/tests/live-store/zone_aware_test.yaml
+++ b/charts/tempo-distributed/tests/live-store/zone_aware_test.yaml
@@ -218,22 +218,35 @@ tests:
           path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
           value: dedicated
 
-  - it: renders one PodDisruptionBudget per zone
+  - it: keeps one PodDisruptionBudget for every zone together
     template: live-store/poddisruptionbudget-live-store.yaml
     set:
       rollout_operator.enabled: true
       liveStore.zoneAwareReplication.enabled: true
     asserts:
       - hasDocuments:
-          count: 2
+          count: 1
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-tempo-live-store-zone-a
-        documentIndex: 0
-      - equal:
+          value: RELEASE-NAME-tempo-live-store
+      - notExists:
           path: spec.selector.matchLabels.zone
-          value: zone-b
-        documentIndex: 1
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: live-store
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+
+  - it: budgets the live-stores of every zone once the zones together hold more than one
+    template: live-store/poddisruptionbudget-live-store.yaml
+    set:
+      rollout_operator.enabled: true
+      liveStore.replicas: 1
+      liveStore.zoneAwareReplication.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
 
   - it: fails when fewer than two zones are defined
     template: live-store/statefulset-live-store.yaml

--- a/charts/tempo-distributed/tests/live-store/zone_aware_test.yaml
+++ b/charts/tempo-distributed/tests/live-store/zone_aware_test.yaml
@@ -94,6 +94,29 @@ tests:
           path: spec.template.metadata.labels.name
           value: live-store-zone-a
 
+  - it: keeps a maxUnavailable of 0 on the zone StatefulSet
+    template: live-store/statefulset-live-store.yaml
+    set:
+      rollout_operator.enabled: true
+      liveStore.zoneAwareReplication.enabled: true
+      liveStore.zoneAwareReplication.maxUnavailable: 0
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: metadata.annotations["rollout-max-unavailable"]
+          value: "0"
+
+  - it: drops the annotation when maxUnavailable is null
+    template: live-store/statefulset-live-store.yaml
+    set:
+      rollout_operator.enabled: true
+      liveStore.zoneAwareReplication.enabled: true
+      liveStore.zoneAwareReplication.maxUnavailable: null
+    documentIndex: 0
+    asserts:
+      - notExists:
+          path: metadata.annotations["rollout-max-unavailable"]
+
   - it: scopes the selector of a zone to that zone
     template: live-store/statefulset-live-store.yaml
     set:

--- a/charts/tempo-distributed/tests/live-store/zone_aware_test.yaml
+++ b/charts/tempo-distributed/tests/live-store/zone_aware_test.yaml
@@ -3,6 +3,7 @@ suite: live-store zone-aware replication
 templates:
   - live-store/statefulset-live-store.yaml
   - live-store/poddisruptionbudget-live-store.yaml
+  - live-store/zonepoddisruptionbudget-live-store.yaml
   - configmap-tempo.yaml
 
 tests:
@@ -218,11 +219,51 @@ tests:
           path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
           value: dedicated
 
-  - it: keeps one PodDisruptionBudget for every zone together
+  - it: budgets the evictions per partition across the zones
+    template: live-store/zonepoddisruptionbudget-live-store.yaml
+    set:
+      rollout_operator.enabled: true
+      liveStore.zoneAwareReplication.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ZoneAwarePodDisruptionBudget
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-tempo-live-store
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+      - equal:
+          path: spec.podNamePartitionRegex
+          value: .*-([0-9]+)
+      - notExists:
+          path: spec.selector.matchLabels.zone
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: live-store
+      - notExists:
+          path: spec.crossZoneEvictionDelay
+      - notExists:
+          path: spec.podNameRegexGroup
+
+  - it: hands the budget over from the native PodDisruptionBudget
     template: live-store/poddisruptionbudget-live-store.yaml
     set:
       rollout_operator.enabled: true
       liveStore.zoneAwareReplication.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: keeps one native PodDisruptionBudget over all zones when the zone-aware one is off
+    template: live-store/poddisruptionbudget-live-store.yaml
+    set:
+      rollout_operator.enabled: true
+      liveStore.replicas: 1
+      liveStore.zoneAwareReplication.enabled: true
+      liveStore.zoneAwareReplication.podDisruptionBudget.enabled: false
     asserts:
       - hasDocuments:
           count: 1
@@ -232,21 +273,44 @@ tests:
       - notExists:
           path: spec.selector.matchLabels.zone
       - equal:
-          path: spec.selector.matchLabels["app.kubernetes.io/component"]
-          value: live-store
-      - equal:
           path: spec.maxUnavailable
           value: 1
 
-  - it: budgets the live-stores of every zone once the zones together hold more than one
-    template: live-store/poddisruptionbudget-live-store.yaml
-    set:
-      rollout_operator.enabled: true
-      liveStore.replicas: 1
-      liveStore.zoneAwareReplication.enabled: true
+  - it: renders no zone-aware budget on the flat path
+    template: live-store/zonepoddisruptionbudget-live-store.yaml
     asserts:
       - hasDocuments:
-          count: 1
+          count: 0
+
+  - it: renders no budget at all when the PodDisruptionBudget is turned off
+    template: live-store/zonepoddisruptionbudget-live-store.yaml
+    set:
+      rollout_operator.enabled: true
+      liveStore.zoneAwareReplication.enabled: true
+      liveStore.podDisruptionBudget.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: carries the eviction delay and the capture group when they are set
+    template: live-store/zonepoddisruptionbudget-live-store.yaml
+    set:
+      rollout_operator.enabled: true
+      liveStore.zoneAwareReplication.enabled: true
+      liveStore.zoneAwareReplication.podDisruptionBudget.maxUnavailable: 0
+      liveStore.zoneAwareReplication.podDisruptionBudget.podNamePartitionRegex: "[a-z-]+-zone-([a-z]+)-([0-9]+)"
+      liveStore.zoneAwareReplication.podDisruptionBudget.podNameRegexGroup: 2
+      liveStore.zoneAwareReplication.podDisruptionBudget.crossZoneEvictionDelay: 20m
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 0
+      - equal:
+          path: spec.podNameRegexGroup
+          value: 2
+      - equal:
+          path: spec.crossZoneEvictionDelay
+          value: 20m
 
   - it: fails when fewer than two zones are defined
     template: live-store/statefulset-live-store.yaml

--- a/charts/tempo-distributed/tests/validate_test.yaml
+++ b/charts/tempo-distributed/tests/validate_test.yaml
@@ -176,3 +176,45 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: cluster-domain=custom.local
+
+  - it: fails when the pod eviction webhook is turned off
+    set:
+      ingest.kafka.address: kafka:9092
+      rollout_operator.enabled: true
+      rollout_operator.webhooks.enabled: false
+      liveStore.zoneAwareReplication.enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: rollout-operator pod eviction webhook
+
+  - it: fails when the ZoneAwarePodDisruptionBudget CRD is not installed
+    set:
+      ingest.kafka.address: kafka:9092
+      rollout_operator.enabled: true
+      rollout_operator.crds.enabled: false
+      liveStore.zoneAwareReplication.enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: needs the ZoneAwarePodDisruptionBudget CRD
+
+  - it: fails on a cross-zone eviction delay without a partition regex
+    set:
+      ingest.kafka.address: kafka:9092
+      rollout_operator.enabled: true
+      liveStore.zoneAwareReplication.enabled: true
+      liveStore.zoneAwareReplication.podDisruptionBudget.podNamePartitionRegex: null
+      liveStore.zoneAwareReplication.podDisruptionBudget.crossZoneEvictionDelay: 20m
+    asserts:
+      - failedTemplate:
+          errorPattern: crossZoneEvictionDelay needs podNamePartitionRegex
+
+  - it: leaves the webhooks alone when the zone-aware budget is off
+    set:
+      ingest.kafka.address: kafka:9092
+      rollout_operator.enabled: true
+      rollout_operator.webhooks.enabled: false
+      liveStore.zoneAwareReplication.enabled: true
+      liveStore.zoneAwareReplication.podDisruptionBudget.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/tempo-distributed/tests/validate_test.yaml
+++ b/charts/tempo-distributed/tests/validate_test.yaml
@@ -71,3 +71,57 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: fails when noDownscale and prepareDownscale are both set
+    set:
+      ingest.kafka.address: kafka:9092
+      rollout_operator.enabled: true
+      liveStore.zoneAwareReplication.enabled: true
+      liveStore.zoneAwareReplication.noDownscale: true
+      liveStore.zoneAwareReplication.prepareDownscale.enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: mutually exclusive
+
+  - it: fails when a downscale setting is used without zone-awareness
+    set:
+      ingest.kafka.address: kafka:9092
+      liveStore.zoneAwareReplication.prepareDownscale.enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: only apply to zone-aware live-stores
+
+  - it: fails when the rollout-operator webhooks are turned off
+    set:
+      ingest.kafka.address: kafka:9092
+      rollout_operator.enabled: true
+      rollout_operator.webhooks.enabled: false
+      liveStore.zoneAwareReplication.enabled: true
+      liveStore.zoneAwareReplication.prepareDownscale.enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: rollout-operator admission webhooks
+
+  - it: fails when the cluster domain is not passed to the rollout-operator
+    set:
+      ingest.kafka.address: kafka:9092
+      global.clusterDomain: custom.local
+      rollout_operator.enabled: true
+      liveStore.zoneAwareReplication.enabled: true
+      liveStore.zoneAwareReplication.prepareDownscale.enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: cluster-domain=custom.local
+
+  - it: accepts a cluster domain passed to the rollout-operator
+    set:
+      ingest.kafka.address: kafka:9092
+      global.clusterDomain: custom.local
+      rollout_operator.enabled: true
+      rollout_operator.extraArgs:
+        - -cluster-domain=custom.local
+      liveStore.zoneAwareReplication.enabled: true
+      liveStore.zoneAwareReplication.prepareDownscale.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/tempo-distributed/tests/validate_test.yaml
+++ b/charts/tempo-distributed/tests/validate_test.yaml
@@ -125,3 +125,54 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: accepts a double-dash cluster domain arg
+    set:
+      ingest.kafka.address: kafka:9092
+      global.clusterDomain: custom.local
+      rollout_operator.enabled: true
+      rollout_operator.extraArgs:
+        - --cluster-domain=custom.local
+      liveStore.zoneAwareReplication.enabled: true
+      liveStore.zoneAwareReplication.prepareDownscale.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: accepts a space-separated cluster domain arg
+    set:
+      ingest.kafka.address: kafka:9092
+      global.clusterDomain: custom.local
+      rollout_operator.enabled: true
+      rollout_operator.extraArgs:
+        - -cluster-domain
+        - custom.local
+      liveStore.zoneAwareReplication.enabled: true
+      liveStore.zoneAwareReplication.prepareDownscale.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: leaves the cluster domain of an externally managed rollout-operator alone
+    set:
+      ingest.kafka.address: kafka:9092
+      global.clusterDomain: custom.local
+      liveStore.zoneAwareReplication.enabled: true
+      liveStore.zoneAwareReplication.rolloutOperatorManagedExternally: true
+      liveStore.zoneAwareReplication.prepareDownscale.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: still rejects a cluster domain that reaches no rollout-operator arg
+    set:
+      ingest.kafka.address: kafka:9092
+      global.clusterDomain: custom.local
+      rollout_operator.enabled: true
+      rollout_operator.extraArgs:
+        - -cluster-domain=other.local
+      liveStore.zoneAwareReplication.enabled: true
+      liveStore.zoneAwareReplication.prepareDownscale.enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: cluster-domain=custom.local

--- a/charts/tempo-distributed/tests/validate_test.yaml
+++ b/charts/tempo-distributed/tests/validate_test.yaml
@@ -45,3 +45,29 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: fails when zone-aware live-stores have no rollout-operator
+    set:
+      ingest.kafka.address: kafka:9092
+      liveStore.zoneAwareReplication.enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: needs a rollout-operator in this namespace
+
+  - it: renders nothing when the rollout-operator is installed by the chart
+    set:
+      ingest.kafka.address: kafka:9092
+      rollout_operator.enabled: true
+      liveStore.zoneAwareReplication.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders nothing when the rollout-operator is managed outside the chart
+    set:
+      ingest.kafka.address: kafka:9092
+      liveStore.zoneAwareReplication.enabled: true
+      liveStore.zoneAwareReplication.rolloutOperatorManagedExternally: true
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -1131,29 +1131,49 @@ liveStore:
     # not installed by this chart. Skips the `rollout_operator.enabled` check.
     rolloutOperatorManagedExternally: false
     # -- Topology key of the failure domain. When set, the live-stores of one zone
-    # never share a domain with the live-stores of another zone.
+    # never share a domain with the live-stores of another zone. The cluster must
+    # hold at least as many domains as there are zones, otherwise the extra zones
+    # stay unschedulable. With neither this nor a `nodeSelector` on every zone,
+    # the zones still give separate pods and one partition owner each, but two
+    # zones can share a failure domain.
     topologyKey: null
     # -- Maximum number of live-stores the rollout-operator restarts at the same
     # time inside one zone. The rollout-operator always moves one zone at a time.
+    # A zone with fewer live-stores than this restarts as a whole, which the read
+    # quorum of 1 covers, at the cost of the read capacity of that zone.
     maxUnavailable: 25
     # -- Reject every scale-down of the live-stores. The live-store count must
     # match the Kafka partition count, so an accidental scale-down drops the
     # recent-read tier of the partitions that go away. Needs the rollout-operator
     # webhooks. Cannot be combined with `prepareDownscale.enabled`.
     noDownscale: false
-    # Coordinated scale-down through the rollout-operator admission webhook. On a
-    # scale-down the webhook calls `httpPath` on every live-store that goes away,
-    # which moves its partition to INACTIVE before the pod stops. The webhook
-    # rejects the scale-down of a second zone until
-    # `minTimeBetweenZonesDownscale` has passed, so the zones go down one at a
-    # time. A rejected scale-down fails the `helm upgrade`: wait for the window,
-    # then run the upgrade again.
+    # Coordinated scale-down through the rollout-operator admission webhook. It
+    # guards a lower `liveStore.replicas`, which retires the last Kafka
+    # partitions. On such a scale-down the webhook calls `httpPath` on every
+    # live-store that goes away, which moves its partition to INACTIVE and stops
+    # the writes to it. The webhook then rejects the scale-down of a second zone
+    # until `minTimeBetweenZonesDownscale` has passed, so the zones go down one
+    # at a time. A rejected scale-down fails the `helm upgrade`: wait for the
+    # window, then run the upgrade again.
+    #
+    # The webhook is the only mechanism the chart uses, so a pod stops as soon
+    # as its partition is INACTIVE. The remaining zones still own that partition
+    # and still hold its recent traces, which is what keeps the read path whole
+    # until the last zone goes down. Do not remove a zone from the `zones` list
+    # in the same step: that deletes the StatefulSet, which the webhook never
+    # sees.
     prepareDownscale:
       # -- Enable the coordinated scale-down
       enabled: false
-      # -- Minimum time between the scale-down of two zones
+      # -- Minimum time between the scale-down of two zones. Must be longer than
+      # the period a live-store still serves recent traces, because the last
+      # zone to go down takes the last owner of the retired partitions with it.
       minTimeBetweenZonesDownscale: 12h
-      # -- Endpoint the webhook calls on every live-store that goes away
+      # -- Endpoint the webhook calls on every live-store that goes away. Must
+      # accept a POST while the partition is still ACTIVE.
+      # `live-store/prepare-downscale` does not: it answers 409 until the
+      # partition is INACTIVE, so it needs the delayed-downscale mechanism of
+      # the rollout-operator, which this chart does not configure.
       httpPath: live-store/prepare-partition-downscale
     # -- Zones to deploy. At least 2 zones are required. Every zone runs
     # `liveStore.replicas` live-stores.
@@ -1161,7 +1181,8 @@ liveStore:
       - name: zone-a
         # -- Node selector for the live-stores of this zone
         nodeSelector: null
-        # -- Extra affinity merged into the zone anti-affinity
+        # -- Extra affinity for the live-stores of this zone. The zone
+        # anti-affinity of `topologyKey` overwrites a `podAntiAffinity` here.
         extraAffinity: {}
         # -- Extra annotations for the StatefulSet of this zone
         annotations: {}

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -1118,6 +1118,41 @@ liveStore:
   statefulStrategy:
     rollingUpdate:
       partition: 0
+  # Zone-aware replication spreads the live-stores over failure domains such as
+  # availability zones, racks or data centres. Every zone runs a full set of
+  # live-stores, so each Kafka partition gets one owner per zone (RF equals the
+  # number of zones). The read quorum is 1: a querier only needs an answer from
+  # one zone, so recent-trace queries survive the loss of a zone.
+  # Requires `rollout_operator.enabled: true`.
+  zoneAwareReplication:
+    # -- Enable zone-aware replication for the live-store
+    enabled: false
+    # -- Set to true when a rollout-operator already runs in this namespace and is
+    # not installed by this chart. Skips the `rollout_operator.enabled` check.
+    rolloutOperatorManagedExternally: false
+    # -- Topology key of the failure domain. When set, the live-stores of one zone
+    # never share a domain with the live-stores of another zone.
+    topologyKey: null
+    # -- Maximum number of live-stores the rollout-operator restarts at the same
+    # time inside one zone. The rollout-operator always moves one zone at a time.
+    maxUnavailable: 25
+    # -- Zones to deploy. At least 2 zones are required. Every zone runs
+    # `liveStore.replicas` live-stores.
+    zones:
+      - name: zone-a
+        # -- Node selector for the live-stores of this zone
+        nodeSelector: null
+        # -- Extra affinity merged into the zone anti-affinity
+        extraAffinity: {}
+        # -- Extra annotations for the StatefulSet of this zone
+        annotations: {}
+        # -- Extra annotations for the pods of this zone
+        podAnnotations: {}
+      - name: zone-b
+        nodeSelector: null
+        extraAffinity: {}
+        annotations: {}
+        podAnnotations: {}
   # -- Pod Disruption Budget configuration
   podDisruptionBudget:
     # -- Enable PodDisruptionBudget for live-store

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -271,9 +271,7 @@ metricsGenerator:
     enabled: true
     # -- Set unhealthyPodEvictionPolicy for the metrics-generator PodDisruptionBudget. Requires policy/v1.
     unhealthyPodEvictionPolicy: ""
-  # -- Pod Disruption Budget maxUnavailable. With zone-aware replication the
-  # budget covers the live-stores of every zone together, because the same pod
-  # ordinal in two zones holds every owner of one partition.
+  # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: 1
   # -- Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing/terminating
   minReadySeconds: 10
@@ -500,9 +498,7 @@ distributor:
     enabled: true
     # -- Set unhealthyPodEvictionPolicy for the distributor PodDisruptionBudget. Requires policy/v1.
     unhealthyPodEvictionPolicy: ""
-  # -- Pod Disruption Budget maxUnavailable. With zone-aware replication the
-  # budget covers the live-stores of every zone together, because the same pod
-  # ordinal in two zones holds every owner of one partition.
+  # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: 1
   # -- Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing/terminating
   minReadySeconds: 10
@@ -1031,9 +1027,7 @@ blockBuilder:
     enabled: true
     # -- Set unhealthyPodEvictionPolicy for the block-builder PodDisruptionBudget. Requires policy/v1.
     unhealthyPodEvictionPolicy: ""
-  # -- Pod Disruption Budget maxUnavailable. With zone-aware replication the
-  # budget covers the live-stores of every zone together, because the same pod
-  # ordinal in two zones holds every owner of one partition.
+  # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: 1
   service:
     # -- Annotations for block-builder service
@@ -1342,9 +1336,7 @@ querier:
     enabled: true
     # -- Set unhealthyPodEvictionPolicy for the querier PodDisruptionBudget. Requires policy/v1.
     unhealthyPodEvictionPolicy: ""
-  # -- Pod Disruption Budget maxUnavailable. With zone-aware replication the
-  # budget covers the live-stores of every zone together, because the same pod
-  # ordinal in two zones holds every owner of one partition.
+  # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: 1
   # -- Max Surge for querier pods
   maxSurge: 0
@@ -1620,9 +1612,7 @@ queryFrontend:
     enabled: true
     # -- Set unhealthyPodEvictionPolicy for the query-frontend PodDisruptionBudget. Requires policy/v1.
     unhealthyPodEvictionPolicy: ""
-  # -- Pod Disruption Budget maxUnavailable. With zone-aware replication the
-  # budget covers the live-stores of every zone together, because the same pod
-  # ordinal in two zones holds every owner of one partition.
+  # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: 1
   # -- Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing/terminating
   minReadySeconds: 10
@@ -1751,9 +1741,7 @@ enterpriseFederationFrontend:
   podDisruptionBudget:
     # -- Enable PodDisruptionBudget for enterprise-federation-frontend
     enabled: true
-  # -- Pod Disruption Budget maxUnavailable. With zone-aware replication the
-  # budget covers the live-stores of every zone together, because the same pod
-  # ordinal in two zones holds every owner of one partition.
+  # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: 1
   # -- Node selector for federation-frontend pods
   nodeSelector: {}
@@ -2372,9 +2360,7 @@ memcached:
     enabled: true
     # -- Set unhealthyPodEvictionPolicy for the memcached PodDisruptionBudget. Requires policy/v1.
     unhealthyPodEvictionPolicy: ""
-  # -- Pod Disruption Budget maxUnavailable. With zone-aware replication the
-  # budget covers the live-stores of every zone together, because the same pod
-  # ordinal in two zones holds every owner of one partition.
+  # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: 1
   # -- Init containers for the memcached pod
   initContainers: []
@@ -2487,9 +2473,7 @@ memcachedBloom:
   podDisruptionBudget:
     # -- Enable PodDisruptionBudget for memcached-bloom
     enabled: true
-  # -- Pod Disruption Budget maxUnavailable. With zone-aware replication the
-  # budget covers the live-stores of every zone together, because the same pod
-  # ordinal in two zones holds every owner of one partition.
+  # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: 1
   # -- Init containers for the memcached-bloom pod
   initContainers: []
@@ -2576,9 +2560,7 @@ memcachedParquetFooter:
   podDisruptionBudget:
     # -- Enable PodDisruptionBudget for memcached-parquet-footer
     enabled: true
-  # -- Pod Disruption Budget maxUnavailable. With zone-aware replication the
-  # budget covers the live-stores of every zone together, because the same pod
-  # ordinal in two zones holds every owner of one partition.
+  # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: 1
   # -- Init containers for the memcached-parquet-footer pod
   initContainers: []
@@ -2665,9 +2647,7 @@ memcachedFrontendSearch:
   podDisruptionBudget:
     # -- Enable PodDisruptionBudget for memcached-frontend-search
     enabled: true
-  # -- Pod Disruption Budget maxUnavailable. With zone-aware replication the
-  # budget covers the live-stores of every zone together, because the same pod
-  # ordinal in two zones holds every owner of one partition.
+  # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: 1
   # -- Init containers for the memcached-frontend-search pod
   initContainers: []
@@ -2917,9 +2897,7 @@ gateway:
     enabled: true
     # -- Set unhealthyPodEvictionPolicy for the gateway PodDisruptionBudget. Requires policy/v1.
     unhealthyPodEvictionPolicy: ""
-  # -- Pod Disruption Budget maxUnavailable. With zone-aware replication the
-  # budget covers the live-stores of every zone together, because the same pod
-  # ordinal in two zones holds every owner of one partition.
+  # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: 1
   # -- Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing/terminating
   minReadySeconds: 10

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -1176,13 +1176,16 @@ liveStore:
       # the rollout-operator, which this chart does not configure.
       httpPath: live-store/prepare-partition-downscale
     # -- Zones to deploy. At least 2 zones are required. Every zone runs
-    # `liveStore.replicas` live-stores.
+    # `liveStore.replicas` live-stores. A zone name must be a DNS label: it
+    # becomes a StatefulSet name suffix and the value of the zone label.
     zones:
       - name: zone-a
-        # -- Node selector for the live-stores of this zone
+        # -- Node selector for the live-stores of this zone. Merged on top of
+        # `liveStore.nodeSelector`, or of `defaults.nodeSelector`.
         nodeSelector: null
-        # -- Extra affinity for the live-stores of this zone. The zone
-        # anti-affinity of `topologyKey` overwrites a `podAntiAffinity` here.
+        # -- Extra affinity for the live-stores of this zone. Merged on top of
+        # `liveStore.affinity`. The zone anti-affinity of `topologyKey`
+        # overwrites a `podAntiAffinity` here.
         extraAffinity: {}
         # -- Extra annotations for the StatefulSet of this zone
         annotations: {}

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -271,7 +271,9 @@ metricsGenerator:
     enabled: true
     # -- Set unhealthyPodEvictionPolicy for the metrics-generator PodDisruptionBudget. Requires policy/v1.
     unhealthyPodEvictionPolicy: ""
-  # -- Pod Disruption Budget maxUnavailable
+  # -- Pod Disruption Budget maxUnavailable. With zone-aware replication the
+  # budget covers the live-stores of every zone together, because the same pod
+  # ordinal in two zones holds every owner of one partition.
   maxUnavailable: 1
   # -- Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing/terminating
   minReadySeconds: 10
@@ -498,7 +500,9 @@ distributor:
     enabled: true
     # -- Set unhealthyPodEvictionPolicy for the distributor PodDisruptionBudget. Requires policy/v1.
     unhealthyPodEvictionPolicy: ""
-  # -- Pod Disruption Budget maxUnavailable
+  # -- Pod Disruption Budget maxUnavailable. With zone-aware replication the
+  # budget covers the live-stores of every zone together, because the same pod
+  # ordinal in two zones holds every owner of one partition.
   maxUnavailable: 1
   # -- Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing/terminating
   minReadySeconds: 10
@@ -1027,7 +1031,9 @@ blockBuilder:
     enabled: true
     # -- Set unhealthyPodEvictionPolicy for the block-builder PodDisruptionBudget. Requires policy/v1.
     unhealthyPodEvictionPolicy: ""
-  # -- Pod Disruption Budget maxUnavailable
+  # -- Pod Disruption Budget maxUnavailable. With zone-aware replication the
+  # budget covers the live-stores of every zone together, because the same pod
+  # ordinal in two zones holds every owner of one partition.
   maxUnavailable: 1
   service:
     # -- Annotations for block-builder service
@@ -1202,7 +1208,9 @@ liveStore:
     enabled: true
     # -- Set unhealthyPodEvictionPolicy for the live-store PodDisruptionBudget. Requires policy/v1.
     unhealthyPodEvictionPolicy: ""
-  # -- Pod Disruption Budget maxUnavailable
+  # -- Pod Disruption Budget maxUnavailable. With zone-aware replication the
+  # budget covers the live-stores of every zone together, because the same pod
+  # ordinal in two zones holds every owner of one partition.
   maxUnavailable: 1
   service:
     # -- Annotations for live-store service
@@ -1300,7 +1308,9 @@ querier:
     enabled: true
     # -- Set unhealthyPodEvictionPolicy for the querier PodDisruptionBudget. Requires policy/v1.
     unhealthyPodEvictionPolicy: ""
-  # -- Pod Disruption Budget maxUnavailable
+  # -- Pod Disruption Budget maxUnavailable. With zone-aware replication the
+  # budget covers the live-stores of every zone together, because the same pod
+  # ordinal in two zones holds every owner of one partition.
   maxUnavailable: 1
   # -- Max Surge for querier pods
   maxSurge: 0
@@ -1576,7 +1586,9 @@ queryFrontend:
     enabled: true
     # -- Set unhealthyPodEvictionPolicy for the query-frontend PodDisruptionBudget. Requires policy/v1.
     unhealthyPodEvictionPolicy: ""
-  # -- Pod Disruption Budget maxUnavailable
+  # -- Pod Disruption Budget maxUnavailable. With zone-aware replication the
+  # budget covers the live-stores of every zone together, because the same pod
+  # ordinal in two zones holds every owner of one partition.
   maxUnavailable: 1
   # -- Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing/terminating
   minReadySeconds: 10
@@ -1705,7 +1717,9 @@ enterpriseFederationFrontend:
   podDisruptionBudget:
     # -- Enable PodDisruptionBudget for enterprise-federation-frontend
     enabled: true
-  # -- Pod Disruption Budget maxUnavailable
+  # -- Pod Disruption Budget maxUnavailable. With zone-aware replication the
+  # budget covers the live-stores of every zone together, because the same pod
+  # ordinal in two zones holds every owner of one partition.
   maxUnavailable: 1
   # -- Node selector for federation-frontend pods
   nodeSelector: {}
@@ -2324,7 +2338,9 @@ memcached:
     enabled: true
     # -- Set unhealthyPodEvictionPolicy for the memcached PodDisruptionBudget. Requires policy/v1.
     unhealthyPodEvictionPolicy: ""
-  # -- Pod Disruption Budget maxUnavailable
+  # -- Pod Disruption Budget maxUnavailable. With zone-aware replication the
+  # budget covers the live-stores of every zone together, because the same pod
+  # ordinal in two zones holds every owner of one partition.
   maxUnavailable: 1
   # -- Init containers for the memcached pod
   initContainers: []
@@ -2437,7 +2453,9 @@ memcachedBloom:
   podDisruptionBudget:
     # -- Enable PodDisruptionBudget for memcached-bloom
     enabled: true
-  # -- Pod Disruption Budget maxUnavailable
+  # -- Pod Disruption Budget maxUnavailable. With zone-aware replication the
+  # budget covers the live-stores of every zone together, because the same pod
+  # ordinal in two zones holds every owner of one partition.
   maxUnavailable: 1
   # -- Init containers for the memcached-bloom pod
   initContainers: []
@@ -2524,7 +2542,9 @@ memcachedParquetFooter:
   podDisruptionBudget:
     # -- Enable PodDisruptionBudget for memcached-parquet-footer
     enabled: true
-  # -- Pod Disruption Budget maxUnavailable
+  # -- Pod Disruption Budget maxUnavailable. With zone-aware replication the
+  # budget covers the live-stores of every zone together, because the same pod
+  # ordinal in two zones holds every owner of one partition.
   maxUnavailable: 1
   # -- Init containers for the memcached-parquet-footer pod
   initContainers: []
@@ -2611,7 +2631,9 @@ memcachedFrontendSearch:
   podDisruptionBudget:
     # -- Enable PodDisruptionBudget for memcached-frontend-search
     enabled: true
-  # -- Pod Disruption Budget maxUnavailable
+  # -- Pod Disruption Budget maxUnavailable. With zone-aware replication the
+  # budget covers the live-stores of every zone together, because the same pod
+  # ordinal in two zones holds every owner of one partition.
   maxUnavailable: 1
   # -- Init containers for the memcached-frontend-search pod
   initContainers: []
@@ -2861,7 +2883,9 @@ gateway:
     enabled: true
     # -- Set unhealthyPodEvictionPolicy for the gateway PodDisruptionBudget. Requires policy/v1.
     unhealthyPodEvictionPolicy: ""
-  # -- Pod Disruption Budget maxUnavailable
+  # -- Pod Disruption Budget maxUnavailable. With zone-aware replication the
+  # budget covers the live-stores of every zone together, because the same pod
+  # ordinal in two zones holds every owner of one partition.
   maxUnavailable: 1
   # -- Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing/terminating
   minReadySeconds: 10

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -1181,6 +1181,40 @@ liveStore:
       # partition is INACTIVE, so it needs the delayed-downscale mechanism of
       # the rollout-operator, which this chart does not configure.
       httpPath: live-store/prepare-partition-downscale
+    # Voluntary evictions of zone-aware live-stores, through the
+    # ZoneAwarePodDisruptionBudget of the rollout-operator. A native
+    # PodDisruptionBudget counts pods, so it cannot tell that the same pod
+    # ordinal in two zones holds every owner of one partition. This one counts
+    # per partition across zones and rejects an eviction that would take the
+    # last owner, whatever the budget of a single zone allows.
+    #
+    # Needs the ZoneAwarePodDisruptionBudget CRD and the pod eviction webhook of
+    # the rollout-operator. The bundled subchart installs both. The webhook
+    # rejects an eviction while the rollout-operator is unreachable, so this
+    # never opens a window. While this is on, it replaces the
+    # `liveStore.podDisruptionBudget` object.
+    podDisruptionBudget:
+      # -- Guard the evictions with a ZoneAwarePodDisruptionBudget. Set to false
+      # to keep a single native PodDisruptionBudget over all zones instead.
+      enabled: true
+      # -- Live-stores of one partition that may be unavailable at the same
+      # time, counted over every zone. 1 keeps a partition served through any
+      # single voluntary eviction. 0 rejects every voluntary eviction.
+      maxUnavailable: 1
+      # -- Regular expression that returns the partition of a live-store from
+      # its pod name. The rollout-operator anchors it with `^` and `$`, so it
+      # must match the whole name. The default reads the pod ordinal, which is
+      # the Kafka partition, and holds for any zone name.
+      podNamePartitionRegex: ".*-([0-9]+)"
+      # -- Capture group of the partition. Only needed when
+      # `podNamePartitionRegex` holds more than one group.
+      podNameRegexGroup: null
+      # -- Minimum time after a live-store becomes ready before another owner of
+      # the same partition may be evicted. A Go duration, so days are not a
+      # unit. Set this when the live-stores run with the default
+      # `readiness-target-lag` of 0, because a live-store then reports ready
+      # while it still replays its partition.
+      crossZoneEvictionDelay: null
     # -- Zones to deploy. At least 2 zones are required. Every zone runs
     # `liveStore.replicas` live-stores. A zone name must be a DNS label: it
     # becomes a StatefulSet name suffix and the value of the zone label.

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -1136,6 +1136,25 @@ liveStore:
     # -- Maximum number of live-stores the rollout-operator restarts at the same
     # time inside one zone. The rollout-operator always moves one zone at a time.
     maxUnavailable: 25
+    # -- Reject every scale-down of the live-stores. The live-store count must
+    # match the Kafka partition count, so an accidental scale-down drops the
+    # recent-read tier of the partitions that go away. Needs the rollout-operator
+    # webhooks. Cannot be combined with `prepareDownscale.enabled`.
+    noDownscale: false
+    # Coordinated scale-down through the rollout-operator admission webhook. On a
+    # scale-down the webhook calls `httpPath` on every live-store that goes away,
+    # which moves its partition to INACTIVE before the pod stops. The webhook
+    # rejects the scale-down of a second zone until
+    # `minTimeBetweenZonesDownscale` has passed, so the zones go down one at a
+    # time. A rejected scale-down fails the `helm upgrade`: wait for the window,
+    # then run the upgrade again.
+    prepareDownscale:
+      # -- Enable the coordinated scale-down
+      enabled: false
+      # -- Minimum time between the scale-down of two zones
+      minTimeBetweenZonesDownscale: 12h
+      # -- Endpoint the webhook calls on every live-store that goes away
+      httpPath: live-store/prepare-partition-downscale
     # -- Zones to deploy. At least 2 zones are required. Every zone runs
     # `liveStore.replicas` live-stores.
     zones:


### PR DESCRIPTION
## Problem

Closes #718. The chart renders a single flat live-store StatefulSet, so each Kafka partition has exactly one owner. If that pod goes away (node or AZ failure, spot eviction, rollout), recent-trace queries for its partition fail with no fallback. Backend blocks only cover already-flushed data.

## Change

`liveStore.zoneAwareReplication` renders one StatefulSet per zone. Each zone runs a full set of live-stores and passes `-live-store.instance-availability-zone` to Tempo. A live-store reads Kafka under a consumer group of its own, because the chart leaves `ingest.kafka.consumer_group` unset and Tempo then falls back to the pod name, so every partition gets one owner per zone. dskit sets the read quorum to 1 across zones, so a querier only needs an answer from one zone.

Zones carry `rollout-group` and `zone` labels, a `rollout-max-unavailable` annotation and the `OnDelete` update strategy, so the rollout-operator moves one zone at a time. Rendering fails when no rollout-operator is available, since `OnDelete` would otherwise freeze every upgrade.

Voluntary evictions are guarded by a `ZoneAwarePodDisruptionBudget`. The same pod ordinal in every zone holds every owner of one Kafka partition, and a native PodDisruptionBudget counts pods, so it either lets both go at once or has to be tightened to one eviction for the whole live-store set. The rollout-operator reads the partition from the pod name and counts the unavailable live-stores of that partition over every zone, so a drain takes one live-store per partition and many partitions at once, and never the last owner. It replaces the native object while zone-awareness is on, `crossZoneEvictionDelay` covers a live-store that reports ready while it still replays, and `podDisruptionBudget.enabled: false` falls back to one native budget over all zones.

Scale-down is coordinated too, through two opt-in settings. `prepareDownscale` marks the zones for the rollout-operator admission webhook, which calls `live-store/prepare-partition-downscale` on every live-store that goes away and rejects the scale-down of a second zone until `minTimeBetweenZonesDownscale` has passed. `noDownscale` rejects every scale-down instead. What this guards is a lower `liveStore.replicas`, which retires the last Kafka partitions: the endpoint moves the partition to INACTIVE and stops the writes to it, and the zones that are still up keep the read path whole until the last one goes down. `minTimeBetweenZonesDownscale` must therefore stay longer than the period a live-store still serves recent traces. Because the webhook addresses live-stores through the pod DNS names of the headless service, zone StatefulSets carry the real service name rather than the placeholder the flat StatefulSet uses. That placeholder stays as it is on the flat path: `spec.serviceName` is immutable, so correcting it there would break every existing release.

Default values are unchanged. The rendered output with default values differs from main only by the chart version label and the config checksum it feeds.

The Tempo jsonnet points the same webhook at `live-store/prepare-downscale`, which also stops a pod from re-creating its partition on start. That endpoint answers 409 while the partition is still ACTIVE, so it only works behind the delayed-downscale mechanism of the rollout-operator, which needs a `ReplicaTemplate` and the mirror-replicas annotations. The chart does not configure either, and the zone stagger does that job instead. `liveStore.annotations` stays open for anyone who wants to add them.

A new `ci/live-store-zone-aware-values.yaml` runs the switch on the kind cluster: the flat StatefulSet from the base branch, then the upgrade to the per-zone ones, then the trace roundtrip test.

Two deliberate deviations from the issue:

- Replicas are not divided across zones. A live-store takes its partition from its pod ordinal and its consumer group from its pod name, so a zone must run the full partition set. `liveStore.replicas` stays the Kafka partition count and is now the size of one zone.
- No `live_store.ring.zone_awareness_enabled` is set. The live-store instance ring is RF1 by construction; zone awareness on the read path lives in the partition instance ring, which dskit already runs zone-aware. The availability-zone flag is the only knob needed.



