### PR TITLE
[loki] Don't render a memcached PDB with no budget

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Grafana Loki supporting monolithic, simple scalable,
 type: application
 # renovate: docker=docker.io/grafana/loki
 appVersion: 3.7.6
-version: 18.11.3
+version: 18.11.4
 kubeVersion: ">=1.25.0-0"
 home: https://grafana-community.github.io/helm-charts
 sources:

--- a/charts/loki/templates/_pdb.tpl
+++ b/charts/loki/templates/_pdb.tpl
@@ -14,6 +14,7 @@ PDB helper
   {{- $suffix := .suffix }}
   {{- $extraMatchLabels := .extraMatchLabels }}
   {{- $extraMatchExpressions := .extraMatchExpressions }}
+  {{- $componentLabel := default $target .componentLabel }}
   {{- with $ctx }}
     {{- $podDisruptionBudget := dict }}
     {{- if hasKey $component "maxUnavailable"}}
@@ -38,7 +39,7 @@ metadata:
   {{- end }}
   labels:
     {{- include "loki.labels" $ctx | nindent 4 }}
-    app.kubernetes.io/component: {{ $target }}
+    app.kubernetes.io/component: {{ $componentLabel }}
     {{- with $component.podDisruptionBudget.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -51,7 +52,7 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.selectorLabels" $ctx | nindent 6 }}
-      app.kubernetes.io/component: {{ $target }}
+      app.kubernetes.io/component: {{ $componentLabel }}
     {{- with $extraMatchLabels }}
       {{- toYaml . | nindent 6 }}
     {{- end }}

--- a/charts/loki/templates/memcached/_memcached-pdb.tpl
+++ b/charts/loki/templates/memcached/_memcached-pdb.tpl
@@ -9,33 +9,35 @@ valuesSection and component are specified separately because helm prefers camelc
 */}}
 {{- define "loki.memcached.pdb" -}}
 {{ with $.memcacheConfig }}
-{{- $pdb := mergeOverwrite (pick . "maxUnavailable") .podDisruptionBudget }}
 {{- $pdbSpec := dict }}
-{{- range $key, $value := omit $pdb "enabled" "labels" "annotations" }}
+{{- range $key, $value := pick . "maxUnavailable" }}
 {{- if not (kindIs "invalid" $value) }}
 {{- $_ := set $pdbSpec $key $value }}
 {{- end }}
 {{- end }}
-{{- if and .enabled .podDisruptionBudget.enabled (gt (int .replicas) 1) -}}
+{{- range $key, $value := omit (.podDisruptionBudget | default dict) "enabled" "labels" "annotations" }}
+{{- if not (kindIs "invalid" $value) }}
+{{- $_ := set $pdbSpec $key $value }}
+{{- end }}
+{{- end }}
+{{- if and .enabled .podDisruptionBudget.enabled (gt (int .replicas) 1) $pdbSpec -}}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.resourceName" (dict "ctx" $.ctx "component" $.component "suffix" .suffix) }}
   namespace: {{ include "loki.namespace" $.ctx }}
-  {{- with $pdb.annotations }}
+  {{- with .podDisruptionBudget.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
     {{- include "loki.selectorLabels" $.ctx | nindent 4 }}
     app.kubernetes.io/component: "memcached-{{ $.component }}{{ include "loki.memcached.suffix" .suffix }}"
-    {{- with $pdb.labels }}
+    {{- with .podDisruptionBudget.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- with $pdbSpec }}
-  {{- toYaml . | nindent 2 }}
-  {{- end }}
+  {{- toYaml $pdbSpec | nindent 2 }}
   selector:
     matchLabels:
       {{- include "loki.selectorLabels" $.ctx | nindent 6 }}

--- a/charts/loki/templates/memcached/_memcached-pdb.tpl
+++ b/charts/loki/templates/memcached/_memcached-pdb.tpl
@@ -8,40 +8,13 @@ Params:
 valuesSection and component are specified separately because helm prefers camelcase for naming convention and k8s components are named with snake case.
 */}}
 {{- define "loki.memcached.pdb" -}}
