### PR TITLE
[tempo] Add the missing headless service

### DIFF
--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo
 description: Grafana Tempo Single Binary Mode
 type: application
-version: 2.3.0
+version: 2.4.0
 # renovate: docker=docker.io/grafana/tempo
 appVersion: 2.10.8
 home: https://grafana.net

--- a/charts/tempo/templates/service-headless.yaml
+++ b/charts/tempo/templates/service-headless.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "tempo.fullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tempo.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    {{- include "tempo.udp" . | indent 2 }}
+    {{- include "tempo.tcp" . | indent 2 }}
+  selector:
+    {{- include "tempo.selectorLabels" . | nindent 4 }}

--- a/charts/tempo/templates/service-headless.yaml
+++ b/charts/tempo/templates/service-headless.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tempo.labels" . | nindent 4 }}
+    prometheus.io/service-monitor: "false"
     {{- with .Values.service.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/tempo/templates/servicemonitor.yaml
+++ b/charts/tempo/templates/servicemonitor.yaml
@@ -19,6 +19,11 @@ spec:
   selector:
     matchLabels:
       {{- include "tempo.labels" . | nindent 6 }}
+    matchExpressions:
+      - key: prometheus.io/service-monitor
+        operator: NotIn
+        values:
+          - "false"
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace | quote }}

--- a/charts/tempo/tests/service-headless_test.yaml
+++ b/charts/tempo/tests/service-headless_test.yaml
@@ -1,0 +1,57 @@
+# $schema: https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json
+suite: headless service
+templates:
+  - service-headless.yaml
+tests:
+  - it: should render the headless service named in the StatefulSet governing service
+    release:
+      name: my-release
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: my-release-tempo-headless
+      - equal:
+          path: spec.clusterIP
+          value: None
+      - equal:
+          path: spec.publishNotReadyAddresses
+          value: true
+
+  - it: should select the tempo pods
+    release:
+      name: my-release
+    asserts:
+      - equal:
+          path: spec.selector["app.kubernetes.io/name"]
+          value: tempo
+      - equal:
+          path: spec.selector["app.kubernetes.io/instance"]
+          value: my-release
+
+  - it: should expose the tempo http port
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: tempo-prom-metrics
+            port: 3200
+            protocol: TCP
+            targetPort: 3200
+
+  - it: should carry the service labels and annotations
+    set:
+      service.labels:
+        test-label: test-value
+      service.annotations:
+        test-annotation: test-value
+    asserts:
+      - equal:
+          path: metadata.labels["test-label"]
+          value: test-value
+      - equal:
+          path: metadata.annotations["test-annotation"]
+          value: test-value

--- a/charts/tempo/tests/service-headless_test.yaml
+++ b/charts/tempo/tests/service-headless_test.yaml
@@ -55,3 +55,9 @@ tests:
       - equal:
           path: metadata.annotations["test-annotation"]
           value: test-value
+
+  - it: should be excluded from the ServiceMonitor selector
+    asserts:
+      - equal:
+          path: metadata.labels["prometheus.io/service-monitor"]
+          value: "false"

--- a/charts/tempo/tests/servicemonitor_test.yaml
+++ b/charts/tempo/tests/servicemonitor_test.yaml
@@ -1,0 +1,25 @@
+# $schema: https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json
+suite: service monitor
+templates:
+  - servicemonitor.yaml
+tests:
+  - it: should not render when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not select services marked as excluded
+    set:
+      serviceMonitor.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceMonitor
+      - contains:
+          path: spec.selector.matchExpressions
+          content:
+            key: prometheus.io/service-monitor
+            operator: NotIn
+            values:
+              - "false"


### PR DESCRIPTION
## Problem

`templates/statefulset.yaml` sets `serviceName: {{ template "tempo.fullname" . }}-headless`, but the chart never creates that Service. The governing service of the StatefulSet does not exist, so the stable per-pod DNS names (`<pod>.<fullname>-headless.<namespace>.svc`) do not resolve.

## Change

Add `templates/service-headless.yaml`: a headless Service with the name the StatefulSet already references, `publishNotReadyAddresses: true`, the same ports as the main Service, and the same selector.

The ServiceMonitor selects on `tempo.labels`, which both services carry, so it would match the headless Service too and scrape every pod twice. The headless Service therefore gets `prometheus.io/service-monitor: "false"`, and the ServiceMonitor selector excludes that label, as the loki chart already does.

Add helm-unittest coverage for the new Service and for the ServiceMonitor selector.

The Service is additive and the selector change only narrows, so an upgrade only creates the missing object.

Closes #682
