### PR TITLE
[loki] Fix Zone-aware ingester StatefulSets emit a duplicate name label

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.6
-version: 18.11.2
+version: 18.11.3
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/templates/_pod.tpl
+++ b/charts/loki/templates/_pod.tpl
@@ -29,7 +29,17 @@ metadata:
     name: {{ if $component.addIngesterNamePrefix }}loki-{{ end }}{{ $target }}-{{ $rolloutZoneName }}
     rollout-group: {{ with $component.rolloutGroupPrefix }}{{ . }}-{{ end }}{{ $target }}
     {{- end }}
-    {{- with (mergeOverwrite (dict) .Values.loki.podLabels .Values.defaults.podLabels $component.podLabels) }}
+    {{- $podLabels := mergeOverwrite (dict) .Values.loki.podLabels .Values.defaults.podLabels $component.podLabels }}
+    {{- /* labels referenced by the workload selectors (and, for zone-aware ingesters, the
+    per-zone headless Services and grafana/rollout-operator) are chart-owned and must win */}}
+    {{- $reserved := list "app.kubernetes.io/name" "app.kubernetes.io/instance" "app.kubernetes.io/component" }}
+    {{- if $rolloutZoneName }}
+    {{- $reserved = concat $reserved (list "name" "rollout-group") }}
+    {{- end }}
+    {{- range $reserved }}
+    {{- $podLabels = unset $podLabels . }}
+    {{- end }}
+    {{- with $podLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:

--- a/charts/loki/tests/ingester/zone_test.yaml
+++ b/charts/loki/tests/ingester/zone_test.yaml
@@ -159,6 +159,70 @@ tests:
         documentIndex: 2
         template: ingester/workload.yaml
 
+  - it: should keep chart-owned zone labels when podLabels sets reserved keys
+    set:
+      ingester.podLabels:
+        name: my-ingester
+        rollout-group: my-group
+        app.kubernetes.io/component: my-component
+        custom-label: kept
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.name
+          value: ingester-zone-a
+        documentIndex: 0
+        template: ingester/workload.yaml
+      - equal:
+          path: spec.template.metadata.labels.name
+          value: ingester-zone-b
+        documentIndex: 1
+        template: ingester/workload.yaml
+      - equal:
+          path: spec.template.metadata.labels["rollout-group"]
+          value: ingester
+        template: ingester/workload.yaml
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: ingester
+        template: ingester/workload.yaml
+      - equal:
+          path: spec.template.metadata.labels["custom-label"]
+          value: kept
+        template: ingester/workload.yaml
+
+  - it: should keep selector matchLabels a subset of template labels when podLabels collides
+    set:
+      loki.podLabels:
+        name: from-loki
+      defaults.podLabels:
+        rollout-group: from-defaults
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.name
+          value: ingester-zone-a
+        documentIndex: 0
+        template: ingester/workload.yaml
+      - equal:
+          path: spec.selector.matchLabels.name
+          value: ingester-zone-a
+        documentIndex: 0
+        template: ingester/workload.yaml
+      - equal:
+          path: spec.template.metadata.labels["rollout-group"]
+          value: ingester
+        template: ingester/workload.yaml
+
+  - it: should pass through podLabels name when zoneAwareReplication is disabled
+    set:
+      ingester.zoneAwareReplication.enabled: false
+      ingester.podLabels:
+        name: my-ingester
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.name
+          value: my-ingester
+        template: ingester/workload.yaml
+
   # ── Annotations ──────────────────────────────────────────────────────────────
 
   - it: should set rollout-max-unavailable annotation based on maxUnavailablePct

--- a/charts/loki/values.schema.json
+++ b/charts/loki/values.schema.json
@@ -5318,7 +5318,7 @@
                     }
                 },
                 "podLabels": {
-                    "description": "Labels for ingester pods",
+                    "description": "Labels for ingester pods. Keys used by the workload selectors (`app.kubernetes.io/name`, `app.kubernetes.io/instance`, `app.kubernetes.io/component` and, with zoneAwareReplication, `name` and `rollout-group`) are reserved and ignored here: the latter are also used by the per-zone headless Services and grafana/rollout-operator.",
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -3026,7 +3026,11 @@ ingester:
   # -- Annotations for ingester
   annotations: {}
   # @schema additionalProperties:{"type":"string"}
-  # -- Labels for ingester pods
+  # -- Labels for ingester pods. Keys used by the workload selectors
+  # (`app.kubernetes.io/name`, `app.kubernetes.io/instance`, `app.kubernetes.io/component`
+  # and, with zoneAwareReplication, `name` and `rollout-group`) are reserved and
+  # ignored here: the latter are also used by the per-zone headless Services and
+  # grafana/rollout-operator.
   podLabels: {}
   # @schema additionalProperties:{"type":"string"}
   # -- Annotations for ingester pods


### PR DESCRIPTION
<!--
Thank you for contributing to grafana-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/grafana-community/helm-charts/blob/main/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.

If you are an AI, please identify yourself so the maintainers know how to respond correctly.

Please make sure you test your changes before you push them (see CONTRIBUTING.md).
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.  Please check the results.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

When `ingester.zoneAwareReplication.enabled=true`, the pod template helper emits the
chart's zone discriminator labels (`name: <prefix>ingester-zone-{a,b,c}`, `rollout-group`)
and then appends the merged user `podLabels` (`loki.podLabels` / `defaults.podLabels` /
`ingester.podLabels`) verbatim, without merging them against the chart's own labels.

If a user sets `podLabels.name`, the rendered `spec.template.metadata.labels` contains
the key `name` twice. This is invalid YAML per the spec, and since duplicate keys resolve
last-wins, the effective pod label becomes the user's value while
`spec.selector.matchLabels` still requires the chart's — the API server rejects the
StatefulSet with `` `selector` does not match template `labels` ``.

This PR strips the selector-referenced label keys from the merged user `podLabels` before
emitting them, so each key is rendered exactly once and the chart's structural labels
always win:

- `app.kubernetes.io/name`, `app.kubernetes.io/instance`, `app.kubernetes.io/component`
  (always — these are in every workload's selector)
- `name`, `rollout-group` (only when zone-aware replication is active)

This guarantees `spec.selector.matchLabels ⊆ spec.template.metadata.labels` for any
user-supplied `podLabels`. The reserved keys are documented on `ingester.podLabels` in
`values.yaml`, and `values.schema.json` is regenerated (description-only diff).

#### Which issue this PR fixes

- fixes #759

#### Special notes for your reviewer

**Why the chart's labels must win (not the user's):** `name` is not just a label — it is
the zone discriminator agreed on by three parties: the StatefulSet selector (immutable),
the per-zone headless Services (`_service.tpl` selects on it; losing it would drop their
endpoints and break stable pod DNS), and grafana/rollout-operator, which hardcodes the
`name` pod label in its selector (`listPodsByStatefulSet`, `pkg/controller/controller.go`)
with no flag to change it. Letting user values through would silently break zone-aware
rollouts even when the manifest applies cleanly.

**No behavior change for any previously-working configuration:** every stripped key is
part of a workload selector, so any values that collided with them were already rejected
by the API server at apply time — this change only turns un-deployable configs into
deployable ones. Deliberately out of scope (previous behavior preserved):

- Non-selector chart labels (`helm.sh/chart`, `app.kubernetes.io/version`,
  `app.kubernetes.io/part-of`, `commonLabels` keys) can still be overridden via
  `podLabels` as before.
- Without `zoneAwareReplication`, `podLabels.name` still passes through unchanged
  (nothing selects on it there); a test pins this.
- Workload `metadata.labels` (user `defaults.labels` / component `labels`) are untouched.

Verified with the issue's exact repro values: `helm template` now renders a single
`name: ingester-zone-a` and the selector is a strict subset of the template labels.
Full loki suite passes (64 suites, 562 tests).

This was originally reported upstream as grafana/loki#23919 (chart 6.25.0); the
refactored shared helpers in this repository carried the same bug.

*Disclosure: this change was authored with the assistance of Claude Code (AI), reviewed
and driven by a human.*

#### Checklist

- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
- [x] Add an [helm unittest](https://github.com/helm-unittest/helm-unittest) test case to cover this change.

A couple of notes: the template asks AI contributors to identify themselves, so I added a one-line disclosure — remove it if you prefer, since you're the author of record. The DCO box is checked assuming you commit with git commit -s; the branch currently has the changes uncommitted. If you want, I can also save this to a file so you can pass it to gh pr create --body-file.