-{{ with $.memcacheConfig }}
-{{- $pdbSpec := dict }}
-{{- range $key, $value := pick . "maxUnavailable" }}
-{{- if not (kindIs "invalid" $value) }}
-{{- $_ := set $pdbSpec $key $value }}
-{{- end }}
-{{- end }}
-{{- range $key, $value := omit (.podDisruptionBudget | default dict) "enabled" "labels" "annotations" }}
-{{- if not (kindIs "invalid" $value) }}
-{{- $_ := set $pdbSpec $key $value }}
-{{- end }}
-{{- end }}
-{{- if and .enabled .podDisruptionBudget.enabled (gt (int .replicas) 1) $pdbSpec -}}
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: {{ include "loki.resourceName" (dict "ctx" $.ctx "component" $.component "suffix" .suffix) }}
-  namespace: {{ include "loki.namespace" $.ctx }}
-  {{- with .podDisruptionBudget.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-  labels:
-    {{- include "loki.selectorLabels" $.ctx | nindent 4 }}
-    app.kubernetes.io/component: "memcached-{{ $.component }}{{ include "loki.memcached.suffix" .suffix }}"
-    {{- with .podDisruptionBudget.labels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-spec:
-  {{- toYaml $pdbSpec | nindent 2 }}
-  selector:
-    matchLabels:
-      {{- include "loki.selectorLabels" $.ctx | nindent 6 }}
-      app.kubernetes.io/component: "memcached-{{ $.component }}{{ include "loki.memcached.suffix" .suffix }}"
-    {{- end }}
+{{- with $.memcacheConfig }}
+{{- include "loki.pdb" (dict
+  "ctx" $.ctx
+  "target" $.component
+  "suffix" .suffix
+  "component" .
+  "componentLabel" (printf "memcached-%s%s" $.component (include "loki.memcached.suffix" .suffix))
+) }}
 {{- end -}}
 {{- end -}}

--- a/charts/loki/tests/results-cache/pdb_test.yaml
+++ b/charts/loki/tests/results-cache/pdb_test.yaml
@@ -23,3 +23,20 @@ tests:
           path: spec.minAvailable
       - notExists:
           path: spec.unhealthyPodEvictionPolicy
+
+  - it: should not render a PodDisruptionBudget when no budget is configured
+    set:
+      resultsCache.maxUnavailable: null
+      resultsCache.podDisruptionBudget.maxUnavailable: null
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should let podDisruptionBudget.maxUnavailable override the deprecated field
+    set:
+      resultsCache.maxUnavailable: 1
+      resultsCache.podDisruptionBudget.maxUnavailable: 2
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 2


### PR DESCRIPTION
### What this fixes

`loki.memcached.pdb` can emit a PodDisruptionBudget whose `spec` contains only a `selector`. The API server accepts it, and the disruption controller then reports `disruptionsAllowed: 0` with `reason: InsufficientPods` — so every eviction is refused and the nodes behind those pods can no longer be drained, node pool upgrades stall on the drain timeout, and cluster-autoscaler consolidation stops.

Two things combine to produce it.

`#723` filters null-valued keys out of `spec` (correct — that fixed `#716`), but nothing stops the filtered map from being empty, and the helper renders the resource anyway. `loki.pdb` already guards this with `if (omit $podDisruptionBudget "selector")`; the memcached helper has no equivalent.

Separately, `mergeOverwrite (pick . "maxUnavailable") .podDisruptionBudget` lets an explicit `null` under `podDisruptionBudget` defeat the deprecated sibling `maxUnavailable` it is meant to fall back to. Helm 3.21+/4.x preserve those nulls where older versions stripped them (the version split described in `#716`), so the values this chart ships — `chunksCache.maxUnavailable: 1` alongside `chunksCache.podDisruptionBudget.maxUnavailable: null` — resolve to an empty budget rather than to 1.

### Reproduction

On `main`, Helm v4.2.4:

```console
$ helm template loki charts/loki --set chunksCache.replicas=8 \
    --set chunksCache.podDisruptionBudget.maxUnavailable=null \
    -s templates/chunks-cache/pdb.yaml
spec:
  selector:
    matchLabels:
      ...
```

`maxUnavailable: 1` is declared in values and does not appear.

### After

| values | before | after |
| --- | --- | --- |
| defaults | `maxUnavailable: 1` | `maxUnavailable: 1` |
| `podDisruptionBudget.maxUnavailable: null` | selector only | `maxUnavailable: 1` |
| `podDisruptionBudget.maxUnavailable: 2` | `maxUnavailable: 2` | `maxUnavailable: 2` |
| both null | selector only | no PDB rendered |

The spec is built from the deprecated field first, only non-null overrides replace it, and the resource is skipped when nothing is left.

Two cases added to `tests/results-cache/pdb_test.yaml`; the empty-budget one fails on `main`. Full chart suite is 59 passing across 9 suites. Chart bumped 18.11.3 → 18.11.4.

Note the null-precedence case is not expressible in `helm-unittest` — its `set:` drops a `null` rather than setting one — so that path is covered by the CLI reproduction above rather than by a unit test.