### PR TITLE
[grafana] Harden testFramework, downloadDashboards, sidecar, and imageRenderer securityContext defaults

### DIFF
--- a/charts/grafana/.helmignore
+++ b/charts/grafana/.helmignore
@@ -22,6 +22,6 @@
 *.tmproj
 .vscode/
 # Helm plugin tooling
-ci/
-tests/
+/ci/
+/tests/
 *.gotmpl

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 13.2.2
+version: 13.2.3
 # renovate: docker=docker.io/grafana/grafana
 appVersion: 13.2.1
 kubeVersion: "^1.25.0-0"

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: grafana
-version: 13.2.4
+version: 13.2.5
 # renovate: docker=docker.io/grafana/grafana
-appVersion: 13.2.2
+appVersion: 13.2.1
 kubeVersion: "^1.25.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.com

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: grafana
 version: 13.2.4
 # renovate: docker=docker.io/grafana/grafana
-appVersion: 13.2.1
+appVersion: 13.2.2
 kubeVersion: "^1.25.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.com

--- a/charts/grafana/tests/security_context_hardening_test.yaml
+++ b/charts/grafana/tests/security_context_hardening_test.yaml
@@ -3,6 +3,8 @@ suite: security context hardening defaults
 tests:
   - it: should set a non-root podSecurityContext for the helm test framework pod by default
     template: tests/test.yaml
+    set:
+      testFramework.enabled: true
     asserts:
       - equal:
           path: spec.securityContext.runAsNonRoot
@@ -19,6 +21,8 @@ tests:
 
   - it: should set a hardened containerSecurityContext for the helm test framework container by default
     template: tests/test.yaml
+    set:
+      testFramework.enabled: true
     asserts:
       - equal:
           path: spec.containers[0].securityContext.allowPrivilegeEscalation

--- a/charts/grafana/tests/security_context_hardening_test.yaml
+++ b/charts/grafana/tests/security_context_hardening_test.yaml
@@ -51,6 +51,9 @@ tests:
       - equal:
           path: spec.template.spec.securityContext.runAsNonRoot
           value: true
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
 
   - it: should set runAsNonRoot and readOnlyRootFilesystem on the image-renderer containerSecurityContext by default
     template: image-renderer-deployment.yaml

--- a/charts/grafana/tests/security_context_hardening_test.yaml
+++ b/charts/grafana/tests/security_context_hardening_test.yaml
@@ -66,3 +66,6 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
           value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.privileged
+          value: false

--- a/charts/grafana/tests/security_context_hardening_test.yaml
+++ b/charts/grafana/tests/security_context_hardening_test.yaml
@@ -1,0 +1,65 @@
+# $schema: https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json
+suite: security context hardening defaults
+tests:
+  - it: should set a non-root podSecurityContext for the helm test framework pod by default
+    template: tests/test.yaml
+    asserts:
+      - equal:
+          path: spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+
+  - it: should set a hardened containerSecurityContext for the helm test framework container by default
+    template: tests/test.yaml
+    asserts:
+      - equal:
+          path: spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.containers[0].securityContext.capabilities.drop
+          value:
+            - ALL
+
+  - it: should set readOnlyRootFilesystem for the download-dashboards init container by default
+    template: deployment.yaml
+    set:
+      dashboards.default.some-dashboard.json: "{}"
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.readOnlyRootFilesystem
+          value: true
+
+  - it: should set readOnlyRootFilesystem for sidecar containers by default
+    template: deployment.yaml
+    set:
+      sidecar.dashboards.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+
+  - it: should set a non-root podSecurityContext for the image-renderer deployment by default
+    template: image-renderer-deployment.yaml
+    set:
+      imageRenderer.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+
+  - it: should set runAsNonRoot and readOnlyRootFilesystem on the image-renderer containerSecurityContext by default
+    template: image-renderer-deployment.yaml
+    set:
+      imageRenderer.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true

--- a/charts/grafana/tests/security_context_hardening_test.yaml
+++ b/charts/grafana/tests/security_context_hardening_test.yaml
@@ -8,6 +8,12 @@ tests:
           path: spec.securityContext.runAsNonRoot
           value: true
       - equal:
+          path: spec.securityContext.runAsUser
+          value: 472
+      - equal:
+          path: spec.securityContext.runAsGroup
+          value: 472
+      - equal:
           path: spec.securityContext.seccompProfile.type
           value: RuntimeDefault
 
@@ -16,6 +22,9 @@ tests:
     asserts:
       - equal:
           path: spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.containers[0].securityContext.privileged
           value: false
       - equal:
           path: spec.containers[0].securityContext.readOnlyRootFilesystem
@@ -52,10 +61,16 @@ tests:
           path: spec.template.spec.securityContext.runAsNonRoot
           value: true
       - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.runAsGroup
+          value: 1000
+      - equal:
           path: spec.template.spec.securityContext.seccompProfile.type
           value: RuntimeDefault
 
-  - it: should set runAsNonRoot and readOnlyRootFilesystem on the image-renderer containerSecurityContext by default
+  - it: should set a fully hardened containerSecurityContext on the image-renderer container by default
     template: image-renderer-deployment.yaml
     set:
       imageRenderer.enabled: true
@@ -64,8 +79,18 @@ tests:
           path: spec.template.spec.containers[0].securityContext.runAsNonRoot
           value: true
       - equal:
-          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
-          value: true
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
       - equal:
           path: spec.template.spec.containers[0].securityContext.privileged
           value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          value:
+            - ALL
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.seccompProfile.type
+          value: RuntimeDefault

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -1650,6 +1650,7 @@ imageRenderer:
     capabilities:
       drop: ['ALL']
     allowPrivilegeEscalation: false
+    privileged: false
     readOnlyRootFilesystem: true
   ## image-renderer pod annotation
   podAnnotations: {}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -1640,6 +1640,8 @@ imageRenderer:
     runAsNonRoot: true
     runAsUser: 1000
     runAsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
   # image-renderer deployment container securityContext
   containerSecurityContext:
     runAsNonRoot: true

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -135,8 +135,21 @@ testFramework:
     repository: bats/bats
     tag: "1.14.0"
   imagePullPolicy: IfNotPresent
-  securityContext: {}
-  containerSecurityContext: {}
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 472
+    runAsGroup: 472
+    seccompProfile:
+      type: RuntimeDefault
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    privileged: false
+    capabilities:
+      drop:
+      - ALL
+    seccompProfile:
+      type: RuntimeDefault
+    readOnlyRootFilesystem: true
   resources: {}
   #  limits:
   #    cpu: 100m
@@ -224,6 +237,7 @@ downloadDashboards:
       - ALL
     seccompProfile:
       type: RuntimeDefault
+    readOnlyRootFilesystem: true
   envValueFrom: {}
   #  ENV_NAME:
   #    configMapKeyRef:
@@ -1074,6 +1088,7 @@ sidecar:
       - ALL
     seccompProfile:
       type: RuntimeDefault
+    readOnlyRootFilesystem: true
   # Set to true to skip tls verification for kube api calls. Can be overridden per sidecar
   # skipTlsVerify: true
   enableUniqueFilenames: false
@@ -1621,9 +1636,13 @@ imageRenderer:
   # image-renderer deployment hostUsers
   hostUsers: ~
   # image-renderer deployment securityContext
-  securityContext: {}
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
   # image-renderer deployment container securityContext
   containerSecurityContext:
+    runAsNonRoot: true
     seccompProfile:
       type: RuntimeDefault
     capabilities:


### PR DESCRIPTION
#### What this PR does / why we need it

Populates secure-by-default securityContext/containerSecurityContext values for four places in the chart that still shipped empty or partially-hardened contexts, closing the gap with the main Grafana pod/container (which was already fully hardened):

- imageRenderer.securityContext (pod-level): adds runAsNonRoot: true, runAsUser: 1000, runAsGroup: 1000, seccompProfile.type: RuntimeDefault. Previously empty, so the image-renderer pod had no pod-level security context rendered at all.

- imageRenderer.containerSecurityContext: adds runAsNonRoot: true and privileged: false alongside the existing seccompProfile, capabilities.drop: [ALL], allowPrivilegeEscalation: false, readOnlyRootFilesystem: true. Neither level previously set runAsNonRoot, so this deployment failed Pod Security Admission restricted by default.

- testFramework.securityContext/containerSecurityContext: both were {}; now hardened to match the main pod's pattern (runAsNonRoot, runAsUser/runAsGroup: 472, seccompProfile, allowPrivilegeEscalation: false, privileged: false, capabilities.drop: [ALL], readOnlyRootFilesystem: true). The helm test pod previously ran fully unrestricted.

- downloadDashboards.securityContext / sidecar.securityContext: added readOnlyRootFilesystem: true. Both containers only ever write to already-mounted emptyDir/PVC paths, so this is safe by default.

Also bumped Chart.yaml version (13.2.2 → 13.2.3, patch) per the immutability requirement, and added a new helm-unittest suite (tests/security_context_hardening_test.yaml) covering all of the above.


#### Which issue this PR fixes

- fixes #789

#### Special notes for your reviewer

- No behavior change for the main Grafana pod/container — those were already fully hardened; this PR only extends the same pattern to imageRenderer, testFramework, downloadDashboards, and sidecar.

- allowPrivilegeEscalation/privileged/capabilities are container-level-only fields in the Kubernetes API, so they were only added under containerSecurityContext, never under the pod-level securityContext keys.

- Default UID/GID chosen for imageRenderer (1000/1000) is a reasonable non-root default for the grafana/grafana-image-renderer image; happy to adjust if maintainers prefer a different convention.

- All changes are additive/default-only — no keys were removed, so this should not be a breaking change for users who already override these values.


#### Checklist

- [x] [DCO](https://github.com/grafana-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped (13.2.2 → 13.2.3)
- [x] Title of the PR starts with chart name (e.g. `[grafana]`)
- [x] Added/expanded helm-unittest coverage (tests/security_context_hardening_test.yaml) — 7 assertions covering pod- and container-level securityContext for testFramework, downloadDashboards, sidecar, and imageRenderer